### PR TITLE
Adds Saltern back into rotation.

### DIFF
--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -12,4 +12,5 @@
   - Omega
   - Packed
   - Reach
+  - Saltern
   #- Train


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Simply adds Saltern back into the rotation in it's current state, without changes. Feel free to close this but I figured I'd put it here for discussion.

## Why / Balance
During lower population shifts it just ends up being a back and forth between Omega and Packed. This is an immediate solution, but will (probably) have longer term issues that need addressed.

**Changelog**
:cl:
- add: Added Saltern back into rotation.
