### PR TITLE
Harmony Craftable lockable buttons and button frames

### DIFF
--- a/Resources/Prototypes/Harmony/Entities/Structures/Wallmounts/switch.yml
+++ b/Resources/Prototypes/Harmony/Entities/Structures/Wallmounts/switch.yml
@@ -1,0 +1,65 @@
+# Button frames
+- type: entity
+  id: ButtonFrameGreyBuildable
+  parent: ButtonFrame
+  suffix: grey
+  components:
+    - type: Sprite
+      drawdepth: SmallObjects
+      sprite: Structures/Wallmounts/switch_frame.rsi
+      state: grey
+    - type: Construction
+      graph: ButtonFrameGraph
+      node: ButtonFrameGreyNode
+
+- type: entity
+  id: ButtonFrameCautionBuildable
+  parent: ButtonFrame
+  suffix: caution
+  components:
+    - type: Sprite
+      drawdepth: SmallObjects
+      sprite: Structures/Wallmounts/switch_frame.rsi
+      state: caution
+    - type: Construction
+      graph: ButtonFrameGraph
+      node: ButtonFrameCautionNode
+
+- type: entity
+  id: ButtonFrameCautionSecurityBuildable
+  parent: ButtonFrame
+  suffix: caution_security
+  components:
+    - type: Sprite
+      drawdepth: SmallObjects
+      sprite: Structures/Wallmounts/switch_frame.rsi
+      state: caution_security
+    - type: Construction
+      graph: ButtonFrameGraph
+      node: ButtonFrameCautionSecurityNode
+
+- type: entity
+  id: ButtonFrameExitBuildable
+  parent: ButtonFrame
+  suffix: exit
+  components:
+    - type: Sprite
+      drawdepth: SmallObjects
+      sprite: Structures/Wallmounts/switch_frame.rsi
+      state: exit
+    - type: Construction
+      graph: ButtonFrameGraph
+      node: ButtonFrameExitNode
+
+- type: entity
+  id: ButtonFrameJanitorBuildable
+  parent: ButtonFrame
+  suffix: janitor
+  components:
+    - type: Sprite
+      drawdepth: SmallObjects
+      sprite: Structures/Wallmounts/switch_frame.rsi
+      state: janitor
+    - type: Construction
+      graph: ButtonFrameGraph
+      node: ButtonFrameJanitorNode

--- a/Resources/Prototypes/Harmony/Entities/Structures/Wallmounts/switch.yml
+++ b/Resources/Prototypes/Harmony/Entities/Structures/Wallmounts/switch.yml
@@ -63,3 +63,37 @@
     - type: Construction
       graph: ButtonFrameGraph
       node: ButtonFrameJanitorNode
+
+# Lockable buttons
+- type: entity
+  id: LockableButtonBuildableAssembly
+  name: lockable button assembly
+  description: It's a lockable button for activating something.
+  components:
+    - type: Clickable
+    - type: InteractionOutline
+    - type: Sprite
+      sprite: Structures/Wallmounts/locked_switch.rsi
+      state: unlocked
+    - type: Construction
+      graph: LockableButtonGraph
+      node: assembly
+    - type: WallMount
+      arc: 175
+  placement:
+    mode: SnapgridCenter
+
+- type: entity
+  id: LockableButtonBuildable
+  name: constructed lockable button
+  description: It's a lockable button for activating something.
+  parent: LockableButton
+  components:
+    - type: Construction
+      graph: LockableButtonGraph
+      node: LockableButtonNode
+    - type: ContainerFill
+      containers:
+        board: [DoorElectronics]
+    - type: AccessReader
+      containerAccessProvider: board

--- a/Resources/Prototypes/Harmony/Recipes/Construction/Graphs/machines/switching.yml
+++ b/Resources/Prototypes/Harmony/Recipes/Construction/Graphs/machines/switching.yml
@@ -95,3 +95,58 @@
               prototype: SheetSteel1
               amount: 1
             - !type:DeleteEntity {}
