### PR TITLE
Add No EORG popup on round end

### DIFF
--- a/Content.Client/_Harmony/RoundEnd/RoundEndNoEorgUIController.cs
+++ b/Content.Client/_Harmony/RoundEnd/RoundEndNoEorgUIController.cs
@@ -42,8 +42,7 @@ public sealed class RoundEndNoEorgUIController : UIController
         if (_window == null)
             InitializeWindow();
 
-        if (_window != null)
-            _window.MoveToFront();
+        _window?.MoveToFront();
     }
 
     private void InitializeWindow()

--- a/Content.Client/_Harmony/RoundEnd/RoundEndNoEorgUIController.cs
+++ b/Content.Client/_Harmony/RoundEnd/RoundEndNoEorgUIController.cs
@@ -1,0 +1,84 @@
+using Content.Shared.GameTicking;
+using JetBrains.Annotations;
+using Robust.Client.UserInterface.Controllers;
+using Robust.Client.UserInterface.Controls;
+using Content.Shared._Harmony.CCVars;
+using Robust.Shared.Timing;
+using Robust.Shared.Configuration;
+
+namespace Content.Client._Harmony.RoundEnd;
+
+[UsedImplicitly]
+public sealed class RoundEndNoEorgUIController : UIController
+{
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
+    private RoundEndNoEorgWindow? _window;
+    private float _timer;
+    private bool _skipPopup;
+
+    private bool GetSkipPopupCvar() => _cfg.GetCVar(HCCVars.SkipRoundEndNoEorgMessage);
+
+    private void SetSkipPopupCvar(bool value)
+    {
+        if (GetSkipPopupCvar() == value)
+            return;
+        _cfg.SetCVar(HCCVars.SkipRoundEndNoEorgMessage, value);
+        _cfg.SaveToFile();
+    }
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        if (GetSkipPopupCvar())
+            return;
+        SubscribeNetworkEvent<RoundEndMessageEvent>((_, _) => OpenRoundEndNoEorgWindow());
+    }
+
+    public void OpenRoundEndNoEorgWindow()
+    {
+        if (GetSkipPopupCvar())
+            return;
+        if (_window == null)
+        {
+            InitializeWindow();
+        }
+    }
+
+    private void InitializeWindow()
+    {
+        _window = new RoundEndNoEorgWindow();
+        _timer = 5;
+        _window.TimedCloseButton.OnPressed += OnClosePressed;
+        _window.CheckBox.Pressed = GetSkipPopupCvar();
+        _window.CheckBox.OnToggled += args => _skipPopup = args.Pressed;
+        _window.OpenCentered();
+        _window.OnClose += () => _window = null;
+    }
+
+    public void OnClosePressed(BaseButton.ButtonEventArgs args)
+    {
+        SetSkipPopupCvar(_skipPopup);
+        _window?.Close();
+        _window = null;
+    }
+
+    public override void FrameUpdate(FrameEventArgs args)
+    {
+        base.FrameUpdate(args);
+
+        if (_window == null)
+            return;
+
+        if (!_window.TimedCloseButton.Disabled)
+            return;
+
+        if (_timer > 0.0f)
+        {
+            _timer -= args.DeltaSeconds;
+            if (_timer < 0)
+                _timer = 0;
+        }
+
+        _window.UpdateCloseButton(_timer);
+    }
+}

--- a/Content.Client/_Harmony/RoundEnd/RoundEndNoEorgUIController.cs
+++ b/Content.Client/_Harmony/RoundEnd/RoundEndNoEorgUIController.cs
@@ -38,10 +38,12 @@ public sealed class RoundEndNoEorgUIController : UIController
     {
         if (GetSkipPopupCvar())
             return;
+
         if (_window == null)
-        {
             InitializeWindow();
-        }
+
+        if (_window != null)
+            _window.MoveToFront();
     }
 
     private void InitializeWindow()

