### PR TITLE
Adjusts minimum population of several maps.

### DIFF
--- a/Resources/Prototypes/Maps/bagel.yml
+++ b/Resources/Prototypes/Maps/bagel.yml
@@ -2,7 +2,7 @@
   id: Bagel
   mapName: 'Bagel Station'
   mapPath: /Maps/bagel.yml
-  minPlayers: 35
+  minPlayers: 30
   maxPlayers: 70
   stations:
     Bagel:

--- a/Resources/Prototypes/Maps/box.yml
+++ b/Resources/Prototypes/Maps/box.yml
@@ -2,7 +2,7 @@
   id: Box
   mapName: 'Box Station'
   mapPath: /Maps/box.yml
-  minPlayers: 50
+  minPlayers: 40
   stations:
     Boxstation:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/core.yml
+++ b/Resources/Prototypes/Maps/core.yml
@@ -2,7 +2,7 @@
   id: Core
   mapName: 'Core'
   mapPath: /Maps/core.yml
-  minPlayers: 35
+  minPlayers: 30
   maxPlayers: 70
   stations:
     Core:

--- a/Resources/Prototypes/Maps/marathon.yml
+++ b/Resources/Prototypes/Maps/marathon.yml
@@ -2,7 +2,7 @@
   id: Marathon
   mapName: 'Marathon Station'
   mapPath: /Maps/marathon.yml
-  minPlayers: 35
+  minPlayers: 30
   maxPlayers: 70
   stations:
     Marathon:

--- a/Resources/Prototypes/Maps/meta.yml
+++ b/Resources/Prototypes/Maps/meta.yml
@@ -2,7 +2,7 @@
   id: Meta
   mapName: 'Meta Station'
   mapPath: /Maps/meta.yml
-  minPlayers: 50
+  minPlayers: 40
   stations:
     Meta:
       stationProto: StandardNanotrasenStation


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Slightly adjusts the minimum populations of the following maps:

- **Meta:** 50 > 40
- **Box:** 50 > 40
- **Bagel:** 35 > 30
- **Marathon:** 35 > 30
- **Core:** 35 > 30

## Why / Balance
This should hopefully diversify the map pool of Harmony a bit more than at present. Basic testing has shown that these maps operate fine in our community with slightly reduced populations.

**Changelog**
:cl:
- tweak: Lowered the minimum population of several mid-pop maps.