### PR TITLE
Make red phone an Intercom with CentCom channel

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_misc.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_misc.yml
@@ -41,9 +41,12 @@
     size: Small
     storedRotation: 90
 
+# Entity is renamed to hijack its id
+# ID is redefined in Resources/Prototypes/_Harmony/Entities/Objects/Devices/red_phone.yml
+# child entites: PhoneInstrumentSyndicate, BananaPhoneInstrument
 - type: entity
   parent: BaseHandheldInstrument
-  id: PhoneInstrument
+  id: PhoneInstrumentUpstream # Harmony
   name: red phone
   description: Should anything ever go wrong...
   components:
@@ -64,7 +67,7 @@
     verbImage: null
 
 - type: entity
-  parent: PhoneInstrument
+  parent: PhoneInstrumentUpstream # Harmony, due to hijacked 'PhoneInstrument'
   id: PhoneInstrumentSyndicate
   name: blood-red phone
   description: For evil people to call their friends.
@@ -150,7 +153,7 @@
     quickEquip: false
 
 - type: entity
-  parent: PhoneInstrument
+  parent: PhoneInstrumentUpstream # Harmony, due to hijacked 'PhoneInstrument'
   id: BananaPhoneInstrument
   name: banana phone
   description: A direct line to the Honkmother. Seems to always go to voicemail.

--- a/Resources/Prototypes/_Harmony/Entities/Objects/Devices/red_phone.yml
+++ b/Resources/Prototypes/_Harmony/Entities/Objects/Devices/red_phone.yml
@@ -28,6 +28,9 @@
       containers:
         key_slots:
           - EncryptionKeyCentCom
+    - type: ContainerContainer
+      containers:
+        key_slots: !type:Container
     - type: TelecomExempt
     - type: RadioMicrophone
       unobstructedRequired: true

--- a/Resources/Prototypes/_Harmony/Entities/Objects/Devices/red_phone.yml
+++ b/Resources/Prototypes/_Harmony/Entities/Objects/Devices/red_phone.yml
@@ -1,0 +1,46 @@
+# Red phone, but CentCom intercom
+# Note: the ID is hijacked from Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_misc.yml
+# New upstream ID: PhoneInstrumentUpstream
+# Child entites also have PhoneInstrumentUpstream parent: PhoneInstrumentSyndicate, BananaPhoneInstrument
+- type: entity
+  id: PhoneInstrument
+  parent: [BaseItem, BaseCommandContraband]
+  name: red phone
+  suffix: harmony intercom
+  description: Should anything ever go wrong...
+  components:
+    - type: Sprite
+      sprite: Objects/Fun/Instruments/otherinstruments.rsi
+      state: red_phone
+    - type: EmitSoundOnLand
+      sound:
+        path: /Audio/Items/ring.ogg
+    - type: Prayable
+      sentMessage: prayer-popup-notify-centcom-sent
+      notificationPrefix: prayer-chat-notify-centcom
+      verb: prayer-verbs-call
+      verbImage: null
+    - type: Speech
+      speechVerb: Robotic
+    - type: EncryptionKeyHolder
+      keySlots: 1
+    - type: ContainerFill
+      containers:
+        key_slots:
+          - EncryptionKeyCentCom
+    - type: TelecomExempt
+    - type: RadioMicrophone
+      unobstructedRequired: true
+      listenRange: 2
+      toggleOnInteract: false
+    - type: RadioSpeaker
+      toggleOnInteract: false
+    - type: Intercom
+      requiresPower: false
+    - type: ActivatableUI
+      key: enum.IntercomUiKey.Key
+      singleUser: true
+    - type: UserInterface
+      interfaces:
+        enum.IntercomUiKey.Key:
+          type: IntercomBoundUserInterface


### PR DESCRIPTION
## About the PR
Red phone is now an Intercom with CentComm channel.

## Why / Balance
More immersion when talking to Central Command. Proposed by Spanky.

## Technical details
### Harmony
`Resources/Prototypes/_Harmony/Entities/Objects/Devices/red_phone.yml`
- New red phone entity with components that make it an Intercom
- Also a command contraband

### Upstream files
`Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_misc.yml`
- Changed ID of red phone to `PhoneInstrumentUpstream`
    <ins>This is done to automatically remap all red phones on all maps to our version.</ins>
- Changed parent of blood-red phone and banana phone to `PhoneInstrumentUpstream`
    To avoid nukies and clown having direct line to CentCom.

## Media
**In game**
![image](https://github.com/user-attachments/assets/a106578c-cd88-4d80-8f68-91e1ea39d2e8)

**In action**
![image](https://github.com/user-attachments/assets/6c0f8f77-1b32-408b-98f9-ff6de94033e4)

## Notes for admins and mappers
- New phone has a `[harmony intercom]` suffix for easier spawn and to distinguish from the OG version.
- If you are mapping on Harmony codebase, this is the phone you want to place due to hijacked ID.
![image](https://github.com/user-attachments/assets/b3076459-9595-4d73-b3e6-2c4038a7c462)

**Changelog**
:cl:
- tweak: Red phone is now an intercom for CentCom channel.
