### PR TITLE
Add CVar to disable suicide command and ghost instead

### DIFF
--- a/Content.Shared/_Harmony/CCVars/HCCVars.cs
+++ b/Content.Shared/_Harmony/CCVars/HCCVars.cs
@@ -14,4 +14,10 @@ public sealed class HCCVars
     /// </summary>
     public static readonly CVarDef<bool> RoundEndPacifist =
         CVarDef.Create("game.round_end_pacifist", false, CVar.SERVERONLY);
+
+    /// <summary>
+    /// Modifies suicide command to ghost without killing the entity.
+    /// </summary>
+    public static readonly CVarDef<bool> DisableSuicide =
+        CVarDef.Create("ic.disable_suicide", false, CVar.SERVER);
 }


### PR DESCRIPTION
## About the PR
Adds a `ic.disable_suicide` server CVar.
When `false` (default) -- no change.
When `true` -- ghosts but leaves the entity alive and SSD.

## Why / Balance
Admins wanted it.
> There aren't really a lot of scenarios (if any) where doing it wouldn't be a rulebreak and it would solve some issues if it was disabled. Keeping /ghost is fine since it keeps you alive, along with mechanical suicide methods.
~ Spanky

## Technical details
- `Content.Shared/_Harmony/CCVars/HCCVars.cs` -- new CVar
- `Content.Server/Chat/SuicideSystem.cs` -- subs to CVar, sets a boolean, nopes out without error at appropriate moment if set (before the suicide event raised, but after ghost event is raised)

## Media
https://github.com/user-attachments/assets/d9bc2b81-2af5-443d-b5d1-e3901c6df668

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

**Changelog**
:cl:
- tweak: Suicide console command is now disabled on Harmony. It will just ghost you instead.