--- a/Content.Client/_Harmony/RoundEnd/RoundEndNoEorgWindow.cs
+++ b/Content.Client/_Harmony/RoundEnd/RoundEndNoEorgWindow.cs
@@ -1,0 +1,111 @@
+using System.Numerics;
+using Robust.Client.UserInterface.Controls;
+using Robust.Client.UserInterface.CustomControls;
+using Robust.Shared.Utility;
+using static Robust.Client.UserInterface.Controls.BoxContainer;
+
+namespace Content.Client._Harmony.RoundEnd
+{
+    public sealed class RoundEndNoEorgWindow : DefaultWindow
+    {
+        private static readonly Vector2 WindowSize = new Vector2(520, 420);
+        private const string TitleText = "harmony-round-end-no-eorg-window-title";
+        private const string LabelText = "harmony-round-end-no-eorg-window-label";
+        private const string MessageText = "harmony-round-end-no-eorg-window-message";
+        private const string RuleText = "harmony-round-end-no-eorg-window-rule";
+        private const string RuleDetailText = "harmony-round-end-no-eorg-window-rule-text";
+        private const string CloseButtonText = "harmony-round-end-no-eorg-window-close-button";
+        private const string CloseButtonWaitText = "harmony-round-end-no-eorg-window-close-button-wait";
+        private const string CheckboxText = "harmony-round-end-no-eorg-window-checkbox-text";
+        public Button TimedCloseButton;
+        public CheckBox CheckBox;
+
+        public RoundEndNoEorgWindow()
+        {
+            MinSize = SetSize = WindowSize;
+            Title = Loc.GetString(TitleText);
+            CloseButton.Visible = false;
+            CloseButton.Disabled = true;
+            TimedCloseButton = CreateButton();
+            CheckBox = CreateCheckBox();
+
+            var container = CreateContainer();
+
+            var noEorgLabel = CreateLabel();
+            var noEorgMessage = CreateMessage();
+            var noEorgRule = CreateRule();
+
+            container.AddChild(noEorgLabel);
+            container.AddChild(noEorgMessage);
+            container.AddChild(noEorgRule);
+            container.AddChild(CheckBox);
+            container.AddChild(TimedCloseButton);
+            Contents.AddChild(container);
+        }
+
+        private static BoxContainer CreateContainer()
+        {
+            return new BoxContainer
+            {
+                Orientation = LayoutOrientation.Vertical,
+            };
+        }
+
+        private static Label CreateLabel()
+        {
+            return new Label
+            {
+                Text = Loc.GetString(LabelText),
+                StyleClasses = { "LabelBig" },
+                FontColorOverride = Color.Red,
+                Align = Label.AlignMode.Center
+            };
+        }
+
+        private static RichTextLabel CreateMessage()
+        {
+            var message = new FormattedMessage();
+            message.AddMarkupOrThrow(Loc.GetString(MessageText) + "\n");
+
+            var richTextLabel = new RichTextLabel();
+            richTextLabel.SetMessage(message);
+            return richTextLabel;
+        }
+
+        private static RichTextLabel CreateRule()
+        {
+            var rule = new FormattedMessage();
+            rule.PushColor(Color.Gray);
+            rule.AddMarkupOrThrow(Loc.GetString(RuleText));
+            rule.AddText("\n...\n" + Loc.GetString(RuleDetailText) + "\n...\n");
+
+            var richTextLabel = new RichTextLabel();
+            richTextLabel.SetMessage(rule);
+            return richTextLabel;
+        }
+
+        private static CheckBox CreateCheckBox()
+        {
+            return new CheckBox
+            {
+                Text = Loc.GetString(CheckboxText)
+            };
+        }
+
+        private Button CreateButton() => new Button { Disabled = true };
+
+        public void UpdateCloseButton(float timer)
+        {
+            if (timer > 0.0f)
+            {
+                TimedCloseButton.Text = Loc.GetString(CloseButtonWaitText, ("time", MathF.Floor(timer)));
+                TimedCloseButton.Disabled = true;
+            }
+            else
+            {
+                TimedCloseButton.Text = Loc.GetString(CloseButtonText);
+                TimedCloseButton.Disabled = false;
+            }
+        }
+    }
+}

