### PR TITLE
CC Gear Presets

### DIFF
--- a/Resources/Prototypes/_Harmony/Roles/Jobs/CentComm/official.yml
+++ b/Resources/Prototypes/_Harmony/Roles/Jobs/CentComm/official.yml
@@ -1,7 +1,7 @@
 # Harmony CC character presets
 
 - type: startingGear
-  id: HarmonyCentcomOfficialGear
+  id: CentcomOfficialGearHarmony
   equipment:
     jumpsuit: ClothingUniformJumpsuitCentcomFormal
     back: ClothingBackpackSatchelLeather
@@ -19,7 +19,7 @@
     - MindShieldImplanter
 
 - type: startingGear
-  id: HarmonyCentcomAgentGear
+  id: CentcomAgentGearHarmony
   equipment:
     jumpsuit: ClothingUniformJumpsuitCentcomAgent
     back: ClothingBackpackSatchelLeather

--- a/Resources/Prototypes/_Harmony/Roles/Jobs/CentComm/official.yml
+++ b/Resources/Prototypes/_Harmony/Roles/Jobs/CentComm/official.yml
@@ -1,0 +1,33 @@
+- type: startingGear
+  id: HarmonyCentcomOfficialGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitCentcomFormal
+    back: ClothingBackpackSatchelLeather
+    shoes: ClothingShoesBootsLaceup
+    head: ClothingHeadHatCentcomcap
+    eyes: ClothingEyesGlassesCommand
+    neck: ClothingNeckCloakCentcom
+    gloves: WristwatchGold
+    id: CentcomPDA
+    ears: ClothingHeadsetAltCentCom
+    belt: BoxFolderCentComClipboard
+    pocket1: WeaponPistolN1984
+    pocket2: MagazineMagnum
+  inhand:
+    - MindShieldImplanter
+
+- type: startingGear
+  id: HarmonyCentcomAgentGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitCentcomAgent
+    back: ClothingBackpackSatchelLeather
+    shoes: ClothingShoesBootsLaceup
+    eyes: ClothingEyesGlassesSecurity
+    gloves: WristwatchGold
+    id: CentcomPDA
+    ears: ClothingHeadsetAltCentCom
+    belt: WeaponPulsePistol
+    pocket1: BoxFolderCentComClipboard
+    pocket2: RubberStampCentcom
+  inhand:
+    - MindShieldImplanter

--- a/Resources/Prototypes/_Harmony/Roles/Jobs/CentComm/official.yml
+++ b/Resources/Prototypes/_Harmony/Roles/Jobs/CentComm/official.yml
@@ -1,3 +1,5 @@
+# Harmony CC character presets
+
 - type: startingGear
   id: HarmonyCentcomOfficialGear
   equipment:


### PR DESCRIPTION
## About the PR
Adds new startingGear presets which can be used to clothe characters for admin use via the right-click debug menu.

## Why / Balance
Increases speed and ease of admin interaction via CC officials by allowing admins to dress characters in preferred clothing with a few button clicks rather than spawning everything. Largely not player facing, PR also serves as template for future presets.

## Technical details
New file in: `\Resources\Prototypes\_Harmony\Roles\Jobs\CentComm`

## Media
![image](https://github.com/user-attachments/assets/637f5143-b819-4cc1-b1d8-3483b9b53f07)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->