### PR TITLE
Medical fabricator update & whitelist tweaks

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Chemistry/chem_bag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Chemistry/chem_bag.yml
@@ -30,4 +30,5 @@
         - Bottle
         - Syringe
         - Dropper
+        - ChemDispensable #Harmony
   - type: Dumpable

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry-vials.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry-vials.yml
@@ -9,6 +9,7 @@
   - type: Tag
     tags:
     - Trash
+    - Bottle # Harmony
     - CentrifugeCompatible
   - type: PhysicalComposition
     materialComposition:

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -871,7 +871,7 @@
     staticRecipes:
       - Brutepack
       - Ointment
-      - BloodPack # Harmony
+      - Bloodpack # Harmony
       - Gauze
       - HandLabeler
       - Defibrillator

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -871,6 +871,7 @@
     staticRecipes:
       - Brutepack
       - Ointment
+      - BloodPack # Harmony
       - Gauze
       - HandLabeler
       - Defibrillator
@@ -888,6 +889,7 @@
       - PillCanister
       - BodyBag
       - ChemistryEmptyBottle01
+      - BaseChemistryEmptyVial # Harmony
       - RollerBedSpawnFolded
       - CheapRollerBedSpawnFolded
       - EmergencyRollerBedSpawnFolded
@@ -898,14 +900,17 @@
       - MedkitBrute
       - MedkitAdvanced
       - MedkitRadiation
-      - MedkitCombat
+      # - MedkitCombat -- Harmony
       - Scalpel
       - Retractor
       - Cautery
       - Drill
       - Saw
       - Hemostat
+      - CircularSaw # Harmony
       - ClothingEyesGlassesChemical
+      - ClothingEyesHudMedical # Harmony
+      - ClothingEyesEyepatchHudMedical # Harmony
       - WhiteCane
     dynamicRecipes:
       - ChemicalPayload

--- a/Resources/Prototypes/_Harmony/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/_Harmony/Entities/Objects/Specific/Medical/healing.yml
@@ -1,0 +1,8 @@
+- type: entity
+  id: Bloodpack1
+  parent: Bloodpack
+  suffix: Single
+  components:
+  - type: Stack
+    stackType: Bloodpack
+    count: 1

--- a/Resources/Prototypes/_Harmony/Recipes/Lathes/medical.yml
+++ b/Resources/Prototypes/_Harmony/Recipes/Lathes/medical.yml
@@ -1,0 +1,37 @@
+- type: latheRecipe
+  id: BaseChemistryEmptyVial
+  result: BaseChemistryEmptyVial
+  completetime: 2
+  materials:
+    Glass: 50
+
+- type: latheRecipe
+  id: Bloodpack
+  result: Bloodpack1
+  completetime: 1
+  materials:
+    Steel: 25
+    Plastic: 25
+
+- type: latheRecipe
+  parent: BaseSurgicalRecipe
+  id: CircularSaw
+  result: SawElectric
+
+- type: latheRecipe
+  id: ClothingEyesHudMedical
+  result: ClothingEyesHudMedical
+  completetime: 2
+  materials:
+    Steel: 200
+    Plastic: 300
+    Glass: 500
+
+- type: latheRecipe
+  id: ClothingEyesEyepatchHudMedical
+  result: ClothingEyesEyepatchHudMedical
+  completetime: 2
+  materials:
+    Steel: 200
+    Plastic: 300
+    Glass: 500


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added Blood packs, Vials, Circular saws and Medical HUDs to the medfab inventory
Removed combat medikits from the medfab inventory
Allowed vials to be inserted in various medical containers, like bottles (Chemistry shelves, Medical belt)
Allowed jugs to be inserted into chemistry bags.

## Why / Balance
Consistency is good. 
Recipes were most likely forgotten about over time. For instance, there is no reason for vials to not be obtainable in the same way as bottles, and for them not to be insertable in belts while bottles are.
Advanced medikits are a 2x4 inventory which takes 2x2 room, leading to situations where people fill their inventory with nested storage. Besides, it's an uplink item and should be special.
Chemistry bags being able to fit everything chemistry related BUT jugs, which would be the most useful, feels like an oversight.

## Technical details
Just YAML
This is 100% untested. I expect this to fail, but the computer I am working on is a potato and I want this there so I can add to it later on on a better PC.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl: Jajsha
- tweak: Modified medical fabricator inventory.
- tweak: Jugs now fit in chemistry bags.
- fix: Vials now fit in medical related containers.
