### PR TITLE
Add clipboard to Autolathe recipes

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -198,6 +198,7 @@
       - ClothingHeadHatWelding
       - WetFloorSign
       - ClothingHeadHatCone
+      - BoxFolderClipboard # Harmony
 
   - type: EmagLatheRecipes
     emagStaticRecipes:

--- a/Resources/Prototypes/Harmony/Recipes/Lathes/paper.yml
+++ b/Resources/Prototypes/Harmony/Recipes/Lathes/paper.yml
@@ -1,0 +1,6 @@
+- type: latheRecipe
+  id: BoxFolderClipboard
+  result: BoxFolderClipboard
+  completetime: 2
+  materials:
+    Wood: 50


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added clipboard item to the Autolathe recipes.
Requires 0.5 wood to be printed

## Why
Requested by players who play mute characters to have a reliable source of clipboards round start.

## Technical details
A recipe added; Autolahe recipes list modified in the upstream file.

## Media
![image](https://github.com/user-attachments/assets/24dc9840-e832-476d-b977-706784b4eead)


**Changelog**
:cl:
- add: clipboard can now be printed in Autolathe.
