### PR TITLE
Change in-game Space Law guidebooks to reflect Harmony Space Law

### DIFF
--- a/Resources/Locale/en-US/Harmony/guidebook/guides.ftl
+++ b/Resources/Locale/en-US/Harmony/guidebook/guides.ftl
@@ -1,0 +1,1 @@
+guide-entry-rules-sl-restricted-list = Restricted Lists

--- a/Resources/Prototypes/Guidebook/rules.yml
+++ b/Resources/Prototypes/Guidebook/rules.yml
@@ -391,6 +391,7 @@
   priority: 1
   text: "/ServerInfo/Guidebook/ServerRules/SpaceLaw/SpaceLaw.xml"
   children:
+  - SpaceLawRestrictedList # Harmony
   - SpaceLawCrimeList
 
 - type: guideEntry
@@ -398,6 +399,12 @@
   name: guide-entry-rules-sl-crime-list
   priority: 5
   text: "/ServerInfo/Guidebook/ServerRules/SpaceLaw/SLCrimeList.xml"
+
+- type: guideEntry
+  id: SpaceLawRestrictedList # Harmony
+  name: guide-entry-rules-sl-restricted-list
+  priority: 4
+  text: "/ServerInfo/Guidebook/ServerRules/SpaceLaw/SLRestrictedList.xml"
 
 - type: guideEntry
   id: BanTypes

--- a/Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/SLCrimeList.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/SLCrimeList.xml
@@ -1,8 +1,10 @@
 <Document>
   # Space Law: Crime Listing
-  Crime codes are colored by linked crime groups, which are collections of non-stackable crimes. Suffixes are also included in the Quick Crime Guide to identify linked crimes.
 
   ## Quick Crime Guide
+
+  Crime codes are organized by a Category Code (_-xx) which is a collection of non-stackable crimes on a row, prefixed by the Severity Number (X-__).
+
   <Table Columns="6">
     <ColorBox>
       <Box>
@@ -66,21 +68,22 @@
     </ColorBox>
     <ColorBox Color="#2f3832">
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
-        Possession: Minor (P)
+        Possession: Substances (P)
       </Box>
     </ColorBox>
     <ColorBox Color="#2f3832">
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
-        Possession: Major (P)
+        Possession: Gear (P)
       </Box>
     </ColorBox>
     <ColorBox Color="#2f3832">
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
-        Possession: Syndicate (P)
+        Possession: Weaponry (P)
       </Box>
     </ColorBox>
-    <ColorBox>
+    <ColorBox Color="#2f3832">
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
+        Possession: Terrorism (P)
       </Box>
     </ColorBox>
     <ColorBox>
@@ -307,19 +310,23 @@
         1-00
       </Box>
     </ColorBox>
-    <ColorBox>
+    <ColorBox Color="#2f3832">
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
-        Possession/Use of Minor Contraband
+        Possession/
+        Use of Controlled
+        Substances
       </Box>
     </ColorBox>
     <ColorBox>
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
-        To make, hold, or use minor contraband without authorization.
+        To make, hold, or abuse restricted drugs or chemicals without authorization.
       </Box>
     </ColorBox>
     <ColorBox>
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
-        The Captain or Head of Security may authorize individual use of minor contraband. Any contraband which is restricted to a department other than command or security is minor contraband unless otherwise specified.
+        Combat enhancing drugs are those that benefit stun times, or movement speed, and are restricted.
+        Poisons are restricted. Substances such as Ephedrine, Desoxyephedrine, and stimulants are restricted.
+        The captain or highest standing command staff may publicly restrict other harmful substances.
       </Box>
     </ColorBox>
     <ColorBox>
@@ -327,7 +334,7 @@
         1-01
       </Box>
     </ColorBox>
-    <ColorBox>
+    <ColorBox Color="#2e422e">
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
         Petty Theft
       </Box>
@@ -350,7 +357,7 @@
         1-02
       </Box>
     </ColorBox>
-    <ColorBox>
+    <ColorBox Color="#453a59">
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
         Vandalism
       </Box>
@@ -371,7 +378,7 @@
         1-03
       </Box>
     </ColorBox>
-    <ColorBox>
+    <ColorBox Color="#59563a">
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
         Trespass
       </Box>
@@ -391,7 +398,7 @@
         1-04
       </Box>
     </ColorBox>
