### PR TITLE
Anti EORG measures (round end pacifist mode)

### DIFF
--- a/Content.Server/_Harmony/RoundEnd/RoundEndSystem.Pacified.cs
+++ b/Content.Server/_Harmony/RoundEnd/RoundEndSystem.Pacified.cs
@@ -1,0 +1,65 @@
+// Credits:
+// This code was originally created by DebugOk, deltanedas, and NullWanderer for DeltaV.
+// Available at https://github.com/DebugOk/Delta-v/blob/master/Content.Server/DeltaV/RoundEnd/RoundEndSystem.Pacified.cs
+// Original PR: https://github.com/DeltaV-Station/Delta-v/pull/350
+// Modified by FluffMe on 12.10.2024 with no major changes except the Namespaces and the CVar name.
+using Content.Server.GameTicking;
+using Content.Shared.CombatMode;
+using Content.Shared.CombatMode.Pacification;
+using Content.Shared._Harmony.CCVars;
+using Content.Shared.Explosion.Components;
+using Content.Shared.Flash.Components;
+using Content.Shared.Store.Components;
+using Robust.Shared.Configuration;
+
+namespace Content.Server._Harmony.RoundEnd;
+
+public sealed class PacifiedRoundEnd : EntitySystem
+{
+    [Dependency] private readonly IConfigurationManager _configurationManager = default!;
+
+    private bool _enabled;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        _configurationManager.OnValueChanged(HCCVars.RoundEndPacifist, v => _enabled = v, true);
+        SubscribeLocalEvent<RoundEndTextAppendEvent>(OnRoundEnded);
+    }
+
+    private void OnRoundEnded(RoundEndTextAppendEvent ev)
+    {
+        if (!_enabled)
+            return;
+
+        var harmQuery = EntityQueryEnumerator<CombatModeComponent>();
+        while (harmQuery.MoveNext(out var uid, out _))
+        {
+            EnsureComp<PacifiedComponent>(uid);
+        }
+
+        var explosiveQuery = EntityQueryEnumerator<ExplosiveComponent>();
+        while (explosiveQuery.MoveNext(out var uid, out _))
+        {
+            RemComp<ExplosiveComponent>(uid);
+        }
+
+        var grenadeQuery = EntityQueryEnumerator<OnUseTimerTriggerComponent>();
+        while (grenadeQuery.MoveNext(out var uid, out _))
+        {
+            RemComp<OnUseTimerTriggerComponent>(uid);
+        }
+
+        var flashQuery = EntityQueryEnumerator<FlashComponent>();
+        while (flashQuery.MoveNext(out var uid, out _))
+        {
+            RemComp<FlashComponent>(uid);
+        }
+
+        var uplinkQuery = EntityQueryEnumerator<StoreComponent>();
+        while (uplinkQuery.MoveNext(out var uid, out _))
+        {
+            RemComp<StoreComponent>(uid);
+        }
+    }
+}

--- a/Content.Shared/_Harmony/CCVars/HCCVars.cs
+++ b/Content.Shared/_Harmony/CCVars/HCCVars.cs
@@ -13,4 +13,11 @@ public sealed class HCCVars
     /// </summary>
     public static readonly CVarDef<bool> SkipRoundEndNoEorgMessage =
         CVarDef.Create("harmony.skip_roundend_noeorg", false, CVar.CLIENTONLY | CVar.ARCHIVE, "Toggles displaying of No EORG reminder.");
+
+    /// <summary>
+    /// Anti-EORG measure. Will add pacified to all players upon round end.
+    /// Its not perfect, but gets the job done.
+    /// </summary>
+    public static readonly CVarDef<bool> RoundEndPacifist =
+        CVarDef.Create("game.round_end_pacifist", false, CVar.SERVERONLY);
 }


### PR DESCRIPTION
## About the PR
Original code by DebugOk, deltanedas, and NullWanderer for DeltaV
Available at: https://github.com/DebugOk/Delta-v/blob/master/Content.Server/DeltaV/RoundEnd/RoundEndSystem.Pacified.cs
Original PR: https://github.com/DeltaV-Station/Delta-v/pull/350

* Gives any entity that is able to harm a pacified component
* Makes explosives useless
* Makes grenades useless
* Makes flashes useless
* Breaks uplinks

## Why / Balance
Having no mechanical changes did not help with EORG.

## Technical details
* Requires `game.round_end_pacifist` CVar to be set to `true`
* `Content.Server/_Harmony/RoundEnd/RoundEndSystem.Pacified.cs`

## Breaking changes
https://github.com/ss14-harmony/space-station-14/pull/96 should be reverted

**Changelog**
:cl:
- add: Added anti-EORG measures.
- remove: Removed "No EORG" popup at round end.
