### PR TITLE
Secret Nukies Gamemode

### DIFF
--- a/Resources/Prototypes/Harmony/game_presets.yml
+++ b/Resources/Prototypes/Harmony/game_presets.yml
@@ -1,0 +1,14 @@
+- type: gamePreset
+  id: SecretNukeops #For Admin Use: Runs Nukeops but shows "Secret" in lobby.
+  alias:
+    - secretnukeops
+  name: secret-title
+  description: secret-description
+  showInVote: false #Admin Use
+  rules:
+    - Nukeops
+    - SubGamemodesRule
+    - BasicStationEventScheduler
+    - MeteorSwarmScheduler
+    - SpaceTrafficControlEventScheduler
+    - BasicRoundstartVariation

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -185,6 +185,21 @@
     - BasicRoundstartVariation
 
 - type: gamePreset
+  id: SecretNukeops #For Admin Use: Runs Nukeops but shows "Secret" in lobby.
+  alias:
+    - secretnukeops
+  name: secret-title
+  description: secret-description
+  showInVote: false #Admin Use
+  rules:
+    - Nukeops
+    - SubGamemodesRule
+    - BasicStationEventScheduler
+    - MeteorSwarmScheduler
+    - SpaceTrafficControlEventScheduler
+    - BasicRoundstartVariation
+
+- type: gamePreset
   id: Revolutionary
   alias:
     - rev

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -185,21 +185,6 @@
     - BasicRoundstartVariation
 
 - type: gamePreset
-  id: SecretNukeops #For Admin Use: Runs Nukeops but shows "Secret" in lobby.
-  alias:
-    - secretnukeops
-  name: secret-title
-  description: secret-description
-  showInVote: false #Admin Use
-  rules:
-    - Nukeops
-    - SubGamemodesRule
-    - BasicStationEventScheduler
-    - MeteorSwarmScheduler
-    - SpaceTrafficControlEventScheduler
-    - BasicRoundstartVariation
-
-- type: gamePreset
   id: Revolutionary
   alias:
     - rev


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds Secret Nukies gamemode that admins can force.

## Why / Balance
Nukies are rare at the moment on Harmony for god knows why, something to do with the random gamemode scheduler even though the .yml looks normal. This will let admins force nukies once in a while until that's fixed plus this is nice to have regardless.

## Technical details
<!-- Summary of code changes for easier review. -->
- type: gamePreset
  id: SecretNukeops #For Admin Use: Runs Nukeops but shows "Secret" in lobby.
  alias:
    - secretnukeops
  name: secret-title
  description: secret-description
  showInVote: false #Admin Use
  rules:
    - Nukeops
    - SubGamemodesRule
    - BasicStationEventScheduler
    - MeteorSwarmScheduler
    - SpaceTrafficControlEventScheduler
    - BasicRoundstartVariation