-    <ColorBox>
+    <ColorBox Color="#3b4354">
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
         Disturbance
       </Box>
@@ -438,7 +445,7 @@
         Code
       </Box>
     </ColorBox>
-    <ColorBox>
+    <ColorBox Color="#593a4e">
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
         Failure to Comply
       </Box>
@@ -459,19 +466,19 @@
         2-00
       </Box>
     </ColorBox>
-    <ColorBox>
+    <ColorBox Color="#2f3832">
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
-        Possession/Use of Major Contraband
+        Possession of Restricted Gear
       </Box>
     </ColorBox>
     <ColorBox>
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
-        To make, hold, or use major contraband without authorization.
+        To hold or use non-lethal items or objects that are restricted or illegal.
       </Box>
     </ColorBox>
     <ColorBox>
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
-        The Captain may authorize individual use of major contraband. Any contraband which is restricted to the command or security department is major contraband unless otherwise specified.
+        This is mostly for syndicate contraband; EMAGs, syndicate gas masks, bloodred hardsuits, hijacked PDAs, or syndicate implants, however can sometimes extend to things the individual shouldn't possess like kevlar vests and security gear.
       </Box>
     </ColorBox>
     <ColorBox>
@@ -479,7 +486,7 @@
         2-01
       </Box>
     </ColorBox>
-    <ColorBox>
+    <ColorBox Color="#453a59">
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
         Damage/Destruction of Property
       </Box>
@@ -500,7 +507,7 @@
         2-03
       </Box>
     </ColorBox>
-    <ColorBox>
+    <ColorBox Color="#4d2e2e">
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
         Endangerment
       </Box>
@@ -547,7 +554,7 @@
         Code
       </Box>
     </ColorBox>
-    <ColorBox>
+    <ColorBox Color="#593a4e">
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
         Breach of Arrest
       </Box>
@@ -568,19 +575,19 @@
         3-00
       </Box>
     </ColorBox>
-    <ColorBox>
+    <ColorBox Color="#2f3832">
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
-        Possession/Use of Syndicate Contraband
+        Possession of Restricted Weaponry
       </Box>
     </ColorBox>
     <ColorBox>
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
-        To make, hold, or use Syndicate contraband.
+        To hold or use a weapon that is unlawful or contraband.
       </Box>
     </ColorBox>
     <ColorBox>
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
-        Syndicate contraband may only be used in emergencies, and only to prevent death or gross bodily harm.
+        Everything from guns without a permit, deadly blades, explosives, syndicate firearms to explosive implants.
       </Box>
     </ColorBox>
     <ColorBox>
@@ -588,7 +595,7 @@
         3-01
       </Box>
     </ColorBox>
-    <ColorBox>
+    <ColorBox Color="#2e422e">
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
         Grand Theft
       </Box>
@@ -610,7 +617,7 @@
         3-02
       </Box>
     </ColorBox>
-    <ColorBox>
+    <ColorBox Color="#453a59">
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
         Mass Destruction
       </Box>
@@ -631,7 +638,7 @@
         3-03
       </Box>
     </ColorBox>
-    <ColorBox>
+    <ColorBox Color="#59563a">
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
         Secure Trespass
       </Box>
@@ -651,7 +658,7 @@
         3-04
       </Box>
     </ColorBox>
-    <ColorBox>
+    <ColorBox Color="#4d2e2e">
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
         Assault/Battery
       </Box>
@@ -672,7 +679,7 @@
         3-05
       </Box>
     </ColorBox>
-    <ColorBox>
+    <ColorBox Color="#4d2e2e">
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
         Manslaughter
       </Box>
@@ -692,7 +699,7 @@
         3-06
       </Box>
     </ColorBox>
-    <ColorBox>
+    <ColorBox Color="#3b4354">
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
         Rioting
       </Box>
@@ -740,7 +747,7 @@
         Code
       </Box>
     </ColorBox>
-    <ColorBox>
+    <ColorBox Color="#593a4e">
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
         Breach of Custody
       </Box>
@@ -758,6 +765,26 @@
     <ColorBox>
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
         4-00
