### PR TITLE
Adjust Gamemode Weight (Reduce Nukies + Add Extended)

### DIFF
--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -1,10 +1,11 @@
 - type: weightedRandom
   id: Secret
   weights:
-    Nukeops: 0.20
-    Traitor: 0.60
+# Harmony Changes
+    Traitor: 0.65
+    Nukeops: 0.13
+    Survival: 0.08
+    Extended: 0.08
     Zombie: 0.04
-    Zombieteors: 0.02
-    Survival: 0.13
     KesslerSyndrome: 0.01
-#    Revolutionary: 0.05
+    Zombieteors: 0.01


### PR DESCRIPTION
## About the PR
Adjusts secret game mode weights after community/admin discussion. Primarily reduces Nukeops chance to 13% (from 20%) and adds Extended as an option at 8%. Also increases Traitor by 5% (now 65%), reduces survival by 1% (now 8%) and reduces Zombieteors by 1% (now 1%). List also organized by weight instead of arbitrary. Revolutionaries are still disabled.

## Technical details
New Weights:
- Traitor: 0.65
- Nukeops: 0.13
- Survival: 0.08
- Extended: 0.08
- Zombie: 0.04
- KesslerSyndrome: 0.01
- Zombieteors: 0.01

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Nukeops game mode chance has been reduced and Extended has been added.