### PR TITLE
Port Illeism trait

### DIFF
--- a/Content.Server/_Harmony/Speech/Components/IlleismAccentComponent.cs
+++ b/Content.Server/_Harmony/Speech/Components/IlleismAccentComponent.cs
@@ -1,0 +1,8 @@
+using Content.Server.Speech.EntitySystems;
+
+namespace Content.Server.Speech.Components;
+
+[RegisterComponent]
+[Access(typeof(IlleismAccentSystem))]
+public sealed partial class IlleismAccentComponent : Component
+{ }

--- a/Content.Server/_Harmony/Speech/EntitySystems/IlleismAccentSystem.cs
+++ b/Content.Server/_Harmony/Speech/EntitySystems/IlleismAccentSystem.cs
@@ -1,0 +1,122 @@
+using System.Text.RegularExpressions;
+using System.Text;
+using Content.Server.Speech.Components;
+
+namespace Content.Server.Speech.EntitySystems;
+
+public sealed class IlleismAccentSystem : EntitySystem
+{
+    // I am going to Sec -> NAME is going to Sec
+    private static readonly Regex RegexIAmUpper = new(@"\bI\s*AM\b|\bI'?M\b");
+    private static readonly Regex RegexIAmLower = new(@"\bi\s*am\b|\bI'?m\b", RegexOptions.IgnoreCase);
+
+    // I have it -> NAME has it
+    private static readonly Regex RegexIHaveUpper = new(@"\bI\s*HAVE\b|\bI'?VE\b");
+    private static readonly Regex RegexIHaveLower = new(@"\bi\s*have\b|\bI'?ve\b", RegexOptions.IgnoreCase);
+
+    // I do! -> NAME does!
+    private static readonly Regex RegexIDoUpper = new(@"\bI\s*DO\b");
+    private static readonly Regex RegexIDoLower = new(@"\bi\s*do\b", RegexOptions.IgnoreCase);
+
+    // I don't! -> NAME doesn't!
+    private static readonly Regex RegexIDontUpper = new(@"\bI\s+DON'?T\b");
+    private static readonly Regex RegexIDontLower = new(@"\bi\s+don'?t\b", RegexOptions.IgnoreCase);
+
+    // I/Myself -> NAME
+    private static readonly Regex RegexMyselfUpper = new(@"\bMYSELF\b");
+    private static readonly Regex RegexI = new(@"\bI\b|\bmyself\b", RegexOptions.IgnoreCase);
+
+    // Me -> NAME
+    private static readonly Regex RegexMeUpper = new(@"\bME\b");
+    private static readonly Regex RegexMeLower = new(@"\bme\b", RegexOptions.IgnoreCase);
+
+    // My crowbar -> NAME's crowbar
+    // That's mine! -> That's NAME's
+    private static readonly Regex RegexMyUpper = new(@"\bMY\b|\bMINE\b");
+    private static readonly Regex RegexMyLower = new(@"\bmy\b|\bmine\b", RegexOptions.IgnoreCase);
+
+    // I'll do it -> NAME'll do it
+    private static readonly Regex RegexIllUpper = new(@"\bI'LL\b");
+    private static readonly Regex RegexIllLower = new(@"\bi'll\b", RegexOptions.IgnoreCase);
+
+
+    [Dependency] private readonly ReplacementAccentSystem _replacement = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<IlleismAccentComponent, AccentGetEvent>(OnAccent);
+    }
+
+    private bool MostlyUppercase(string message)
+    {
+        int totalLetters = 0;
+        int uppercaseLetters = 0;
+
+        // Iterate through each character in the string
+        foreach (char c in message)
+        {
+            if (char.IsLetter(c)) // Check if the character is a letter
+            {
+                totalLetters++;
+                if (char.IsUpper(c)) // Check if the letter is uppercase
+                {
+                    uppercaseLetters++;
+                }
+            }
+        }
+        if (totalLetters < 2)
+        {
+            return false;
+        }
+        return uppercaseLetters > totalLetters / 2;
+    }
+
+    private void OnAccent(EntityUid uid, IlleismAccentComponent component, AccentGetEvent args)
+    {
+        var message = args.Message;
+        var name = Name(uid).Split(' ')[0];
+        var upperName = name.ToUpper();
+
+        // I am going to Sec -> NAME is going to Sec
+        message = RegexIAmUpper.Replace(message, upperName + " IS");
+        message = RegexIAmLower.Replace(message, name + " is");
+
+        // I have it -> NAME has it
+        message = RegexIHaveUpper.Replace(message, upperName + " HAS");
+        message = RegexIHaveLower.Replace(message, name + " has");
+
+        // I do! -> NAME does!
+        message = RegexIDoUpper.Replace(message, upperName + " DOES");
+        message = RegexIDoLower.Replace(message, name + " does");
+
+        // I don't! -> NAME doesn't!
+        message = RegexIDontUpper.Replace(message, upperName + " DOESN'T");
+        message = RegexIDontLower.Replace(message, name + " doesn't");
+
+		// I'll do it -> NAME will do it
+        message = RegexIllUpper.Replace(message, upperName + " WILL");
+        message = RegexIllLower.Replace(message, name + " will");
+
+        // I/myself -> NAME
+        message = RegexMyselfUpper.Replace(message, upperName);
+        if (MostlyUppercase(message))
+        {
+            message = RegexI.Replace(message, upperName);
+        }
+        else
+        {
+            message = RegexI.Replace(message, name);
+        }
+
+        // Me -> NAME
+        message = RegexMeUpper.Replace(message, upperName);
+        message = RegexMeLower.Replace(message, name);
+
+        // My crowbar -> NAME's crowbar
+        message = RegexMyUpper.Replace(message, upperName + "'S");
+        message = RegexMyLower.Replace(message, name + "'s");
+
+        args.Message = message;
+    }
+};

