### PR TITLE
Keld reducetimers

### DIFF
--- a/Resources/Prototypes/GameRules/unknown_shuttles.yml
+++ b/Resources/Prototypes/GameRules/unknown_shuttles.yml
@@ -64,7 +64,7 @@
   id: UnknownShuttleHonki
   components:
   - type: StationEvent
-    weight: 0
+    weight: 2
   - type: LoadMapRule
     preloadedGrid: Honki
 
@@ -73,6 +73,6 @@
   id: UnknownShuttleSyndieEvacPod
   components:
   - type: StationEvent
-    weight: 0
+    weight: 2
   - type: LoadMapRule
     preloadedGrid: SyndieEvacPod

--- a/Resources/Prototypes/Loadouts/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Cargo/quartermaster.yml
@@ -6,7 +6,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobQuartermaster
-      time: 72000 #20 hrs
+      time: 10800 #20 hrs
 
 # Jumpsuit
 - type: loadout

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/janitor.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/janitor.yml
@@ -5,7 +5,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobJanitor
-      time: 187200 #52 hrs (1 hour per week for 1 year)
+      time: 21600 #52 hrs (1 hour per week for 1 year)
 
 # Head
 - type: loadout

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/passenger.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/passenger.yml
@@ -6,7 +6,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobPassenger
-      time: 36000 #10 hrs, silly reward for people who play passenger a lot
+      time: 10800 #10 hrs, silly reward for people who play passenger a lot
 
 # Head of Greytide (for grey mantle)
 - type: loadoutEffectGroup

--- a/Resources/Prototypes/Loadouts/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Command/captain.yml
@@ -6,7 +6,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobCaptain
-      time: 72000 #20 hrs
+      time: 10800 #20 hrs
 
 # Jumpsuit
 - type: loadout

--- a/Resources/Prototypes/Loadouts/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Command/head_of_personnel.yml
@@ -6,7 +6,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobHeadOfPersonnel
-      time: 72000 #20 hrs
+      time: 10800 #20 hrs
 
 # Professional HoP Time
 - type: loadoutEffectGroup
@@ -16,7 +16,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobHeadOfPersonnel
-      time: 54000 #15 hrs, special reward for HoP mains
+      time: 7200 #15 hrs, special reward for HoP mains
 
 # Jumpsuit
 - type: loadout

--- a/Resources/Prototypes/Loadouts/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Engineering/chief_engineer.yml
@@ -6,7 +6,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobChiefEngineer
-      time: 72000 #20 hrs
+      time: 10800 #20 hrs
 
 # Jumpsuit
 - type: loadout

--- a/Resources/Prototypes/Loadouts/Jobs/Engineering/station_engineer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Engineering/station_engineer.yml
@@ -6,17 +6,17 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobAtmosphericTechnician
-      time: 21600 #6 hrs
+      time: 3600 #6 hrs
   - !type:JobRequirementLoadoutEffect
     requirement:
       !type:RoleTimeRequirement
       role: JobStationEngineer
-      time: 21600 #6 hrs
+      time: 3600 #6 hrs
   - !type:JobRequirementLoadoutEffect
     requirement:
       !type:DepartmentTimeRequirement
       department: Engineering
-      time: 216000 # 60 hrs
+      time: 10800 # 60 hrs
 
 # Head
 - type: startingGear

--- a/Resources/Prototypes/Loadouts/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Medical/chief_medical_officer.yml
@@ -6,7 +6,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobChiefMedicalOfficer
-      time: 72000 #20 hrs
+      time: 10800 #20 hrs
 
 # Jumpsuit
 - type: loadout

--- a/Resources/Prototypes/Loadouts/Jobs/Medical/medical_doctor.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Medical/medical_doctor.yml
@@ -6,17 +6,17 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobChemist
-      time: 21600 #6 hrs
+      time: 3600 #6 hrs
   - !type:JobRequirementLoadoutEffect
     requirement:
       !type:RoleTimeRequirement
       role: JobMedicalDoctor
-      time: 21600 #6 hrs
+      time: 3600 #6 hrs
   - !type:JobRequirementLoadoutEffect
     requirement:
       !type:DepartmentTimeRequirement
       department: Medical
-      time: 216000 # 60 hrs
+      time: 10800 # 60 hrs
 
 # Other Timers
 
@@ -27,7 +27,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobMedicalDoctor
-      time: 108000 #30 hrs
+      time: 10800 #30 hrs
 
 # Head
 

--- a/Resources/Prototypes/Loadouts/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Science/research_director.yml
@@ -6,7 +6,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobResearchDirector
-      time: 72000 #20 hrs
+      time: 7200 #20 hrs
 
 # Head
 - type: loadout

--- a/Resources/Prototypes/Loadouts/Jobs/Science/scientist.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Science/scientist.yml
@@ -6,7 +6,7 @@
     requirement:
       !type:DepartmentTimeRequirement
       department: Science
-      time: 216000 #60 hrs
+      time: 10800 #60 hrs
 
 # Head
 - type: startingGear

--- a/Resources/Prototypes/Loadouts/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/head_of_security.yml
@@ -6,7 +6,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobHeadOfSecurity
-      time: 72000 #20 hrs
+      time: 10800 #20 hrs
 
 # Jumpsuit
 - type: loadout

--- a/Resources/Prototypes/Loadouts/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/security_officer.yml
@@ -6,12 +6,12 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobWarden
-      time: 21600 #6 hrs
+      time: 3600 #6 hrs
   - !type:JobRequirementLoadoutEffect
     requirement:
       !type:DepartmentTimeRequirement
       department: Security
-      time: 216000 # 60 hrs
+      time: 10800 # 60 hrs
 
 #Security Star
 - type: loadoutEffectGroup
@@ -21,7 +21,7 @@
       requirement:
         !type:DepartmentTimeRequirement
         department: Security
-        time: 360000 #100 hrs
+        time: 21600 #100 hrs
 
 # Head
 - type: loadout


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Reduce clothing timers and bring honk and syndi evac shuttles back into rotation

## Why / Balance
Most folks on Harmony are experienced players and would like their clothing swag. Making it an hour or three to get it means they have to have at least done a shift or two for them. 

Re-introducing shuttles since honk shuttle is less spidery. I also want to see if the syndi evac shuttle is going to cause as many issues as we worried.

## Technical details
Just changed some minor config settings. 
