### PR TITLE
Removed clown and syndi evac shuttle from rotation. Updated lobby art…

### DIFF
--- a/Resources/Prototypes/GameRules/unknown_shuttles.yml
+++ b/Resources/Prototypes/GameRules/unknown_shuttles.yml
@@ -39,7 +39,7 @@
   id: UnknownShuttleHonki
   components:
   - type: StationEvent
-    weight: 2
+    weight: 0
   - type: LoadMapRule
     preloadedGrid: Honki
 
@@ -48,6 +48,6 @@
   id: UnknownShuttleSyndieEvacPod
   components:
   - type: StationEvent
-    weight: 2
+    weight: 0
   - type: LoadMapRule
     preloadedGrid: SyndieEvacPod

--- a/Resources/Prototypes/lobbyscreens.yml
+++ b/Resources/Prototypes/lobbyscreens.yml
@@ -48,4 +48,4 @@
   
 - type: lobbyBackground
   id: StationCafe
-  background: /Textures/LobbyScreens/stationcafe.png
+  background: /Textures/LobbyScreens/stationcafe.webp

--- a/Resources/Textures/LobbyScreens/attributions.yml
+++ b/Resources/Textures/LobbyScreens/attributions.yml
@@ -58,7 +58,7 @@
   copyright: "GetOutMarutak,aka.Snicket on Discord/github/Cara/Ko-fi"
   source: "https://github.com/space-wizards/space-station-14"
 
-- files: ["stationcafe.png"]
+- files: ["stationcafe.webp"]
   license: "CC-BY-NC-SA-3.0"
-  copyright: "amatiramasu on discord"
+  copyright: "Amadisaronno. amatiramasu on Discord"
   source: "https://github.com/ss14-harmony/space-station-14"

--- a/Resources/Textures/LobbyScreens/stationcafe.png.yml
+++ b/Resources/Textures/LobbyScreens/stationcafe.png.yml
@@ -1,2 +1,0 @@
-sample:
-  filter: false

--- a/Resources/Textures/LobbyScreens/stationcafe.webp.yml
+++ b/Resources/Textures/LobbyScreens/stationcafe.webp.yml
@@ -1,0 +1,2 @@
+sample:
+  filter: false


### PR DESCRIPTION
Shit, it deleted everything I typed already and it's late. So here's the short version. Changed the shuttlecafe art from png to webp because it's what all the other lobby art uses. May help the slow download issue some users reported. Also added Amatiramasu's artist name to the attributions instead of just their discord name.

Syndi evac pod and clown shuttle mid round events have had their weights set to 0. This _should_ make them not show up anymore. We discussed it not leading to fun or interesting rounds. 