### PR TITLE
Remove rods gibbing you

### DIFF
--- a/Content.Server/ImmovableRod/ImmovableRodSystem.cs
+++ b/Content.Server/ImmovableRod/ImmovableRodSystem.cs
@@ -126,8 +126,7 @@ public sealed class ImmovableRodSystem : EntitySystem
             _bodySystem.GibBody(ent, body: body);
             return;
         }
-
-        QueueDel(ent);
+        else QueueDel(ent); //Harmony - Do not just... delete the entity no matter what. What da hell.
     }
 
     private void OnExamined(EntityUid uid, ImmovableRodComponent component, ExaminedEvent args)

--- a/Content.Server/ImmovableRod/ImmovableRodSystem.cs
+++ b/Content.Server/ImmovableRod/ImmovableRodSystem.cs
@@ -126,7 +126,8 @@ public sealed class ImmovableRodSystem : EntitySystem
             _bodySystem.GibBody(ent, body: body);
             return;
         }
-        else QueueDel(ent); //Harmony - Do not just... delete the entity no matter what. What da hell.
+
+        QueueDel(ent);
     }
 
     private void OnExamined(EntityUid uid, ImmovableRodComponent component, ExaminedEvent args)

--- a/Resources/Prototypes/Entities/Objects/Fun/immovable_rod.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/immovable_rod.yml
@@ -11,6 +11,10 @@
     state: icon
     noRot: false
   - type: ImmovableRod
+    shouldGib: false # Harmony
+    damage:
+      types:
+        Piercing: 400
   - type: Physics
     bodyType: Dynamic
     linearDamping: 0
@@ -69,10 +73,6 @@
     minSpeed: 35
     destroyTiles: false
     randomizeVelocity: false
-    shouldGib: false
-    damage:
-      types:
-        Blunt: 200
   - type: MovementIgnoreGravity
     gravityState: true
   - type: InputMover


### PR DESCRIPTION
## About the PR
Immovable rods now deal 400 pierce damage (ignoring resistances) instead of outright gibbing you.

## Why / Balance
Being round removed by random events outside of your control is not fun.

## Technical details
Fixed upstream bug where the rod would delete you outright instead of gibbing you.
Rest is just yaml.

**Changelog**
:cl: Jajsha
- tweak: Immovable rods now deal massive pierce damage instead of deleting you.