### PR TITLE
Cargo QoL: Add dropdown with list of crew members to order menu

### DIFF
--- a/Content.Client/Cargo/BUI/CargoOrderConsoleBoundUserInterface.cs
+++ b/Content.Client/Cargo/BUI/CargoOrderConsoleBoundUserInterface.cs
@@ -122,6 +122,7 @@ namespace Content.Client.Cargo.BUI
             AccountName = cState.Name;
 
             Populate(cState.Orders);
+            _orderMenu?.PopulateCrewList(cState.CrewManifest); // Harmony change for cargo orders QoL (Crew list)
             _menu?.UpdateCargoCapacity(OrderCount, OrderCapacity);
             _menu?.UpdateBankData(AccountName, BankBalance);
         }

--- a/Content.Client/Cargo/UI/CargoConsoleOrderMenu.xaml
+++ b/Content.Client/Cargo/UI/CargoConsoleOrderMenu.xaml
@@ -14,8 +14,16 @@
             <Label Name="PointCost"
                       Access="Public" />
             <Label Text="{Loc 'cargo-console-order-menu-requester-label'}" />
-            <LineEdit Name="Requester"
-                      Access="Public" />
+            <!--  Harmony change for cargo orders QoL (Crew list) -->
+            <BoxContainer Orientation="Horizontal">
+                <LineEdit Name="Requester"
+                        Access="Public"
+                        HorizontalExpand="True" />
+                <OptionButton Name="CrewList"
+                            Access="Public"
+                            HorizontalExpand="False" />
+            </BoxContainer>
+            <!--  End of Harmony code -->
             <Label Text="{Loc 'cargo-console-order-menu-reason-label'}" />
             <LineEdit Name="Reason"
                       Access="Public" />

--- a/Content.Client/Cargo/UI/CargoConsoleOrderMenu.xaml.cs
+++ b/Content.Client/Cargo/UI/CargoConsoleOrderMenu.xaml.cs
@@ -4,6 +4,7 @@ using Robust.Client.UserInterface.Controls;
 using Robust.Client.UserInterface.CustomControls;
 using Robust.Client.UserInterface.XAML;
 using Robust.Shared.IoC;
+using Content.Shared.CrewManifest;
 
 namespace Content.Client.Cargo.UI
 {
@@ -17,6 +18,43 @@ namespace Content.Client.Cargo.UI
 
             Amount.SetButtons(new List<int> { -3, -2, -1 }, new List<int> { 1, 2, 3 });
             Amount.IsValid = n => n > 0;
+            CrewList.OnItemSelected += OnCrewMemberSelected; // Harmony change for cargo orders QoL (Crew list)
+        }
+
+        /// <summary>
+        ///     Harmony change.
+        ///     Sets requester field to the name of a crewmember from OptionButton metadata.
+        /// </summary>
+        private void OnCrewMemberSelected(OptionButton.ItemSelectedEventArgs args)
+        {
+            if (args.Id == -1 || args.Id == -2)
+                return;
+
+            if (CrewList.GetItemMetadata(args.Id) is string name)
+                Requester.Text = name;
+        }
+
+        /// <summary>
+        ///     Harmony change.
+        ///     Populates the list of crew members in the requester dropdown menu.
+        /// </summary>
+        public void PopulateCrewList(CrewManifestEntries? crewManifest)
+        {
+            CrewList.Clear();
+            // Hacky negative IDs to have iterator aligned with crew manifest entries
+            CrewList.AddItem(Loc.GetString("cargo-console-order-menu-crewlist-label"), -1);
+            if (crewManifest == null)
+            {
+                CrewList.AddItem(Loc.GetString("cargo-console-order-menu-crewlist-nodata-label"), -2);
+                return;
+            }
+            for (var i = 0; i < crewManifest.Entries.Length; i++)
+            {
+                var crewMember = crewManifest.Entries[i];
+                CrewList.AddItem($"{crewMember.Name} ({crewMember.JobTitle})", i);
+                CrewList.SetItemMetadata(i, crewMember.Name);
+            }
+            CrewList.SelectId(-1);
         }
     }
 }

--- a/Content.Server/Cargo/Systems/CargoSystem.Orders.cs
+++ b/Content.Server/Cargo/Systems/CargoSystem.Orders.cs
@@ -15,12 +15,14 @@ using Content.Shared.Paper;
 using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
