### PR TITLE
Adding more ways to obtain rubber duckies

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/fun.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/fun.yml
@@ -324,6 +324,8 @@
       - id: PlasticBanana
       - id: WhoopieCushion
       - id: ToyHammer
+      - id: ToyRubberDuck
+        amount: 2
       - id: MrChips
         orGroup: GiftPool
       - id: MrDips

--- a/Resources/Prototypes/Catalog/Fills/Crates/service.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/service.yml
@@ -20,6 +20,7 @@
       - id: Plunger
         amount: 2
       - id: BoxCleanerGrenades
+      - id: ToyRubberDuck
 
 - type: entity
   id: CrateServiceReplacementLights

--- a/Resources/Prototypes/_Harmony/Catalog/Fills/Items/toolboxes.yml
+++ b/Resources/Prototypes/_Harmony/Catalog/Fills/Items/toolboxes.yml
@@ -6,8 +6,6 @@
   components:
   - type: StorageFill
     contents:
-      - id: ToyRubberDuck
-        amount: 2
       - id: Screwdriver
       - id: Wrench
       - id: NetworkConfigurator

--- a/Resources/Prototypes/_Harmony/Catalog/Fills/Items/toolboxes.yml
+++ b/Resources/Prototypes/_Harmony/Catalog/Fills/Items/toolboxes.yml
@@ -6,6 +6,8 @@
   components:
   - type: StorageFill
     contents:
+      - id: ToyRubberDuck
+        amount: 2
       - id: Screwdriver
       - id: Wrench
       - id: NetworkConfigurator


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added more ways to obtain rubber duckies

## Why / Balance
The lack of rubber duckies in space station 14 has been a disheartening sorrow of mine for too long. In my profound wisdom I am pushing this PR so that we can make space station 14 great again. 

## Technical details
More stuff in catalog and crates
## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None 👍 

**Changelog**
:cl:
- add: Added more ways to obtain rubber duckies. Ducks are now included in toy box and janitorial supplies crate cargo purchases