+      </Box>
+    </ColorBox>
+        <ColorBox Color="#2f3832">
+      <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
+        Restricted Weaponry with Terroristic Intent
+      </Box>
+    </ColorBox>
+    <ColorBox>
+      <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
+        To possess a significant amount of lethal weaponry.
+      </Box>
+    </ColorBox>
+    <ColorBox>
+      <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
+        Examples include having a c-4 bundle versus a single brick of c4. An l6 Saw or China Lake versus a C20 or handgun. Melee weapons are exempt from being labeled for terroristic intent. This crime should be charged rarely, and only for those who truly had an armories worth of gear.
+      </Box>
+    </ColorBox>
+    <ColorBox>
+      <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
+        4-01
       </Box>
     </ColorBox>
     <ColorBox>
@@ -780,7 +807,7 @@
         4-02
       </Box>
     </ColorBox>
-    <ColorBox>
+    <ColorBox Color="#4d2e2e">
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
         Attempted Murder
       </Box>
@@ -800,7 +827,7 @@
         4-05
       </Box>
     </ColorBox>
-    <ColorBox>
+    <ColorBox Color="#4d2e2e">
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
         Murder
       </Box>
@@ -845,7 +872,7 @@
         Code
       </Box>
     </ColorBox>
-    <ColorBox>
+    <ColorBox Color="#593a4e">
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
         Refusal of Mental Shielding
       </Box>
@@ -865,7 +892,7 @@
         5-00
       </Box>
     </ColorBox>
-    <ColorBox>
+    <ColorBox Color="#453a59">
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
         Terrorism
       </Box>
@@ -885,7 +912,7 @@
         5-03
       </Box>
     </ColorBox>
-    <ColorBox>
+    <ColorBox Color="#4d2e2e">
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
         Prevention of Revival
       </Box>
@@ -905,7 +932,7 @@
         5-05
       </Box>
     </ColorBox>
-    <ColorBox>
+    <ColorBox Color="#4d2e2e">
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
         Mass Murder
       </Box>

--- a/Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/SLRestrictedList.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/SLRestrictedList.xml
@@ -1,0 +1,33 @@
+<Document>
+  # Space Law: Restricted Items and Areas Lists
+
+  ## Controlled Substances
+
+  Items in the list are preceded by an indication of which department or job is legally allowed to use or possess the item on most stations. The station captain may modify these lists as they see fit so long as they exercise due care and provide reasonable notification to the station. Members of command who oversee a department that is permitted to use a restricted item may issue permits to specific people outside of their department to use those items. "None" indicates that there are no departments or roles authorized to use or possess the item.
+
+  - \[Chemists/Science\] Explosive and pyrotechnic compounds excluding welding fuel contained in welders or welding fuel storage vessels
+  - \[Science\] Toxins
+  - \[Medical\] Chloral hydrate, Impedrezene, Ipecac, and Pax
+  - \[Medical\] Desoxyephedrine and Ephedrine
+  - \[None\] Mindbreaker toxin
+  - \[None\] Mute toxin
+  - \[None\] Nocturine
+  - \[None\] Norepinephirc acid
+  - \[None\] Romerol
+  - \[None\] Space drugs
+  - \[None\] Stimulants, excluding Desoxyephedrine and Ephedrine
+
+  ## Restricted Areas
+
+  - I Core and Upload: All command usually have access.
+  - Armory: Head of Security, Warden, and any security officer with Warden or Head of Security's approval.
+  - Atmospherics: Only Atmospheric technicians and Chief Engineer have access.
+  - Bridge: All command staff have access.
+  - Camera Servers: Only Engineering and Security personnel usually have access.
+  - Gravity Generation: Only Engineering personnel (sometimes Chief Engineer exclusively) have access normally.
+  - Head Offices: Dependent on the head.
+  - Research Server: Only the Research Director has access.
+  - Security Zones: Any member of security or command. As well as lawyers.
+  - Telecommunications: Only Engineering personnel (sometimes Chief Engineer exclusively) have access normally.
+  - Vault: All command staff have access.
+</Document>

--- a/Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/SpaceLaw.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/SpaceLaw.xml
@@ -4,7 +4,7 @@
 
   Foreign invaders, such as nuclear operatives, ninjas, and pirates, are not protected under space law. Traitors are not foreign invaders so are usually protected by space law.
 