+using Content.Server.CrewManifest;
 
 namespace Content.Server.Cargo.Systems
 {
     public sealed partial class CargoSystem
     {
         [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
+        [Dependency] private readonly CrewManifestSystem _crewManifest = default!;
 
         /// <summary>
         /// How much time to wait (in seconds) before increasing bank accounts balance.
@@ -336,12 +338,15 @@ namespace Content.Server.Cargo.Systems
 
             if (_uiSystem.HasUi(consoleUid, CargoConsoleUiKey.Orders))
             {
+                // Harmony change -- crewManifest added for cargo orders QoL (Crew list)
+                var (_, crewManifest) = _crewManifest.GetCrewManifest(station.Value);
                 _uiSystem.SetUiState(consoleUid, CargoConsoleUiKey.Orders, new CargoConsoleInterfaceState(
                     MetaData(station.Value).EntityName,
                     GetOutstandingOrderCount(orderDatabase),
                     orderDatabase.Capacity,
                     bankAccount.Balance,
-                    orderDatabase.Orders
+                    orderDatabase.Orders,
+                    crewManifest
                 ));
             }
         }

--- a/Content.Shared/Cargo/BUI/CargoConsoleInterfaceState.cs
+++ b/Content.Shared/Cargo/BUI/CargoConsoleInterfaceState.cs
@@ -1,4 +1,5 @@
 using Robust.Shared.Serialization;
+using Content.Shared.CrewManifest;
 
 namespace Content.Shared.Cargo.BUI;
 
@@ -10,13 +11,16 @@ public sealed class CargoConsoleInterfaceState : BoundUserInterfaceState
     public int Capacity;
     public int Balance;
     public List<CargoOrderData> Orders;
+    public CrewManifestEntries? CrewManifest;
 
-    public CargoConsoleInterfaceState(string name, int count, int capacity, int balance, List<CargoOrderData> orders)
+    // Harmony change -- crewManifest added for cargo orders QoL (Crew list)
+    public CargoConsoleInterfaceState(string name, int count, int capacity, int balance, List<CargoOrderData> orders, CrewManifestEntries? crewManifest)
     {
         Name = name;
         Count = count;
         Capacity = capacity;
         Balance = balance;
         Orders = orders;
+        CrewManifest = crewManifest;
     }
 }

--- a/Resources/Locale/en-US/_Harmony/cargo/cargo-console-order-component.ftl
+++ b/Resources/Locale/en-US/_Harmony/cargo/cargo-console-order-component.ftl
@@ -1,0 +1,4 @@
+## UI
+
+cargo-console-order-menu-crewlist-label = Crew
+cargo-console-order-menu-crewlist-nodata-label = No Crew Data


### PR DESCRIPTION
## About the PR
Adds a crew list `OptionButton` to the Cargo console Order menu.

## Why / Balance
This allows to quickly fill out the `Name` field of the order. See the attached video.
If the requester name is too long or too complicated, or they left and you forgot their name while common going crazy -- it's easy to forget or type in the wrong name.
Usually, cargo techs default to their name in this field in these cases (at least I do) or even in all cases.

This QoL feature should make selecting the requesters much easier and will make the blue order slips mostly perfect for the paperwork nerds.
It might also provide an opportunity for spotting the people that are not on the manifest, if this is important for the round.

Vanilla functionality is unchanged. You can still type in anything in this field, if you want to.

## Technical details
- `Content.Shared/Cargo/BUI/CargoConsoleInterfaceState.cs`
    * `crewManifest` added to the state and its constructor
- `Content.Server/Cargo/Systems/CargoSystem.Orders.cs`
   * `UpdateOrderState()` is the updater of the `CargoConsoleInterfaceState`. Now fetches the crew manifest with `CrewManifestSystem.GetCrewManifest()` and constructs the state with it.
- `Content.Client/Cargo/BUI/CargoOrderConsoleBoundUserInterface.cs`
    * Console BUI. Now calls for `PopulateCrewList()` method of `CargoConsoleOrderMenu.xaml.cs` and passes the crew manifest entries to it.
- `Content.Client/Cargo/UI/CargoConsoleOrderMenu.xaml`
    * XAML for the Order menu. Added the `OptionButton`.
- `Content.Client/Cargo/UI/CargoConsoleOrderMenu.xaml.cs`
    * Controller for the Order menu. Now has `PopulateCrewList()` method to populate the list and `OnCrewMemberSelected()` handler for when the item in the list is selected.
- `Resources/Locale/en-US/_Harmony/cargo/cargo-console-order-component.ftl`
    * Loc strings.

## Media
https://github.com/user-attachments/assets/65983367-3555-49e8-b9a3-e3c1227978de

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
:cl:
- add: Added a crew manifest dropdown to the Cargo console Order menu. Paperwork mains sould have an easier time having their shipments in order. 
