### PR TITLE
Security hardsuit rebalance.

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -251,7 +251,7 @@
 - type: entity
   parent: [ClothingOuterHardsuitBase, BaseRestrictedContraband]
   id: ClothingOuterHardsuitWarden
-  name: warden's tanksuit
+  name: warden's hardsuit
   description: The Warden's suit. Built like a tank.
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -210,10 +210,12 @@
         Blunt: 0.6
         Slash: 0.6
         Piercing: 0.6
+        Heat: 0.7
+        Radiation: 0.7
         Caustic: 0.7
   - type: ClothingSpeedModifier
-    walkModifier: 0.75
-    sprintModifier: 0.75
+    walkModifier: 0.85
+    sprintModifier: 0.85
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSecurity
@@ -249,8 +251,8 @@
 - type: entity
   parent: [ClothingOuterHardsuitBase, BaseRestrictedContraband]
   id: ClothingOuterHardsuitWarden
-  name: warden's hardsuit
-  description: A specialized riot suit geared to combat low pressure environments.
+  name: warden's tanksuit
+  description: The Warden's suit. Built like a tank.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/security-warden.rsi
@@ -260,17 +262,19 @@
     highPressureMultiplier: 0.5
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
-    damageCoefficient: 0.4
+    damageCoefficient: 0.35
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.5
-        Slash: 0.6
-        Piercing: 0.6
+        Blunt: 0.35
+        Slash: 0.35
+        Piercing: 0.35
+        Radiation: 0.7
+        Heat: 0.35
         Caustic: 0.7
   - type: ClothingSpeedModifier
-    walkModifier: 0.7
-    sprintModifier: 0.7
+    walkModifier: 0.65
+    sprintModifier: 0.65
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitWarden
@@ -414,8 +418,8 @@
 - type: entity
   parent: [ClothingOuterHardsuitBase, BaseCommandContraband]
   id: ClothingOuterHardsuitSecurityRed
-  name: head of security's hardsuit
-  description: A special suit that protects against hazardous, low pressure environments. Has an additional layer of armor.
+  name: head of security's assault suit
+  description: A huge, looming, armored space suit. The biggest and the baddest.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/security-red.rsi
@@ -425,18 +429,19 @@
     highPressureMultiplier: 0.45
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
-    damageCoefficient: 0.6
+    damageCoefficient: 0.4
   - type: Armor
     modifiers:
       coefficients:
         Blunt: 0.6
         Slash: 0.5
         Piercing: 0.5
-        Radiation: 0.5
-        Caustic: 0.6
+        Heat: 0.6
+        Radiation: 0.7
+        Caustic: 0.7
   - type: ClothingSpeedModifier
-    walkModifier: 0.8
-    sprintModifier: 0.8
+    walkModifier: 0.85
+    sprintModifier: 0.85
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSecurityRed


### PR DESCRIPTION

## About the PR
This PR exists to rebalance the security gear and make it more viable against station threats. 

## Why / Balance
Security space gear is universally regarded as completely terrible and inadequate to handle any of the threats that the station faces on a per round basis. Heat resistance is important for any battle with space dragons, against lasers, eswords, and any of the other heat and fire based threats that security is likely to face. Radiation resistance is because random space suits like the paramedic's voidsuit have 15% resistance to radiation, and it wouldn't feel very consistent for an ultralight paramedic suit to have rad resistance but not the station's dedicated security team. My anecdotal evidence for this working and not causing majorly balance issues is DeltaV, where many of these stat changes were long ago implemented and it works.

## Technical details
Warden's spacesuit now fits the role of a crew version of the juggernaut. It has 65% resistance to most things, now including heat damage, and has been slowed down further to a 35% movement penalty. This suit is also pending a rename and resprite to better reflect this aesthetically, something about tanks or defense or whatever.

Head of Security's space suit has been given a 40% resistance heat, the explosion resistance has been raised to 60% to be in line with the regular officer hardsuit, and the movement has been increased to only a 15% penalty. It has been renamed to "Head of Security's Assault Suit" to reflect this speed increase, and eventual resprite.

Security hardsuits have been given 30% resistance to heat. up from the previous 0%, along with being twice as fast with only a 15% movement penalty. 

All of these suits now have a 30% resistance to radiation. 

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- tweak: Rebalanced security's void cop gear.
-->
