### PR TITLE
Fix Rat King Solo Antag popup

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/ghost_roles.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/ghost_roles.yml
@@ -18,7 +18,7 @@
   - type: GhostRole
     name: ghost-role-information-rat-king-name
     description: ghost-role-information-rat-king-description
-    rules: ghost-role-information-rules-default-solo-antagonist
+    rules: ghost-role-information-antagonist-rules
     raffle:
       settings: default
   - type: GhostRoleMobSpawner


### PR DESCRIPTION
## About the PR
Bug fix
An issue was introduced by https://github.com/ss14-harmony/space-station-14/pull/61
![image](https://github.com/user-attachments/assets/53820156-313a-4702-831f-d270d153da49)
`ghost-role-information-rules-default-solo-antagonist` is not in FTLs but referenced by several roles.

## Technical details
Use `ghost-role-information-antagonist-rules` instead.

## Media
![image](https://github.com/user-attachments/assets/a4abdc4c-4518-42a4-9340-5787b827735c)