+
+# Lockable buttons
+- type: constructionGraph
+  id: LockableButtonGraph
+  start: start
+  graph:
+    - node: start
+      edges:
+        - to: assembly
+          steps:
+            - material: Steel
+              amount: 1
+              doAfter: 2.0
+            - material: Plastic
+              amount: 1
+
+    - node: assembly
+      entity: LockableButtonBuildableAssembly
+      edges:
+        - to: LockableButtonNode
+          steps:
+            - tag: DoorElectronics
+              store: board
+              name: "door electronics circuit board"
+              icon:
+                sprite: "Objects/Misc/module.rsi"
+                state: "door_electronics"
+              doAfter: 2.0
+        - to: start
+          steps:
+            - tool: Screwing
+              doAfter: 2.0
+          completed:
+            - !type:SpawnPrototype
+              prototype: SheetSteel1
+              amount: 1
+            - !type:SpawnPrototype
+              prototype: SheetPlastic1
+              amount: 1
+            - !type:DeleteEntity {}
+
+    - node: LockableButtonNode
+      entity: LockableButtonBuildable
+      edges:
+        - to: assembly
+          conditions:
+            - !type:Locked
+              locked: false
+          steps:
+            - tool: Screwing
+              doAfter: 2.0
+          completed:
+            - !type:EmptyAllContainers
+              pickup: true
+              emptyAtUser: true

--- a/Resources/Prototypes/Harmony/Recipes/Construction/Graphs/machines/switching.yml
+++ b/Resources/Prototypes/Harmony/Recipes/Construction/Graphs/machines/switching.yml
@@ -1,0 +1,97 @@
+# Button frames
+- type: constructionGraph
+  id: ButtonFrameGraph
+  start: start
+  graph:
+    - node: start
+      edges:
+        - to: ButtonFrameGreyNode
+          steps:
+            - material: Steel
+              amount: 1
+              doAfter: 2.0
+        - to: ButtonFrameCautionNode
+          steps:
+            - material: Steel
+              amount: 1
+              doAfter: 2.0
+        - to: ButtonFrameCautionSecurityNode
+          steps:
+            - material: Steel
+              amount: 1
+              doAfter: 2.0
+        - to: ButtonFrameExitNode
+          steps:
+            - material: Steel
+              amount: 1
+              doAfter: 2.0
+        - to: ButtonFrameJanitorNode
+          steps:
+            - material: Steel
+              amount: 1
+              doAfter: 2.0
+
+    - node: ButtonFrameGreyNode
+      entity: ButtonFrameGreyBuildable
+      edges:
+        - to: start
+          steps:
+            - tool: Screwing
+              doAfter: 2.0
+          completed:
+            - !type:SpawnPrototype
+              prototype: SheetSteel1
+              amount: 1
+            - !type:DeleteEntity {}
+
+    - node: ButtonFrameCautionNode
+      entity: ButtonFrameCautionBuildable
+      edges:
+        - to: start
+          steps:
+            - tool: Screwing
+              doAfter: 2.0
+          completed:
+            - !type:SpawnPrototype
+              prototype: SheetSteel1
+              amount: 1
+            - !type:DeleteEntity {}
+
+    - node: ButtonFrameCautionSecurityNode
+      entity: ButtonFrameCautionSecurityBuildable
+      edges:
+        - to: start
+          steps:
+            - tool: Screwing
+              doAfter: 2.0
+          completed:
+            - !type:SpawnPrototype
+              prototype: SheetSteel1
+              amount: 1
+            - !type:DeleteEntity {}
+
+    - node: ButtonFrameExitNode
+      entity: ButtonFrameExitBuildable
+      edges:
+        - to: start
+          steps:
+            - tool: Screwing
+              doAfter: 2.0
+          completed:
+            - !type:SpawnPrototype
+              prototype: SheetSteel1
+              amount: 1
+            - !type:DeleteEntity {}
+
+    - node: ButtonFrameJanitorNode
+      entity: ButtonFrameJanitorBuildable
+      edges:
+        - to: start
+          steps:
+            - tool: Screwing
+              doAfter: 2.0
+          completed:
+            - !type:SpawnPrototype
+              prototype: SheetSteel1
+              amount: 1
+            - !type:DeleteEntity {}

--- a/Resources/Prototypes/Harmony/Recipes/Construction/machines.yml
+++ b/Resources/Prototypes/Harmony/Recipes/Construction/machines.yml
@@ -85,6 +85,25 @@
   objectType: Structure
   placementMode: SnapgridCenter
   canRotate: true
