### PR TITLE
Unnerf the Frezon price

### DIFF
--- a/Resources/Prototypes/Atmospherics/gases.yml
+++ b/Resources/Prototypes/Atmospherics/gases.yml
@@ -99,4 +99,4 @@
   gasMolesVisible: 0.6
   color: 3a758c
   reagent: Frezon
-  pricePerMole: 0.3
+  pricePerMole: 3.5 # Harmony

--- a/Resources/Prototypes/Atmospherics/gases.yml
+++ b/Resources/Prototypes/Atmospherics/gases.yml
@@ -99,4 +99,4 @@
   gasMolesVisible: 0.6
   color: 3a758c
   reagent: Frezon
-  pricePerMole: 3.5 # Harmony
+  pricePerMole: 2 # Harmony


### PR DESCRIPTION
## About the PR
Frezon price/mole 0.3 -> 2

## Why / Balance
Price was nerfed upstream from 3 to 0.3 and the production got more difficult and costly.
Keeping the production change, and bumping the sale price to 2 make it still worth the time and skill investment.

We can revert this when Atmos has more things to do.

Requested by Atmos players to have fun things to do.
I personally don't see it as a major balance issue to have an ultra rich Cargo once in a while. It gives more RP possibilities and time to do it, if anything.

With this change a can of Frezon should sell for around 80k.

**Changelog**
:cl:
- tweak: Frezon selling price is changed to 2 spesos per mole.