### PR TITLE
Add basic raiders

### DIFF
--- a/Resources/Prototypes/_Harmony/Entities/Clothing/Belt/quivers.yml
+++ b/Resources/Prototypes/_Harmony/Entities/Clothing/Belt/quivers.yml
@@ -1,0 +1,9 @@
+- type: entity
+  parent: ClothingBeltQuiver
+  id: ClothingBeltQuiverFilled
+  suffix: Filled, DO NOT MAP
+  components:
+  - type: StorageFill
+    contents:
+      - id: ArrowRegular
+        amount: 16

--- a/Resources/Prototypes/_Harmony/Entities/Mobs/raiders.yml
+++ b/Resources/Prototypes/_Harmony/Entities/Mobs/raiders.yml
@@ -11,7 +11,7 @@
 # Weak raiders. The weapons they get are gimmicky at best, and they have little to no survivability.
 - type: entity
   name: Weak Raider
-  suffix: Claymore
+  suffix: Rimworld, Claymore
   parent: BaseRaider
   id: MobRaiderClaymore
   components:
@@ -21,7 +21,7 @@
 
 - type: entity
   name: Weak Raider
-  suffix: Mosin
+  suffix: Rimworld, Mosin
   parent: BaseRaider
   id: MobRaiderMosin
   components:
@@ -31,7 +31,7 @@
 
 - type: entity
   name: Weak Raider
-  suffix: Bow
+  suffix: Rimworld, Bow
   parent: BaseRaider
   id: MobRaiderBow
   components:
@@ -42,7 +42,7 @@
 #Okay-ish raiders. They are more than capable of taking on some crew members on their own
 - type: entity
   name: Raider
-  suffix: Medic
+  suffix: Rimworld, Medic
   parent: BaseRaider
   id: MobRaiderMedic
   components:
@@ -52,7 +52,7 @@
 
 - type: entity
   name: Raider
-  suffix: Sniper
+  suffix: Rimworld, Sniper
   parent: BaseRaider
   id: MobRaiderSniper
   components:
@@ -62,7 +62,7 @@
 
 - type: entity
   name: Raider
-  suffix: Rifleman
+  suffix: Rimworld, Rifleman
   parent: BaseRaider
   id: MobRaiderRifleman
   components:
@@ -72,7 +72,7 @@
 
 - type: entity
   name: Raider
-  suffix: Demolitionist
+  suffix: Rimworld, Demolitionist
   parent: BaseRaider
   id: MobRaiderDemolitionist
   components:

--- a/Resources/Prototypes/_Harmony/Loadouts/Misc/rimworld.yml
+++ b/Resources/Prototypes/_Harmony/Loadouts/Misc/rimworld.yml
@@ -38,7 +38,7 @@
   equipment:
     outerClothing: ClothingOuterArmorBasicSlim
     back: ClothingBackpackSatchelLeather
-    belt: ClothingBeltQuiver
+    belt: ClothingBeltQuiverFilled
     pocket1: KukriKnife
   inhand:
     - BowImprovised
@@ -49,23 +49,6 @@
     - SmokeGrenade
     - Gauze
     - SpaceCash2500
-    belt:
-    - ArrowRegular
-    - ArrowRegular
-    - ArrowRegular
-    - ArrowRegular
-    - ArrowRegular
-    - ArrowRegular
-    - ArrowRegular
-    - ArrowRegular
-    - ArrowRegular
-    - ArrowRegular
-    - ArrowRegular
-    - ArrowRegular
-    - ArrowRegular
-    - ArrowRegular
-    - ArrowRegular
-    - ArrowRegular
 
 - type: startingGear
   id: RaiderMedicGear


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds 3 weak raiders (Claymore/Mosin/Bow) and 4 regular raiders (Medic/Rifleman/Demolitionist/Sniper) to the admin spawn panel. 

![image](https://github.com/user-attachments/assets/3b3d3972-2ba1-4fdc-bfab-dd00d380c3ce)
I've got more things in the works but I have several local repos on several computers that don't really communicate and its annoying so I'm pushing this now and will finish everything else I have planned on another PC (Until i inevitably get bored again and start another PR on this PC but shhh)

## Why / Balance
When setting up for rimworld, it's painful to need to spawn every item manually and then give it to the character. This allows admins to just spawn preset raiders and ease admin load. 
The balance is entirely untested but it's admeme stuff.

## Technical details
Added a bunch of prototypes. Ideally they have randomly chosen clothing but the way random equipment loadouts work would mean a shitton of duplicated prototypes which is not what anyone wants.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
Not player facing