+  conditions:
+    - !type:WallmountCondition
+  canBuildInImpassable: true
+
+# Lockable buttons
+- type: construction
+  name: lockable button
+  id: LockableButtonRecipe
+  graph: LockableButtonGraph
+  startNode: start
+  targetNode: LockableButtonNode
+  category: construction-category-machines
+  description: It's a lockable button for activating something.
+  icon:
+    sprite: Structures/Wallmounts/locked_switch.rsi
+    state: locked
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canRotate: true
   canBuildInImpassable: true
   conditions:
     - !type:WallmountCondition

--- a/Resources/Prototypes/Harmony/Recipes/Construction/machines.yml
+++ b/Resources/Prototypes/Harmony/Recipes/Construction/machines.yml
@@ -1,0 +1,90 @@
+# Button frames
+- type: construction
+  name: button frame (grey)
+  id: ButtonFrameGreyRecipe
+  graph: ButtonFrameGraph
+  startNode: start
+  targetNode: ButtonFrameGreyNode
+  category: construction-category-machines
+  description: It's a frame to help distinguish switches visually.
+  icon:
+    sprite: Structures/Wallmounts/switch_frame.rsi
+    state: grey
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canRotate: true
+  canBuildInImpassable: true
+  conditions:
+    - !type:WallmountCondition
+
+- type: construction
+  name: button frame (caution)
+  id: ButtonFrameCautionRecipe
+  graph: ButtonFrameGraph
+  startNode: start
+  targetNode: ButtonFrameCautionNode
+  category: construction-category-machines
+  description: It's a frame to help distinguish switches visually.
+  icon:
+    sprite: Structures/Wallmounts/switch_frame.rsi
+    state: caution
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canRotate: true
+  canBuildInImpassable: true
+  conditions:
+    - !type:WallmountCondition
+
+- type: construction
+  name: button frame (danger)
+  id: ButtonFrameCautionSecurityRecipe
+  graph: ButtonFrameGraph
+  startNode: start
+  targetNode: ButtonFrameCautionSecurityNode
+  category: construction-category-machines
+  description: It's a frame to help distinguish switches visually.
+  icon:
+    sprite: Structures/Wallmounts/switch_frame.rsi
+    state: caution_security
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canRotate: true
+  canBuildInImpassable: true
+  conditions:
+    - !type:WallmountCondition
+
+- type: construction
+  name: button frame (exit)
+  id: ButtonFrameExitRecipe
+  graph: ButtonFrameGraph
+  startNode: start
+  targetNode: ButtonFrameExitNode
+  category: construction-category-machines
+  description: It's a frame to help distinguish switches visually.
+  icon:
+    sprite: Structures/Wallmounts/switch_frame.rsi
+    state: exit
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canRotate: true
+  canBuildInImpassable: true
+  conditions:
+    - !type:WallmountCondition
+
+- type: construction
+  name: button frame (janitor)
+  id: ButtonFrameJanitorRecipe
+  graph: ButtonFrameGraph
+  startNode: start
+  targetNode: ButtonFrameJanitorNode
+  category: construction-category-machines
+  description: It's a frame to help distinguish switches visually.
+  icon:
+    sprite: Structures/Wallmounts/switch_frame.rsi
+    state: janitor
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canRotate: true
+  canBuildInImpassable: true
+  conditions:
+    - !type:WallmountCondition


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- Added 5 button frames to "Construction" menu: grey, exit, caution, danger, janitor
Each frame requires 1 sheet of steel.
Can be placed over any button (before or after constructing the button)
- Added lockable button to "Construction" menu
Requires 1 sheet of steel, 1 sheet of plastic, and door electronics
Access is governed by door electronics settings (set via multi tool etc)
Cannot be deconstructed if locked
Otherwise works like regular signal button

## Why
Requested by Harmony population. It should have many practical applications on shifts.

## Technical details
Added new entities that extend base uncraftable ones; Added recipies; Added construction graphs.

## Media
![image](https://github.com/user-attachments/assets/7d8beb0a-ab3c-4d12-bcfc-413c0e4d61e6)
![image](https://github.com/user-attachments/assets/e46307db-50b5-4164-8442-1f82d6233fa3)
