### PR TITLE
Prison Wardrobe Tweaks

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/wardrobe_job.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/wardrobe_job.yml
@@ -13,9 +13,9 @@
        - id: ClothingShoesColorBlack
          amount: 2
        - id: ClothingMaskMuzzle
-       - id: ClothingOuterVestTank
+       - id: ClothingOuterVestTank # Harmony. Required for Vox by space law
          amount: 2
-       - id: ClothingHeadsetGrey
+       - id: ClothingHeadsetGrey # Harmony. Required by space law
          amount: 2
 
 #- type: entity

--- a/Resources/Prototypes/Catalog/Fills/Lockers/wardrobe_job.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/wardrobe_job.yml
@@ -13,6 +13,10 @@
        - id: ClothingShoesColorBlack
          amount: 2
        - id: ClothingMaskMuzzle
+       - id: ClothingOuterVestTank
+         amount: 2
+       - id: ClothingHeadsetGrey
+         amount: 2
 
 #- type: entity
 #  id: WardrobePajamaFilled


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds Vox tank harnesses and passenger headsets to prisoner wardrobes. Vox need a way to hold tanks more comfortably, prisoners have a right to communications. 

## Why / Balance
Space law

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Prisoner wardrobes now contain tank harnesses and passenger headsets. 

