### PR TITLE
Minor balance changes to deathmatch PROMOD

### DIFF
--- a/Resources/Locale/en-US/_Harmony/game-ticking/game-presets/preset-deathmatchpromod.ftl
+++ b/Resources/Locale/en-US/_Harmony/game-ticking/game-presets/preset-deathmatchpromod.ftl
@@ -1,2 +1,2 @@
 death-match-promod-title = DeathMatch PROMOD
-death-match-promod-description = Shoot anything that moves! If it doesn't move, push it and then shoot. The first to 31 points wins!
+death-match-promod-description = Shoot anything that moves! If it doesn't move, push it and then shoot. The first to 16 points wins!

--- a/Resources/Prototypes/_Harmony/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Harmony/GameRules/roundstart.yml
@@ -4,8 +4,9 @@
   components:
   - type: DeathMatchRule
     gear: DeathMatchPROMODGear
-    killCap: 31
+    killCap: 16
     rewardSpawns:
+    - id: MagazinePistol # guaranteed drops
     - id: ClothingOuterArmorBasicSlim   # armor
       orGroup: loot
     - id: ClothingOuterArmorBasic
@@ -56,8 +57,6 @@
       orGroup: loot
     - id: GrenadeFlashBang              # grenades
       orGroup: loot
-    - id: WhiteholeGrenade
-      orGroup: loot
     - id: SmokeGrenade
       orGroup: loot
     - id: TearGasGrenade
@@ -94,4 +93,7 @@
     gloves: ClothingHandsGlovesFingerless
     back: ClothingBackpack
     pocket1: WeaponPistolMk58
-    pocket2: MagazinePistol
+  storage:
+    back:
+      - MagazinePistol
+      - MagazinePistol


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Minor balance changes for DMPM gamemode and DM01 Entryway

## Why / Balance
DMPM changes:
* changed starting loadout in PROMOD to have two spare mk58 magazines
* added guaranteed mk58 magazine drop to PROMOD loot table
* removed whitehole grenade from PROMOD loot table

DM01 Entryway changes:
* TBA

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: changed starting loadout in PROMOD to have two spare mk58 magazines
- tweak: added guaranteed mk58 magazine drop to PROMOD loot table
- tweak: removed whitehole grenade from PROMOD loot table