### PR TITLE
Unhide breathing mask loadout groups

### DIFF
--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -953,7 +953,7 @@
   - HeadofSecurityHead
   - HeadofSecurityBeret
   - HoSWidebrimHarmony # Harmony
-  
+
 - type: loadoutGroup
   id: HeadofSecurityJumpsuit
   name: loadout-group-head-of-security-jumpsuit
@@ -1350,7 +1350,7 @@
   name: loadout-group-breath-tool
   minLimit: 1
   maxLimit: 1
-  hidden: true
+  hidden: false # Harmony change for various Vox masks
   loadouts:
   - LoadoutSpeciesBreathTool
 
@@ -1359,7 +1359,7 @@
   name: loadout-group-breath-tool
   minLimit: 1
   maxLimit: 1
-  hidden: true
+  hidden: false # Harmony change for various Vox masks
   loadouts:
   - LoadoutSpeciesBreathToolMedical
 
@@ -1368,6 +1368,6 @@
   name: loadout-group-breath-tool
   minLimit: 1
   maxLimit: 1
-  hidden: true
+  hidden: false # Harmony change for various Vox masks
   loadouts:
   - LoadoutSpeciesBreathToolSecurity


### PR DESCRIPTION
## About the PR
Unhide the loadout groups for breathing tools (generic, medical, sec)

## Why / Balance
Jack is cooking very pretty Vox masks that allow you to eat.

## Technical details
Boolean switch in three protos.

## Media
![image](https://github.com/user-attachments/assets/75f8d943-087f-4cec-be57-5548deb03034)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
NA

**Changelog**
No need. Explanation should be on the first mask PR.
