### PR TITLE
Sort the crew members in the cargo order crew dropdown by name

### DIFF
--- a/Content.Client/Cargo/UI/CargoConsoleOrderMenu.xaml.cs
+++ b/Content.Client/Cargo/UI/CargoConsoleOrderMenu.xaml.cs
@@ -5,6 +5,7 @@ using Robust.Client.UserInterface.CustomControls;
 using Robust.Client.UserInterface.XAML;
 using Robust.Shared.IoC;
 using Content.Shared.CrewManifest;
+using System.Linq;
 
 namespace Content.Client.Cargo.UI
 {
@@ -48,6 +49,13 @@ namespace Content.Client.Cargo.UI
                 CrewList.AddItem(Loc.GetString("cargo-console-order-menu-crewlist-nodata-label"), -2);
                 return;
             }
+
+            // Sort crewManifest by entry name
+            crewManifest.Entries = crewManifest.Entries
+                .OrderBy(entry => entry.Name)
+                .ToArray();
+
+            // Populate the OptionButton
             for (var i = 0; i < crewManifest.Entries.Length; i++)
             {
                 var crewMember = crewManifest.Entries[i];


### PR DESCRIPTION
## About the PR
Addition to #157 -- crew member list in the dropdown is now sorted alphabetically.

## Why / Balance
After testing this, alphabetical order seems to be more usable than by department order.

## Technical details
Added simple sorting with linq.

## Media
![image](https://github.com/user-attachments/assets/0cecdbf2-5fa3-46f3-810f-6c99a902f1d2)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
:cl:
- tweak: Crew member list in cargo order menu is now sorted by name.
