### PR TITLE
Lower max nukie count to 4

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -136,7 +136,7 @@
     - prefRoles: [ Nukeops ]
       fallbackRoles: [ NukeopsCommander, NukeopsMedic ]
       spawnerPrototype: SpawnPointNukeopsOperative
-      max: 3
+      max: 2
       playerRatio: 10
       startingGear: SyndicateOperativeGearFull
       roleLoadout:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Made max nukie count 4 instead of 5

## Why / Balance
Putting this up as an option, following admin discussion and community feedback. This is not final. This might not get merged. Only time will tell.
Once again, 100% untested :) Will test once I am on a more stable PC

**Changelog**
:cl: Jajsha
- tweak: Lowered nukie max count to 4
