### PR TITLE
Increase Barotrauma Damage

### DIFF
--- a/Content.IntegrationTests/Tests/Commands/SuicideCommandTests.cs
+++ b/Content.IntegrationTests/Tests/Commands/SuicideCommandTests.cs
@@ -168,7 +168,7 @@ public sealed class SuicideCommandTests
         await pair.CleanReturnAsync();
     }
 
-        /// <summary>
+    /// <summary>
     /// Run the suicide command in the console
     /// Should only ghost the player but not kill them
     /// </summary>
@@ -241,6 +241,7 @@ public sealed class SuicideCommandTests
         var mindSystem = entManager.System<SharedMindSystem>();
         var mobStateSystem = entManager.System<MobStateSystem>();
         var transformSystem = entManager.System<TransformSystem>();
+        var damageableSystem = entManager.System<DamageableSystem>();
 
         // We need to know the player and whether they can be hurt, killed, and whether they have a mind
         var player = playerMan.Sessions.First().AttachedEntity!.Value;
@@ -276,6 +277,8 @@ public sealed class SuicideCommandTests
         // and that all the damage is concentrated in the Slash category
         await server.WaitAssertion(() =>
         {
+            // Heal all damage first (possible low pressure damage taken)
+            damageableSystem.SetAllDamage(player, damageableComp, 0);
             consoleHost.GetSessionShell(playerMan.Sessions.First()).ExecuteCommand("suicide");
             var lethalDamageThreshold = mobThresholdsComp.Thresholds.Keys.Last();
 
@@ -313,6 +316,7 @@ public sealed class SuicideCommandTests
         var mindSystem = entManager.System<SharedMindSystem>();
         var mobStateSystem = entManager.System<MobStateSystem>();
         var transformSystem = entManager.System<TransformSystem>();
+        var damageableSystem = entManager.System<DamageableSystem>();
 
         // We need to know the player and whether they can be hurt, killed, and whether they have a mind
         var player = playerMan.Sessions.First().AttachedEntity!.Value;
@@ -348,6 +352,8 @@ public sealed class SuicideCommandTests
         // and that slash damage is split in half
         await server.WaitAssertion(() =>
         {
+            // Heal all damage first (possible low pressure damage taken)
+            damageableSystem.SetAllDamage(player, damageableComp, 0);
             consoleHost.GetSessionShell(playerMan.Sessions.First()).ExecuteCommand("suicide");
             var lethalDamageThreshold = mobThresholdsComp.Thresholds.Keys.Last();
 

--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -287,7 +287,8 @@ namespace Content.Shared.Atmos
         ///     so it just applies this flat value).
         /// </summary>
         // Original value is 4, buff back when we have proper ways for players to deal with breaches.
-        public const int LowPressureDamage = 1;
+        // Harmony, value changed back to 4.
+        public const int LowPressureDamage = 4;
 
         public const float WindowHeatTransferCoefficient = 0.1f;
 


### PR DESCRIPTION
## About the PR
Increased low pressure damage (barotrauma) from 1 to 4.

## Why / Balance
This was originally reduced on upstream via https://github.com/space-wizards/space-station-14/pull/29478 largely due to shuttle bombing and other issues. Recent changes (such as nerfs to meteors) have made this less of a problem, especially paired with Harmony’s anti shuttle bombing rule. Players being able to run around in spaced rooms and even space without protection for extended periods is unrealistic and anti-RP. Some discussion has led to the opinion that players on Harmony will be prepared to deal with a return to the old damage.

## Technical details
Changes one number, should be reverted if upstream changes the value or how the system works.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Barotrauma damage has been quadrupled (to be in line with values before upstream nerf).