--- a/Content.Shared/_Harmony/CCVars/HCCVars.cs
+++ b/Content.Shared/_Harmony/CCVars/HCCVars.cs
@@ -1,0 +1,16 @@
+using Robust.Shared.Configuration;
+
+namespace Content.Shared._Harmony.CCVars;
+
+/// <summary>
+/// Harmony-specific cvars.
+/// </summary>
+[CVarDefs]
+public sealed class HCCVars
+{
+    /// <summary>
+    /// Boolean to define if the round end no EORG message should be skipped.
+    /// </summary>
+    public static readonly CVarDef<bool> SkipRoundEndNoEorgMessage =
+        CVarDef.Create("harmony.skip_roundend_noeorg", false, CVar.CLIENTONLY | CVar.ARCHIVE, "Toggles displaying of No EORG reminder.");
+}

--- a/Resources/Locale/en-US/_Harmony/round-end/round-end-no-eorg-window.ftl
+++ b/Resources/Locale/en-US/_Harmony/round-end/round-end-no-eorg-window.ftl
@@ -1,0 +1,8 @@
+harmony-round-end-no-eorg-window-title = Harmony Station - No EORG Rule
+harmony-round-end-no-eorg-window-label = PLEASE DO NOT EORG!
+harmony-round-end-no-eorg-window-message = [bold]End-of-round grief (EORG)[/bold] is not allowed on Harmony Station. Please refrain from any further hostile actions and stay in character until the lobby screen appears to maintain an immersive environment for everyone. Thank you for respecting the community rules!
+harmony-round-end-no-eorg-window-rule = [bold][color=#a4885c]Rule 6: Self-Antagging[/color][/bold]
+harmony-round-end-no-eorg-window-rule-text = There will be no end-of-round grief once the "end screen" pops up. Antagonists may no longer pursue their objectives, and everyone is to stay in character until the lobby screen appears.
+harmony-round-end-no-eorg-window-close-button = I get it! Close the window.
+harmony-round-end-no-eorg-window-close-button-wait = The close button will be enabled after {$time} seconds.
+harmony-round-end-no-eorg-window-checkbox-text = Don't show this again.


### PR DESCRIPTION
## About the PR
Adds a popup on round end with a reminder about no EORG rules.
- Close button is timed -- enabled after 5 seconds.
- "Don't show again" checkbox works via CVar.

## Why / Balance
A lot of bwoinks are pure EORG from players who are new to the server and didn't read the rules.
This reminder, hopefully, will improve the situation and give admins time to do something other than EORG bwoinks.

## Technical details
- `RoundEndNoEorgUIController` subscribes to the Network Event `RoundEndMessageEvent`.
- CLIENTONLY `harmony.skip_roundend_noeorg` CCVar controls if the popup will be shown or not.
    Saved to client config.
- For testing purposes, you can set `ccvar harmony.skip_roundend_noeorg false` in console to see the popup again on round end, after it was dismissed with "Don't show again" checkmark.

### File changes
### Locale files
- `Resources/Locale/en-US/_Harmony/round-end/round-end-no-eorg-window.ftl` -- All the strings.
    To avoid hardcode and allow easy modification without going into C#.
### `Content.Client._Harmony.RoundEnd` Namespace
- `Content.Client/_Harmony/RoundEnd/RoundEndNoEorgUIController.cs` -- Controller logic.
- `Content.Client/_Harmony/RoundEnd/RoundEndNoEorgWindow.cs` -- Defines the window.
### `Content.Shared._Harmony.CCVars` Namespace
New namespace for Harmony CCVars -- HCCVars.
- `Content.Shared/_Harmony/CCVars/HCCVars.cs` -- Defines all HCCVars

## Media
![image](https://github.com/user-attachments/assets/36fa18a3-293c-46d2-aab4-38c83af371b2)

https://github.com/user-attachments/assets/5a479a00-2182-4134-ad60-067d9dc8e1a3

## Notes
In hindsight this would be a lot more easier and concise with XAML, but oh well...

**Changelog**
:cl:
- add: Added no EORG reminder popup at the end of the round.