--- a/Resources/Locale/en-US/_Harmony/traits/traits.ftl
+++ b/Resources/Locale/en-US/_Harmony/traits/traits.ftl
@@ -48,3 +48,6 @@ trait-voxvocals-desc = You are somehow able to fully mimic Vox speech. (Replace 
 
 trait-hypophonia-name = Hypophonia
 trait-hypophonia-desc = You can only whisper.
+
+trait-illeism-name = Illeism
+trait-illeism-desc = You seem to only be able to refer to yourself by name.

--- a/Resources/Prototypes/_Harmony/Traits/speech.yml
+++ b/Resources/Prototypes/_Harmony/Traits/speech.yml
@@ -95,6 +95,15 @@
       speechVerb: Vox
       speechSounds: Vox
 
+- type: trait
+  id: HarmonyIlleism
+  name: trait-illeism-name
+  description: trait-illeism-desc
+  category: SpeechTraits
+  cost: 1
+  components:
+  - type: IlleismAccent
+
 # Full speech and vocal replacement traits
 - type: trait
   id: HarmonyArachnidVocals


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added a new speech trait, "**illeism**", IE: referring to yourself in third person.
This is a port of my WizDen PR that I do not believe will be merged.
Please see [my WizDen PR](https://github.com/space-wizards/space-station-14/pull/32643) for the comments, reviews, and optimizations that have been discussed and implemented.

## Why / Balance
This added trait makes roleplaying as an illeist much easier, automatically changing references of I, me, my, and some corresponding phrases, to their correct form, rather than having to do it manually. This saves time and makes roleplaying as an illeist much more appealing to a wider audience. Illeism is compatible with other speech traits, including racial speech patterns. 

## Technical details
This PR adds two new files, `IlleismAccentSystem.cs` & `IlleismAccentComponent.cs`, as well as modifies `traits.ftl` & `speech.yml`.

`IlleismAccentSystem.cs` includes the regex functions to search for and replace the correct phrases.
Some phrases include:
I am -> NAME is
I have -> NAME has
I do -> NAME does
I don't -> NAME doesn't
Me -> NAME
My/mine -> NAME's
I'll -> NAME will
_This includes fully capitalized versions_

I/myself -> NAME
_"I" is a special capitalization case, which is not shared by myself. As 'I' is automatically capitalized in the chat, my code can not tell if the user wants their name to be fully capitalized or not. This can result in phrases such as "I SAID" becoming "Name SAID". My code counteracts this by checking if over 50% of the sentence is capitalized, making it possible for 'I' to result in the name being fully capitalized in context._

`IlleismAccentComponent.cs` is the corresponding component.
`traits.ftl` was modified to include a trait name and description.
`speech.yml` was modified to include illeism as a selectable trait worth 1 speech point, as this trait is compatible with others.


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Added illeism as a selectable speech trait!