### PR TITLE
Increase Barotrauma Damage (Alternate)

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -226,7 +226,7 @@
   - type: Barotrauma
     damage:
       types:
-        Blunt: 0.50 #per second, scales with pressure and other constants.
+        Blunt: 2 #per second, scales with pressure and other constants.
         Heat: 0.1
   - type: PassiveDamage # Slight passive regen. Assuming one damage type, comes out to about 4 damage a minute.
     allowedStates:

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -72,7 +72,7 @@
   - type: Barotrauma
     damage:
       types:
-        Blunt: 0.50 #per second, scales with pressure and other constants.
+        Blunt: 2 #per second, scales with pressure and other constants.
         Heat: 0.2 # 0.1 more than humans, i feel like low pressure would make slime boil more than blunt stretch them so i decided on this instead.
   - type: Reactive
     groups:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Increased barotrauma damage via .yml edit rather than the Atmospherics.cs (which is probably a better method anyways). This edit makes you crit without space protection in a little under 30 seconds.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Other PR to increase barotrauma didn't work, so I am trying this method instead at Liltenhead's recommendation. Tested ingame and works.

## Technical details
<!-- Summary of code changes for easier review. -->

- Base mob barotrauma damage increased from 0.5 to 2 (4x increase, inverse proportional to upstream's nerf).
- Slimes received the same change in their .yml, only reason they have a value for it is because of different heat damage (unchanged).

https://github.com/ss14-harmony/space-station-14/pull/137 should be closed if merged.
This PR should be reverted if upstream changes barotrauma damage values.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: More lethal barotrauma damage has returned.