### PR TITLE
Added new lobby art and took revs out of rotation.

### DIFF
--- a/Resources/Prototypes/lobbyscreens.yml
+++ b/Resources/Prototypes/lobbyscreens.yml
@@ -46,3 +46,6 @@
   id: ReclaimerNuke
   background: /Textures/LobbyScreens/reclaimer-nuke.webp
   
+- type: lobbyBackground
+  id: StationCafe
+  background: /Textures/LobbyScreens/stationcafe.png

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -4,5 +4,5 @@
     Nukeops: 0.20
     Traitor: 0.60
     Zombie: 0.05
-    Survival: 0.10
-    Revolutionary: 0.05
+    Survival: 0.15
+    # Revolutionary: 0.05

--- a/Resources/Textures/LobbyScreens/attributions.yml
+++ b/Resources/Textures/LobbyScreens/attributions.yml
@@ -58,7 +58,7 @@
   copyright: "GetOutMarutak,aka.Snicket on Discord/github/Cara/Ko-fi"
   source: "https://github.com/space-wizards/space-station-14"
 
-- files: ["stationcafe.png]
+- files: ["stationcafe.png"]
   license: "NA"
   copyright: "amatiramasu on discord"
   source: "https://github.com/ss14-harmony/space-station-14"

--- a/Resources/Textures/LobbyScreens/attributions.yml
+++ b/Resources/Textures/LobbyScreens/attributions.yml
@@ -59,6 +59,6 @@
   source: "https://github.com/space-wizards/space-station-14"
 
 - files: ["stationcafe.png"]
-  license: "NA"
+  license: "CC-BY-SA-3.0"
   copyright: "amatiramasu on discord"
   source: "https://github.com/ss14-harmony/space-station-14"

--- a/Resources/Textures/LobbyScreens/attributions.yml
+++ b/Resources/Textures/LobbyScreens/attributions.yml
@@ -57,3 +57,8 @@
   license: "CC-BY-NC-SA-3.0"
   copyright: "GetOutMarutak,aka.Snicket on Discord/github/Cara/Ko-fi"
   source: "https://github.com/space-wizards/space-station-14"
+
+- files: ["stationcafe.png]
+  license: NA
+  copyright: "amatiramasu on discord"
+  source: "https://github.com/ss14-harmony/space-station-14"

--- a/Resources/Textures/LobbyScreens/attributions.yml
+++ b/Resources/Textures/LobbyScreens/attributions.yml
@@ -59,6 +59,6 @@
   source: "https://github.com/space-wizards/space-station-14"
 
 - files: ["stationcafe.png]
-  license: NA
+  license: "NA"
   copyright: "amatiramasu on discord"
   source: "https://github.com/ss14-harmony/space-station-14"

--- a/Resources/Textures/LobbyScreens/attributions.yml
+++ b/Resources/Textures/LobbyScreens/attributions.yml
@@ -59,6 +59,6 @@
   source: "https://github.com/space-wizards/space-station-14"
 
 - files: ["stationcafe.png"]
-  license: "CC-BY-SA-3.0"
+  license: "CC-BY-NC-SA-3.0"
   copyright: "amatiramasu on discord"
   source: "https://github.com/ss14-harmony/space-station-14"

--- a/Resources/Textures/LobbyScreens/stationcafe.png.yml
+++ b/Resources/Textures/LobbyScreens/stationcafe.png.yml
@@ -1,0 +1,2 @@
+sample:
+  filter: false


### PR DESCRIPTION
Adding the lobby art made by Amatiramasu
 - Added as a PNG because the size wasn't playing nice with webp. 
 - Should ask them to modify it to be the correct ratio at some point. 

Removing Revolutionaries from secret rotation
 - commented out Revolutionaries
 - Moved the weight for that preset to survival