-  Space Law is not the server rules, but some rules reference Space Law and require it to be followed by certain people or to some degree.
+  Skeletons, lost shuttle refugees (including syndicate refugees), and non hostile foreign ships like the chef ship are all protected under space law. They must, however, seek proper identification (a passenger ID would suffice for IDless persons). Otherwise, they may be detained under failure to comply.
 
   ## Treatment Of Prisoners
   Prisoners still have certain rights that must be upheld by law enforcement:
@@ -15,10 +15,20 @@
   - Prisoners must be given their shift mandated PDA after confinement has finished, unless there is solid proof of PDA tampering. In case of tampering, the PDA is to be secured and replaced with a new unit.
   - Prisoners must be granted freedom of movement, and should not be restrained with handcuffs or other devices after incarceration unless there is an undue risk to life and limb. Similarly, any prisoners held for permanent confinement should be held in the communal brig, and should not be confined to a solitary cell unless they pose a risk to life and limb.
 
+  ## Revival
+  - If lethal force was required to incapacitate a capital offender (any code 5 crime) or an attempted escape from permanent confinement, they are no longer eligible to be revived; that is to say, they should not be revived under any circumstance as they have demonstrated too great a threat or intent to reoffend.
+  - The CMO, Captain, or HoS may also declare a patient or prisoner to not be revived within reason. Examples are a patient immediately killing themselves after getting revived, wasting resources. A prisoner/patient was executed legally due to a combination of other stacking crimes.
+
   ## Search and Seizure
   A personnel search is a seizure of the objects in a person's backpack, hands, coat, belt, and pockets. If any contraband is found during a search, the officer may choose to further the search into a detainment or simply confiscate the restricted items. After the search is conducted, all legal items are to be returned to the person. A crewmate may legally decline any search conducted without probable cause or a warrant while the alert level is green. It should be noted that if the alert level is blue or above, all personnel searches are legal.
 
   A departmental search is the sweep of an entire area or department for contraband. It is recommended that the officers be extremely thorough, checking all lockers, crates, and doors. These can only be done with permission or, ideally, a warrant signed by the department head or highest-ranking command staff, which is the captain in most cases.
+
+  ## Warrants
+  - A warrant is a form that specifies "who" is to be searched and "why". It must be stamped by the proper authority according to it's creation.
+  - Security officers can create a warrant at any time but can not approve it by themselves. The warden or HOS must approve officers search warrants.
+  - The warden can create a warrant but it must be approved by HOS or the departmental head of the to-be searched.
+  - Warrants written by the Head of Security must be looked over by the Warden, Captain, or relevant departmental head.
 
   ## Implantation
   Any prisoner in custody can be subjected to implantation or implant removal procedures, so long as it's within reason. The process of adding an implant should not prolong the detainees sentence, meaning you can not hold them longer to administer the implant, unless stated otherwise. A former inmate can be requested to undergo implantation at a later point in time if they fit the circumstances during their confinement, they must comply. The following have been listed out with special circumstances, anything not in this list can still be applied, given proper legal context. A prisoner can still receive implantation procedures without meeting the circumstances if they give their clear permission.
@@ -31,7 +41,7 @@
   A suspect can be forced to receive implant removal if there is strong, reasonable proof that they have been implanted, such as an officer seeing them use one or their prints being on a discarded injector. Unlike the implantation procedure, a prisoner can have their sentence entirely delayed or extended until they comply with the procedure, as long as security is actively making attempts to perform it. Akin to implanting, if an inmate gives their clear permission, implant removal can proceed without proof.
 
   ## Sentencing
-  From a server rules perspective, security officers are only responsible for ensuring that they only place sentences over 15 minutes where space law would allow permanent confinement. Informing the Warden is highly recommended, even for timed sentences. As long as those requirements are met, security officers not giving inappropriate sentence lengths is considered an in-character issue, not a rule issue.
+  From a server rules perspective, security officers are only responsible for ensuring that they only place sentences over 20 minutes where space law would allow permanent confinement. Informing the Warden is highly recommended, even for timed sentences. As long as those requirements are met, security officers not giving inappropriate sentence lengths is considered an in-character issue, not a rule issue.
 
   The captain, HOS, and warden are responsible, within reason, for ensuring security officers place appropriate sentences that follow space law. If they are aware of an inappropriate sentence, including excessively long sentences, and if there is not an urgent threat or danger that they must prioritize, then they must work to correct that sentence. Unreasonable failures, as determined by game admins, of the captain, HOS, or warden to ensure space law is followed will be considered a rule issue, not an in-character issue.
 
