### PR TITLE
Recycler EMAG Rework

### DIFF
--- a/Content.Server/Materials/MaterialReclaimerSystem.cs
+++ b/Content.Server/Materials/MaterialReclaimerSystem.cs
@@ -186,7 +186,7 @@ public sealed class MaterialReclaimerSystem : SharedMaterialReclaimerSystem
 
         SpawnMaterialsFromComposition(uid, item, completion * component.Efficiency, xform: xform);
 
-        if (CanGib(uid, item, component))
+        if (CanRecycleMob(uid, item, component))
         {
             // Harmony - Recycler now deals damage instead of gibbing.
             if (component.Damage == null)

--- a/Content.Server/Materials/MaterialReclaimerSystem.cs
+++ b/Content.Server/Materials/MaterialReclaimerSystem.cs
@@ -189,6 +189,9 @@ public sealed class MaterialReclaimerSystem : SharedMaterialReclaimerSystem
         if (CanGib(uid, item, component))
         {
             // Harmony - Recycler now deals damage instead of gibbing.
+            if (component.Damage == null)
+                return;
+
             _damageable.TryChangeDamage(item, component.Damage, true);
             _adminLogger.Add(LogType.Damaged, LogImpact.Medium, $"{ToPrettyString(item):victim} was recycled by {ToPrettyString(uid):entity}, dealing {component.Damage.GetTotal()} damage.");
             _appearance.SetData(uid, RecyclerVisuals.Bloody, true);

--- a/Content.Shared/Materials/MaterialReclaimerComponent.cs
+++ b/Content.Shared/Materials/MaterialReclaimerComponent.cs
@@ -130,7 +130,7 @@ public sealed partial class MaterialReclaimerComponent : Component
     /// <summary>
     /// The damage the recycler will deal to creatures.
     /// </summary>
-    public DamageSpecifier Damage = default!;
+    public DamageSpecifier? Damage = default!;
 }
 
 [NetSerializable, Serializable]

--- a/Content.Shared/Materials/MaterialReclaimerComponent.cs
+++ b/Content.Shared/Materials/MaterialReclaimerComponent.cs
@@ -1,4 +1,5 @@
-﻿using Content.Shared.Whitelist;
+﻿using Content.Shared.Damage;
+using Content.Shared.Whitelist;
 using JetBrains.Annotations;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
@@ -123,6 +124,13 @@ public sealed partial class MaterialReclaimerComponent : Component
     /// </remarks>
     [DataField, AutoNetworkedField]
     public int ItemsProcessed;
+
+    [DataField]
+
+    /// <summary>
+    /// The damage the recycler will deal to creatures.
+    /// </summary>
+    public DamageSpecifier Damage = default!;
 }
 
 [NetSerializable, Serializable]

--- a/Content.Shared/Materials/SharedMaterialReclaimerSystem.cs
+++ b/Content.Shared/Materials/SharedMaterialReclaimerSystem.cs
@@ -148,7 +148,7 @@ public abstract class SharedMaterialReclaimerSystem : EntitySystem
 
     /// <summary>
     /// Spawns the materials and chemicals associated
-    /// with an entity. Also deletes the item.
+    /// with an entity. Also deletes the item if it is not a mob.
     /// </summary>
     public virtual void Reclaim(EntityUid uid,
         EntityUid item,
@@ -200,6 +200,7 @@ public abstract class SharedMaterialReclaimerSystem : EntitySystem
     /// <summary>
     /// Whether or not the reclaimer satisfies the conditions
     /// allowing it to gib/reclaim a living creature.
+    /// Harmony - The recycler can no longer gib living creatures, instead dealing significant brute damage.
     /// </summary>
     public bool CanGib(EntityUid uid, EntityUid victim, MaterialReclaimerComponent component)
     {

--- a/Content.Shared/Materials/SharedMaterialReclaimerSystem.cs
+++ b/Content.Shared/Materials/SharedMaterialReclaimerSystem.cs
@@ -88,7 +88,7 @@ public abstract class SharedMaterialReclaimerSystem : EntitySystem
         if (!CanStart(uid, component))
             return false;
 
-        if (HasComp<MobStateComponent>(item) && !CanGib(uid, item, component)) // whitelist? We be gibbing, boy!
+        if (HasComp<MobStateComponent>(item) && !CanRecycleMob(uid, item, component)) // whitelist? We be gibbing, boy!
             return false;
 
         if (_whitelistSystem.IsWhitelistFail(component.Whitelist, item) ||
@@ -199,10 +199,10 @@ public abstract class SharedMaterialReclaimerSystem : EntitySystem
 
     /// <summary>
     /// Whether or not the reclaimer satisfies the conditions
-    /// allowing it to gib/reclaim a living creature.
+    /// allowing it to reclaim a living creature.
     /// Harmony - The recycler can no longer gib living creatures, instead dealing significant brute damage.
     /// </summary>
-    public bool CanGib(EntityUid uid, EntityUid victim, MaterialReclaimerComponent component)
+    public bool CanRecycleMob(EntityUid uid, EntityUid victim, MaterialReclaimerComponent component)
     {
         return component.Powered &&
                component.Enabled &&

--- a/Resources/Prototypes/Entities/Structures/Machines/recycler.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/recycler.yml
@@ -86,8 +86,8 @@
     cutOffSound: false
     damage: # Harmony
       types:
-        Slash: 15
-        Piercing: 15
+        Slash: 25
+        Piercing: 25
   - type: MaterialStorage
     insertOnInteract: false
   - type: Conveyor

--- a/Resources/Prototypes/Entities/Structures/Machines/recycler.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/recycler.yml
@@ -84,6 +84,10 @@
       params:
         volume: -3
     cutOffSound: false
+    damage: # Harmony
+      types:
+        Slash: 15
+        Piercing: 15
   - type: MaterialStorage
     insertOnInteract: false
   - type: Conveyor


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
The recycler now deals 30 (60) damage instead of gibbing you when emagged

## Why / Balance
Rules become mechanics.
Emags are incredibly common items which have so many uses it's almost kneecapping yourself NOT to buy one. Since it's one click to make the recycler into a killing machine, it results in many people being gibbed, which is against server rules.
This retains the danger of the recycler and still allows you to make it into a death trap (with more effort), but avoids situations where people would emag the recycler just because (tm) and RR 3 people

## Technical details
Calls TryChangeDamage instead of doing a whole bunch of gibbing stuff. Added a new property to the Recycler component to control the damage output
Logs and comments updated to reflect the change.
Currently the recycler grinds every entities (even items) twice in quick succession, so mobs get dealt the damage twice too. Fixing this is outside of what this PR is trying to accomplish, though.

## Media
https://github.com/user-attachments/assets/7b4cc715-22ed-4ade-bbc1-3d6ef619efe1


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: Jajsha
- tweak: The emagged recycler now deals massive brute damage instead of instantly gibbing players.