### PR TITLE
Reenable Diff RSIs github action

### DIFF
--- a/.github/workflows/rsi-diff.yml
+++ b/.github/workflows/rsi-diff.yml
@@ -1,10 +1,9 @@
 name: Diff RSIs
 
 on:
-  workflow_dispatch:
-#  pull_request_target:
-#    paths:
-#      - '**.rsi/**.png'
+  pull_request_target:
+    paths:
+      - '**.rsi/**.png'
 
 jobs:
   diff:


### PR DESCRIPTION
I want the action back as it's handy for posters, mapping, clothing, and other changes. Allows us to view the textures right in the PR via bot comment.

We will have run failures due to access, most likely. Same as the tagger action had. But it's worth the fix, IMO.