@@ -39,7 +49,7 @@
 
   [color=#a4885c]Stackable Crimes:[/color] Crimes are to be considered 'stackable' in the sense that if you charge someone with two or more different crimes, you should combine the times you would give them for each crime. Linked crimes, shown in matching colors and suffixes on the Quick Crime Guide, can not be stacked and instead override each other, you should pick the highest crime that matches the case.
 
-  - Example: A suspect has committed a 2-01 (possession: major) and a 3-01 (possession: syndicate). The maximum sentence here would be 10 minutes due to them being linked crimes, and 3-01 is the greater crime.
+  - Example: A suspect has committed a 2-01 (possession of restricted gear) and a 3-01 (possession of restricted weapons). The maximum sentence here would be 10 minutes due to them being linked crimes, and 3-01 is the greater crime.
   - Example 2: A suspect commits a 3-04 (Secure trespassing) and a 3-06 (manslaughter). Those crimes stack since they are not linked crimes. You could sentence for a maximum of 20 minutes, but context matters heavily, and maximum sentences should only be used for the worst offenders.
 
   [color=#a4885c]Repeater Offenders:[/color] Repeated crimes are when someone is released for a crime and then goes to commit the same crime within the same shift. Repeated crimes can be charged with tacked-on time; first repeat: 3:00, second repeat: 6:00, third repeat: permanent confinement. It should be noted each tacked-on time is directly linked to one type of crime, so for example, if someone does their first repeat of trespass and petty theft, you can charge them with an extra 6 minutes.
@@ -52,8 +62,12 @@
   - [color=#a4885c]Demotion:[/color] Entails removing all departmental gear they have on their person and revoking the involved department access off their ID. This requires the captain's or involved department head's approval. Demotions should only be issued if the person pose a threat to their own department or are in a position where they have/can abuse their job's gear to commit further crimes.
 
   ## Major Punishments
-  [color=#a4885c]Permanent Confinement:[/color] Being held in the permanent brig for the entire duration of the shift. A person is eligible for permanent confinement if their timed sentence would exceed 15 minutes. Any persons subject to this punishment are required to be transported in cuffs to CentComm at the end of the shift. A permanent prisoner can not be deprived of anything covered by the section "Treatment Of Prisoners".
+  [color=#a4885c]Permanent Confinement:[/color] Being held in the permanent brig for the entire duration of the shift. A person is eligible for permanent confinement if their timed sentence would exceed 20 minutes. Any persons subject to this punishment are required to be transported in cuffs to CentComm at the end of the shift. A permanent prisoner can not be deprived of anything covered by the section "Treatment Of Prisoners".
+
   [color=#a4885c]Execution:[/color] A humane way of dealing with extremely unruly crewmates. Within reason, a prisoner who has been given the death sentence may pick how they wish to be killed, common methods are firing line, lethal injection, exile, and high voltage electrocution. Another alternate method of "execution" is the process of placing a staff's mind into a borg, this is allowed so long as it is lawful. Execution can only be issued with the captain's or acting captain's approval; if the HoS is acting captain or there is no acting captain, all heads of staff are to hold a vote on the matter.
+
+  ## Restricted Items and Areas
+  - [textlink="Restricted Items and Areas" link="SpaceLawRestrictedList"]
 
   ## Crime Listing
   - [textlink="Crime Listing" link="SpaceLawCrimeList"]


### PR DESCRIPTION
## About the PR
In-game Space Law guidebooks (all sources) edited to reflect Harmony changes to Space Law

## Why / Balance
Because it's good to have correct written Space Law IC.

## Technical details
### Harmony files
- `Resources/Locale/en-US/Harmony/guidebook/guides.ftl` -- Loc string for Restricted Lists
### Upstream files
- `Resources/Prototypes/Guidebook/rules.yml` -- Add separate restricted list guide entry, and add it to Space Law guide children
- `Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/SLCrimeList.xml` -- Crime list modifications
- `Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/SLRestrictedList.xml` -- New Restricted Areas and Items lists
- `Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/SpaceLaw.xml` -- Space Law 

**Changelog**
:cl:
- tweak: In-game Space Law guidebooks are now Harmony Space Law.
