### PR TITLE
ERT GameRules for Admins

### DIFF
--- a/Resources/Locale/en-US/_Harmony/station-events/events/ert-shuttles.ftl
+++ b/Resources/Locale/en-US/_Harmony/station-events/events/ert-shuttles.ftl
@@ -1,0 +1,4 @@
+station-event-ert-generic-shuttle-incoming = An emergency response team has been dispatched via shuttle. Station crew should cooperate where needed.
+station-event-ert-sec-shuttle-incoming = An emergency security team has been dispatched via shuttle. The Head of Security should cooperate where needed.
+station-event-ert-med-shuttle-incoming = An emergency medical team has been dispatched via shuttle. The Chief Medical Officer should cooperate where needed.
+station-event-ert-engi-shuttle-incoming = An emergency engineering team has been dispatched via shuttle. The Chief Engineer should cooperate where needed.

--- a/Resources/Maps/_Harmony/Shuttles/ShuttleEvent/ERTEngiJaniMedium.yml
+++ b/Resources/Maps/_Harmony/Shuttles/ShuttleEvent/ERTEngiJaniMedium.yml
@@ -1,0 +1,3989 @@
+meta:
+  format: 6
+  postmapinit: false
+tilemap:
+  1: Space
+  9: FloorDark
+  10: FloorDarkMono
+  2: FloorSteel
+  8: FloorSteelHerringbone
+  11: FloorSteelMono
+  7: FloorSteelPavement
+  5: FloorTechMaint
+  6: FloorTechMaint2
+  12: FloorWood
+  4: Lattice
+  3: Plating
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: NT-Hephaestus
+    - type: Transform
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        -1,0:
+          ind: -1,0
+          tiles: AQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAABBQAAAAAAAwAAAAAAAwAAAAAACgAAAAACAgAAAAADAgAAAAACDAAAAAABAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAADBQAAAAAABQAAAAAABQAAAAAAAgAAAAACAgAAAAADAgAAAAABDAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAADAgAAAAABAgAAAAAAAgAAAAADAgAAAAABAgAAAAADAgAAAAABAgAAAAABAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAABBgAAAAAABgAAAAAABgAAAAAACwAAAAABAgAAAAADAgAAAAADAgAAAAACAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAAABgAAAAAACAAAAAAABgAAAAAAAgAAAAADAgAAAAADAgAAAAAAAgAAAAADAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAAABgAAAAAACAAAAAABBgAAAAAAAwAAAAAAAgAAAAADAgAAAAADAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAAABgAAAAAABgAAAAAABgAAAAAAAwAAAAAAAgAAAAACAgAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAABAgAAAAADAgAAAAADAgAAAAACAgAAAAAACwAAAAABCwAAAAAAAgAAAAABAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAACBwAAAAAABwAAAAADBwAAAAAABwAAAAACBwAAAAACBwAAAAAABwAAAAADAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAADAgAAAAAABwAAAAADBwAAAAAABwAAAAACBwAAAAADBwAAAAABBwAAAAACAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAAAgAAAAABAgAAAAADCgAAAAADAgAAAAADAgAAAAAAAgAAAAADCgAAAAADAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAAAgAAAAACCQAAAAADCQAAAAACCQAAAAABAwAAAAAACQAAAAACCQAAAAADAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAAAwAAAAAACQAAAAACCQAAAAADCQAAAAACAwAAAAAACQAAAAADCQAAAAADAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAAAAwAAAAAACQAAAAABCQAAAAADAwAAAAAACQAAAAADCQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAACQAAAAABAwAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAA
+          version: 6
+        -1,-1:
+          ind: -1,-1
+          tiles: AQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAABAAAAAAAAgAAAAAAAgAAAAACAgAAAAACAgAAAAACAgAAAAACAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAAAgAAAAABAgAAAAABAgAAAAABAgAAAAACAgAAAAADAgAAAAACAgAAAAABAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAADAgAAAAADBAAAAAAAAgAAAAACAgAAAAAAAgAAAAACAgAAAAABDAAAAAACAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAADBQAAAAAABQAAAAAAAgAAAAACAgAAAAABAgAAAAAAAgAAAAADAgAAAAADAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAADBQAAAAAAAwAAAAAACQAAAAABAgAAAAABAgAAAAABAgAAAAABDAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAABQAAAAAAAwAAAAAACQAAAAAAAgAAAAABAgAAAAABAgAAAAABAgAAAAAB
+          version: 6
+        0,-1:
+          ind: 0,-1
+          tiles: AQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAABAgAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAADAAAAAAAAgAAAAAAAgAAAAACAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAACAgAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAADAAAAAABDAAAAAADAgAAAAADAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAACAgAAAAAAAgAAAAACAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAA
+          version: 6
+        0,0:
+          ind: 0,0
+          tiles: DAAAAAADDAAAAAADAgAAAAADAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAADAAAAAABDAAAAAACAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAgAAAAAAAgAAAAACAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAACAgAAAAACAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAADAgAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAgAAAAADAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAADAgAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAABAgAAAAABAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABwAAAAACBwAAAAACAgAAAAADAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABwAAAAABAgAAAAADAgAAAAADAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAgAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAACQAAAAACAgAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAACQAAAAABAwAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAA
+          version: 6
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            color: '#FFFFFFFF'
+            id: Bot
+          decals:
+            131: -5,8
+        - node:
+            color: '#FFFFFFFF'
+            id: Box
+          decals:
+            42: 1,8
+            43: -7,8
+        - node:
+            color: '#EFB34196'
+            id: BrickBoxOverlay
+          decals:
+            125: -2,13
+        - node:
+            color: '#EFB34196'
+            id: BrickCornerOverlayNW
+          decals:
+            127: -2,12
+        - node:
+            color: '#EFB34196'
+            id: BrickEndOverlayN
+          decals:
+            126: -1,13
+        - node:
+            color: '#334E6DC8'
+            id: BrickTileWhiteBox
+          decals:
+            113: -5,13
+            114: -4,13
+        - node:
+            color: '#334E6DC8'
+            id: BrickTileWhiteCornerNe
+          decals:
+            115: -4,12
+        - node:
+            color: '#9FED5896'
+            id: BrickTileWhiteCornerNe
+          decals:
+            83: 1,6
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteCornerNe
+          decals:
+            72: -5,6
+            118: 0,12
+        - node:
+            color: '#334E6DC8'
+            id: BrickTileWhiteCornerNw
+          decals:
+            85: -6,12
+        - node:
+            color: '#9FED5896'
+            id: BrickTileWhiteCornerNw
+          decals:
+            81: 0,6
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteCornerNw
+          decals:
+            71: -7,6
+        - node:
+            color: '#334E6DC8'
+            id: BrickTileWhiteCornerSe
+          decals:
+            87: -4,11
+        - node:
+            color: '#9FED5896'
+            id: BrickTileWhiteCornerSe
+          decals:
+            75: 1,3
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteCornerSe
+          decals:
+            70: -5,3
+            120: 0,11
+        - node:
+            color: '#334E6DC8'
+            id: BrickTileWhiteCornerSw
+          decals:
+            86: -6,11
+        - node:
+            color: '#9FED5896'
+            id: BrickTileWhiteCornerSw
+          decals:
+            74: 0,3
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteCornerSw
+          decals:
+            73: -7,3
+            121: -2,11
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteInnerNe
+          decals:
+            130: -1,12
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteInnerNw
+          decals:
+            129: -1,12
+        - node:
+            color: '#9FED5896'
+            id: BrickTileWhiteLineE
+          decals:
+            77: 1,4
+            78: 1,5
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteLineE
+          decals:
+            64: -5,5
+            65: -5,4
+        - node:
+            color: '#334E6DC8'
+            id: BrickTileWhiteLineN
+          decals:
+            116: -5,12
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteLineN
+          decals:
+            63: -6,6
+        - node:
+            color: '#334E6DC8'
+            id: BrickTileWhiteLineS
+          decals:
+            88: -5,11
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteLineS
+          decals:
+            62: -6,3
+            122: -1,11
+        - node:
+            color: '#9FED5896'
+            id: BrickTileWhiteLineW
+          decals:
+            79: 0,5
+            80: 0,4
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteLineW
+          decals:
+            67: -7,4
+            68: -7,5
+        - node:
+            angle: -4.71238898038469 rad
+            color: '#FFFFFFFF'
+            id: Caution
+          decals:
+            19: -3,3
+            20: -3,0
+        - node:
+            color: '#EFB34196'
+            id: CheckerNWSE
+          decals:
+            66: -2.5005493,4.997814
+            69: -2.5051727,2.9951744
+            76: -2.4913101,4.006176
+        - node:
+            color: '#FFFFFFB7'
+            id: Delivery
+          decals:
+            107: -3,7
+        - node:
+            angle: 1.5707963267948966 rad
+            color: '#FFFFFFB7'
+            id: Delivery
+          decals:
+            108: -2,7
+        - node:
+            color: '#FFFFFFFF'
+            id: Delivery
+          decals:
+            0: -7,3
+            1: -7,4
+            2: -7,5
+            31: -7,6
+            32: -5,6
+            33: -5,5
+        - node:
+            color: '#FFFFFFB7'
+            id: WarnCornerNE
+          decals:
+            94: 0,9
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnCornerNE
+          decals:
+            61: -2,6
+        - node:
+            color: '#FFFFFFB7'
+            id: WarnCornerNW
+          decals:
+            93: -6,9
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnCornerNW
+          decals:
+            52: -4,-4
+            60: -3,6
+        - node:
+            color: '#FFFFFFB7'
+            id: WarnCornerSE
+          decals:
+            96: 0,8
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnCornerSE
+          decals:
+            51: -2,-5
+        - node:
+            color: '#FFFFFFB7'
+            id: WarnCornerSW
+          decals:
+            95: -6,8
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnCornerSW
+          decals:
+            53: -4,-5
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnCornerSmallNE
+          decals:
+            56: -2,-1
+            57: -2,-3
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnCornerSmallNW
+          decals:
+            55: -3,-4
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnCornerSmallSE
+          decals:
+            58: -2,-1
+            59: -2,-3
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnEndE
+          decals:
+            21: 1,-3
+            22: 1,-1
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineE
+          decals:
+            44: -2,0
+            45: -2,1
+            46: -2,2
+            47: -2,3
+            48: -2,5
+            49: -2,-2
+            50: -2,-4
+            82: -2,4
+        - node:
+            color: '#FFFFFFB7'
+            id: WarnLineN
+          decals:
+            102: -5,8
+            103: -4,8
+            104: -3,8
+            105: -2,8
+            106: -1,8
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineN
+          decals:
+            27: 0,-3
+            28: -1,-3
+            29: 0,-1
+            30: -1,-1
+            54: -3,-5
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineS
+          decals:
+            34: -3,-3
+            35: -3,-2
+            36: -3,-1
+            37: -3,0
+            38: -3,1
+            39: -3,2
+            40: -3,3
+            41: -3,5
+            84: -3,4
+        - node:
+            color: '#FFFFFFB7'
+            id: WarnLineW
+          decals:
+            97: -5,9
+            98: -4,9
+            99: -3,9
+            100: -2,9
+            101: -1,9
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineW
+          decals:
+            23: 0,-1
+            24: -1,-1
+            25: 0,-3
+            26: -1,-3
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinCornerNe
+          decals:
+            14: 1,1
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinCornerNw
+          decals:
+            7: -1,-4
+            13: -1,1
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinCornerSe
+          decals:
+            16: 1,0
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinCornerSw
+          decals:
+            3: -1,0
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinEndE
+          decals:
+            10: 1,-2
+            18: 0,-4
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinEndW
+          decals:
+            9: -1,-2
+            17: -1,-4
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinLineN
+          decals:
+            8: 0,-4
+            11: 0,-2
+            15: 0,1
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinLineS
+          decals:
+            5: 0,0
+            6: 1,0
+            12: 0,-2
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinLineW
+          decals:
+            4: -1,1
+    - type: GridAtmosphere
+      version: 2
+      data:
+        tiles:
+          -2,0:
+            0: 57582
+          -2,1:
+            0: 3822
+          -2,2:
+            0: 51406
+            1: 4352
+          -2,3:
+            1: 1
+            0: 140
+          -2,-1:
+            0: 61024
+            1: 4
+          -1,0:
+            0: 63215
+          -1,2:
+            0: 55551
+          -1,3:
+            0: 221
+          -1,1:
+            0: 26214
+          -1,-1:
+            0: 61167
+          0,0:
+            0: 12339
+          0,1:
+            0: 819
+          0,2:
+            0: 4115
+            1: 17408
+          0,3:
+            0: 1
+            1: 4
+          -2,-2:
+            1: 5632
+          -1,-2:
+            0: 29952
+          0,-2:
+            1: 17152
+          0,-1:
+            0: 29521
+            2: 32
+        uniqueMixes:
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          immutable: True
+          moles:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 21.6852
+          - 81.57766
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        chunkSize: 4
+    - type: OccluderTree
+    - type: Shuttle
+    - type: RadiationGridResistance
+    - type: GravityShake
+      shakeTimes: 10
+    - type: GasTileOverlay
+    - type: SpreaderGrid
+    - type: GridPathfinding
+- proto: AirAlarm
+  entities:
+  - uid: 89
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,10.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 125
+      - 393
+      - 155
+  - uid: 421
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,10.5
+      parent: 1
+  - uid: 423
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,10.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 157
+      - 392
+      - 126
+  - uid: 424
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,7.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 335
+      - 334
+      - 125
+      - 126
+      - 380
+      - 379
+  - uid: 425
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-1.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 122
+      - 94
+      - 250
+      - 162
+      - 402
+      - 376
+      - 161
+  - uid: 426
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,1.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 403
+      - 156
+      - 122
+- proto: AirCanister
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      anchored: True
+      pos: -4.5,-1.5
+      parent: 1
+    - type: Physics
+      bodyType: Static
+  - uid: 3
+    components:
+    - type: Transform
+      pos: -4.5,1.5
+      parent: 1
+- proto: AirlockCentralCommandGlassLocked
+  entities:
+  - uid: 4
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,10.5
+      parent: 1
+- proto: AirlockCentralCommandLocked
+  entities:
+  - uid: 5
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,0.5
+      parent: 1
+- proto: AirlockEngineeringGlassLocked
+  entities:
+  - uid: 10
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,10.5
+      parent: 1
+  - uid: 302
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 1
+- proto: AirlockGlassShuttle
+  entities:
+  - uid: 6
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-0.5
+      parent: 1
+  - uid: 7
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-2.5
+      parent: 1
+  - uid: 8
+    components:
+    - type: Transform
+      pos: -1.5,-5.5
+      parent: 1
+  - uid: 9
+    components:
+    - type: Transform
+      pos: -3.5,-5.5
+      parent: 1
+- proto: AirlockJanitorLocked
+  entities:
+  - uid: 324
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 1
+- proto: APCBasic
+  entities:
+  - uid: 12
+    components:
+    - type: Transform
+      pos: -4.5,2.5
+      parent: 1
+  - uid: 459
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,7.5
+      parent: 1
+- proto: AtmosDeviceFanDirectional
+  entities:
+  - uid: 13
+    components:
+    - type: Transform
+      pos: -1.5,-5.5
+      parent: 1
+  - uid: 14
+    components:
+    - type: Transform
+      pos: -3.5,-5.5
+      parent: 1
+  - uid: 200
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-0.5
+      parent: 1
+  - uid: 496
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-2.5
+      parent: 1
+- proto: BoxLightMixed
+  entities:
+  - uid: 450
+    components:
+    - type: Transform
+      pos: 1.7212837,3.5618596
+      parent: 1
+  - uid: 451
+    components:
+    - type: Transform
+      pos: 1.3983669,3.7076929
+      parent: 1
+- proto: Bucket
+  entities:
+  - uid: 44
+    components:
+    - type: Transform
+      pos: -0.19378823,12.842689
+      parent: 1
+  - uid: 353
+    components:
+    - type: Transform
+      parent: 346
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 372
+    components:
+    - type: Transform
+      parent: 346
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 454
+    components:
+    - type: Transform
+      pos: -0.19378823,12.394772
+      parent: 1
+- proto: CableApcExtension
+  entities:
+  - uid: 11
+    components:
+    - type: Transform
+      pos: -3.5,8.5
+      parent: 1
+  - uid: 15
+    components:
+    - type: Transform
+      pos: 0.5,11.5
+      parent: 1
+  - uid: 16
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 1
+  - uid: 17
+    components:
+    - type: Transform
+      pos: -4.5,11.5
+      parent: 1
+  - uid: 18
+    components:
+    - type: Transform
+      pos: -5.5,5.5
+      parent: 1
+  - uid: 19
+    components:
+    - type: Transform
+      pos: -5.5,-4.5
+      parent: 1
+  - uid: 20
+    components:
+    - type: Transform
+      pos: -6.5,9.5
+      parent: 1
+  - uid: 23
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 25
+    components:
+    - type: Transform
+      pos: -0.5,9.5
+      parent: 1
+  - uid: 26
+    components:
+    - type: Transform
+      pos: -4.5,9.5
+      parent: 1
+  - uid: 27
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 1
+  - uid: 28
+    components:
+    - type: Transform
+      pos: -2.5,13.5
+      parent: 1
+  - uid: 29
+    components:
+    - type: Transform
+      pos: -5.5,11.5
+      parent: 1
+  - uid: 30
+    components:
+    - type: Transform
+      pos: -2.5,14.5
+      parent: 1
+  - uid: 31
+    components:
+    - type: Transform
+      pos: -1.5,14.5
+      parent: 1
+  - uid: 32
+    components:
+    - type: Transform
+      pos: -0.5,14.5
+      parent: 1
+  - uid: 33
+    components:
+    - type: Transform
+      pos: 0.5,14.5
+      parent: 1
+  - uid: 34
+    components:
+    - type: Transform
+      pos: 1.5,13.5
+      parent: 1
+  - uid: 35
+    components:
+    - type: Transform
+      pos: 1.5,12.5
+      parent: 1
+  - uid: 36
+    components:
+    - type: Transform
+      pos: -3.5,14.5
+      parent: 1
+  - uid: 37
+    components:
+    - type: Transform
+      pos: -4.5,14.5
+      parent: 1
+  - uid: 38
+    components:
+    - type: Transform
+      pos: -5.5,14.5
+      parent: 1
+  - uid: 39
+    components:
+    - type: Transform
+      pos: -6.5,13.5
+      parent: 1
+  - uid: 40
+    components:
+    - type: Transform
+      pos: -6.5,12.5
+      parent: 1
+  - uid: 41
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 1
+  - uid: 42
+    components:
+    - type: Transform
+      pos: -0.5,7.5
+      parent: 1
+  - uid: 43
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 1
+  - uid: 45
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 1
+  - uid: 46
+    components:
+    - type: Transform
+      pos: -0.5,-2.5
+      parent: 1
+  - uid: 47
+    components:
+    - type: Transform
+      pos: -0.5,8.5
+      parent: 1
+  - uid: 48
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 49
+    components:
+    - type: Transform
+      pos: -4.5,1.5
+      parent: 1
+  - uid: 51
+    components:
+    - type: Transform
+      pos: -6.5,4.5
+      parent: 1
+  - uid: 52
+    components:
+    - type: Transform
+      pos: -5.5,4.5
+      parent: 1
+  - uid: 53
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 54
+    components:
+    - type: Transform
+      pos: -5.5,-2.5
+      parent: 1
+  - uid: 55
+    components:
+    - type: Transform
+      pos: -0.5,11.5
+      parent: 1
+  - uid: 56
+    components:
+    - type: Transform
+      pos: -4.5,8.5
+      parent: 1
+  - uid: 57
+    components:
+    - type: Transform
+      pos: -6.5,8.5
+      parent: 1
+  - uid: 58
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 1
+  - uid: 59
+    components:
+    - type: Transform
+      pos: -5.5,12.5
+      parent: 1
+  - uid: 60
+    components:
+    - type: Transform
+      pos: -5.5,-0.5
+      parent: 1
+  - uid: 61
+    components:
+    - type: Transform
+      pos: -2.5,6.5
+      parent: 1
+  - uid: 62
+    components:
+    - type: Transform
+      pos: -4.5,2.5
+      parent: 1
+  - uid: 63
+    components:
+    - type: Transform
+      pos: -4.5,0.5
+      parent: 1
+  - uid: 64
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 65
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 1
+  - uid: 66
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 1
+  - uid: 67
+    components:
+    - type: Transform
+      pos: -4.5,10.5
+      parent: 1
+  - uid: 68
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 1
+  - uid: 69
+    components:
+    - type: Transform
+      pos: -5.5,0.5
+      parent: 1
+  - uid: 70
+    components:
+    - type: Transform
+      pos: 1.5,-4.5
+      parent: 1
+  - uid: 71
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+  - uid: 72
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 1
+  - uid: 73
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 1
+  - uid: 74
+    components:
+    - type: Transform
+      pos: -6.5,-4.5
+      parent: 1
+  - uid: 75
+    components:
+    - type: Transform
+      pos: -5.5,8.5
+      parent: 1
+  - uid: 76
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 1
+  - uid: 77
+    components:
+    - type: Transform
+      pos: -5.5,13.5
+      parent: 1
+  - uid: 78
+    components:
+    - type: Transform
+      pos: -0.5,10.5
+      parent: 1
+  - uid: 79
+    components:
+    - type: Transform
+      pos: 0.5,13.5
+      parent: 1
+  - uid: 80
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 1
+  - uid: 81
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 1
+  - uid: 82
+    components:
+    - type: Transform
+      pos: -5.5,-1.5
+      parent: 1
+  - uid: 83
+    components:
+    - type: Transform
+      pos: -6.5,-2.5
+      parent: 1
+  - uid: 106
+    components:
+    - type: Transform
+      pos: -6.5,-3.5
+      parent: 1
+  - uid: 110
+    components:
+    - type: Transform
+      pos: -2.5,7.5
+      parent: 1
+  - uid: 186
+    components:
+    - type: Transform
+      pos: -4.5,5.5
+      parent: 1
+  - uid: 297
+    components:
+    - type: Transform
+      pos: -2.5,8.5
+      parent: 1
+  - uid: 308
+    components:
+    - type: Transform
+      pos: 0.5,12.5
+      parent: 1
+  - uid: 316
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 1
+  - uid: 356
+    components:
+    - type: Transform
+      pos: -3.5,6.5
+      parent: 1
+  - uid: 367
+    components:
+    - type: Transform
+      pos: -6.5,-4.5
+      parent: 1
+  - uid: 368
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 1
+  - uid: 369
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 1
+  - uid: 370
+    components:
+    - type: Transform
+      pos: -2.5,-4.5
+      parent: 1
+  - uid: 415
+    components:
+    - type: Transform
+      pos: -2.5,12.5
+      parent: 1
+  - uid: 416
+    components:
+    - type: Transform
+      pos: -2.5,11.5
+      parent: 1
+  - uid: 460
+    components:
+    - type: Transform
+      pos: -5.5,7.5
+      parent: 1
+  - uid: 461
+    components:
+    - type: Transform
+      pos: -7.5,4.5
+      parent: 1
+  - uid: 462
+    components:
+    - type: Transform
+      pos: -7.5,5.5
+      parent: 1
+  - uid: 463
+    components:
+    - type: Transform
+      pos: -7.5,6.5
+      parent: 1
+  - uid: 464
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 465
+    components:
+    - type: Transform
+      pos: 2.5,6.5
+      parent: 1
+  - uid: 466
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 467
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 1
+- proto: CableHV
+  entities:
+  - uid: 84
+    components:
+    - type: Transform
+      pos: -5.5,-2.5
+      parent: 1
+  - uid: 85
+    components:
+    - type: Transform
+      pos: -6.5,-1.5
+      parent: 1
+  - uid: 86
+    components:
+    - type: Transform
+      pos: -6.5,-0.5
+      parent: 1
+  - uid: 87
+    components:
+    - type: Transform
+      pos: -6.5,0.5
+      parent: 1
+  - uid: 88
+    components:
+    - type: Transform
+      pos: -6.5,-2.5
+      parent: 1
+- proto: CableMV
+  entities:
+  - uid: 22
+    components:
+    - type: Transform
+      pos: -5.5,7.5
+      parent: 1
+  - uid: 90
+    components:
+    - type: Transform
+      pos: -6.5,0.5
+      parent: 1
+  - uid: 91
+    components:
+    - type: Transform
+      pos: -4.5,2.5
+      parent: 1
+  - uid: 93
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 1
+  - uid: 98
+    components:
+    - type: Transform
+      pos: -4.5,1.5
+      parent: 1
+  - uid: 99
+    components:
+    - type: Transform
+      pos: -3.5,8.5
+      parent: 1
+  - uid: 100
+    components:
+    - type: Transform
+      pos: -5.5,0.5
+      parent: 1
+  - uid: 101
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 1
+  - uid: 103
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 1
+  - uid: 105
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 111
+    components:
+    - type: Transform
+      pos: -4.5,0.5
+      parent: 1
+  - uid: 112
+    components:
+    - type: Transform
+      pos: -4.5,8.5
+      parent: 1
+  - uid: 129
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 1
+  - uid: 134
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 143
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 1
+  - uid: 304
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 1
+  - uid: 307
+    components:
+    - type: Transform
+      pos: -2.5,8.5
+      parent: 1
+  - uid: 310
+    components:
+    - type: Transform
+      pos: -4.5,8.5
+      parent: 1
+  - uid: 320
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 332
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 337
+    components:
+    - type: Transform
+      pos: -5.5,8.5
+      parent: 1
+  - uid: 361
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 1
+- proto: CableTerminal
+  entities:
+  - uid: 113
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,-2.5
+      parent: 1
+- proto: Catwalk
+  entities:
+  - uid: 116
+    components:
+    - type: Transform
+      pos: -5.5,-1.5
+      parent: 1
+  - uid: 118
+    components:
+    - type: Transform
+      pos: -4.5,0.5
+      parent: 1
+  - uid: 222
+    components:
+    - type: Transform
+      pos: -5.5,0.5
+      parent: 1
+  - uid: 366
+    components:
+    - type: Transform
+      pos: -5.5,-0.5
+      parent: 1
+  - uid: 484
+    components:
+    - type: Transform
+      pos: -7.5,12.5
+      parent: 1
+  - uid: 485
+    components:
+    - type: Transform
+      pos: -7.5,11.5
+      parent: 1
+  - uid: 486
+    components:
+    - type: Transform
+      pos: -7.5,10.5
+      parent: 1
+  - uid: 487
+    components:
+    - type: Transform
+      pos: 2.5,12.5
+      parent: 1
+  - uid: 488
+    components:
+    - type: Transform
+      pos: 2.5,11.5
+      parent: 1
+  - uid: 489
+    components:
+    - type: Transform
+      pos: 2.5,10.5
+      parent: 1
+  - uid: 490
+    components:
+    - type: Transform
+      pos: 2.5,-4.5
+      parent: 1
+  - uid: 491
+    components:
+    - type: Transform
+      pos: 1.5,-5.5
+      parent: 1
+  - uid: 492
+    components:
+    - type: Transform
+      pos: 0.5,-5.5
+      parent: 1
+  - uid: 493
+    components:
+    - type: Transform
+      pos: -6.5,-5.5
+      parent: 1
+  - uid: 494
+    components:
+    - type: Transform
+      pos: -5.5,-5.5
+      parent: 1
+  - uid: 495
+    components:
+    - type: Transform
+      pos: -7.5,-4.5
+      parent: 1
+- proto: ChairFoldingSpawnFolded
+  entities:
+  - uid: 114
+    components:
+    - type: Transform
+      pos: -5.4663134,-1.5176274
+      parent: 1
+  - uid: 115
+    components:
+    - type: Transform
+      pos: -5.2996464,-1.1736389
+      parent: 1
+- proto: ChairPilotSeat
+  entities:
+  - uid: 97
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,0.5
+      parent: 1
+  - uid: 117
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,12.5
+      parent: 1
+  - uid: 132
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,1.5
+      parent: 1
+  - uid: 325
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 326
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 476
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,12.5
+      parent: 1
+- proto: CleanerDispenser
+  entities:
+  - uid: 471
+    components:
+    - type: Transform
+      pos: 1.5,7.5
+      parent: 1
+- proto: ClosetJanitorFilled
+  entities:
+  - uid: 346
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 1
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 350
+          - 348
+          - 353
+          - 372
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+- proto: ClosetWall
+  entities:
+  - uid: 431
+    components:
+    - type: MetaData
+      name: jetpack wall closet
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-4.5
+      parent: 1
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 433
+          - 432
+  - uid: 434
+    components:
+    - type: MetaData
+      name: jetpack wall closet
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-3.5
+      parent: 1
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+        - 1.8856695
+        - 7.0937095
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 436
+          - 435
+- proto: ClosetWallFireFilledRandom
+  entities:
+  - uid: 428
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-4.5
+      parent: 1
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+- proto: ClothingBeltChiefEngineerFilled
+  entities:
+  - uid: 499
+    components:
+    - type: Transform
+      pos: -5.4853897,11.57526
+      parent: 1
+- proto: ComputerComms
+  entities:
+  - uid: 119
+    components:
+    - type: Transform
+      pos: -3.5,13.5
+      parent: 1
+- proto: ComputerPowerMonitoring
+  entities:
+  - uid: 120
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-0.5
+      parent: 1
+- proto: ComputerShuttle
+  entities:
+  - uid: 121
+    components:
+    - type: Transform
+      pos: -4.5,13.5
+      parent: 1
+- proto: CrateAirlockKit
+  entities:
+  - uid: 363
+    components:
+    - type: Transform
+      pos: -3.5,-3.5
+      parent: 1
+- proto: CrateEngineeringCableBulk
+  entities:
+  - uid: 455
+    components:
+    - type: Transform
+      pos: -0.5,13.5
+      parent: 1
+- proto: CrateJanitorBiosuit
+  entities:
+  - uid: 351
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+- proto: CrateMaterialGlass
+  entities:
+  - uid: 92
+    components:
+    - type: Transform
+      pos: -6.5,4.5
+      parent: 1
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 385
+          - 418
+          - 419
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+- proto: CrateMaterialPlasteel
+  entities:
+  - uid: 305
+    components:
+    - type: Transform
+      pos: -6.5,6.5
+      parent: 1
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 422
+          - 429
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+- proto: CrateMaterialPlastic
+  entities:
+  - uid: 107
+    components:
+    - type: Transform
+      pos: -6.5,3.5
+      parent: 1
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 430
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+- proto: CrateMaterialSteel
+  entities:
+  - uid: 306
+    components:
+    - type: Transform
+      pos: -6.5,5.5
+      parent: 1
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 441
+          - 443
+          - 444
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+- proto: CrateParticleDecelerators
+  entities:
+  - uid: 198
+    components:
+    - type: Transform
+      pos: -1.5,11.5
+      parent: 1
+- proto: CrateTrashCartJani
+  entities:
+  - uid: 352
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 1
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 445
+          - 446
+          - 447
+          - 448
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+- proto: DrinkWaterCup
+  entities:
+  - uid: 328
+    components:
+    - type: Transform
+      pos: 0.6946335,0.9517708
+      parent: 1
+  - uid: 329
+    components:
+    - type: Transform
+      pos: 0.35945892,0.7325134
+      parent: 1
+  - uid: 330
+    components:
+    - type: Transform
+      pos: 0.6172867,0.53904724
+      parent: 1
+- proto: FireAlarm
+  entities:
+  - uid: 24
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,10.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 126
+  - uid: 344
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,4.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 250
+      - 94
+      - 334
+      - 335
+  - uid: 345
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 1
+  - uid: 427
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-0.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 122
+      - 94
+      - 250
+      - 162
+      - 402
+      - 376
+      - 161
+  - uid: 468
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,7.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 334
+      - 335
+      - 126
+      - 125
+  - uid: 469
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,11.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 125
+- proto: FireAxeCabinetFilled
+  entities:
+  - uid: 414
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,10.5
+      parent: 1
+- proto: FirelockGlass
+  entities:
+  - uid: 94
+    components:
+    - type: Transform
+      pos: -2.5,2.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 425
+      - 427
+      - 344
+  - uid: 122
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 425
+      - 427
+      - 426
+  - uid: 125
+    components:
+    - type: Transform
+      pos: -4.5,10.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 424
+      - 89
+      - 468
+      - 469
+  - uid: 126
+    components:
+    - type: Transform
+      pos: -0.5,10.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 424
+      - 423
+      - 468
+      - 24
+  - uid: 250
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 425
+      - 427
+      - 344
+  - uid: 334
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,7.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 424
+      - 468
+      - 344
+  - uid: 335
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,7.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 424
+      - 468
+      - 344
+- proto: FloorDrain
+  entities:
+  - uid: 458
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: FoodBurgerMcguffin
+  entities:
+  - uid: 327
+    components:
+    - type: Transform
+      pos: 0.34657288,1.5321693
+      parent: 1
+- proto: FuelDispenser
+  entities:
+  - uid: 420
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,4.5
+      parent: 1
+- proto: GasPassiveVent
+  entities:
+  - uid: 371
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeBend
+  entities:
+  - uid: 102
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 387
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 391
+    components:
+    - type: Transform
+      pos: 0.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeFourway
+  entities:
+  - uid: 148
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 315
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 338
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeStraight
+  entities:
+  - uid: 104
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 123
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 130
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 131
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 133
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 136
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 137
+    components:
+    - type: Transform
+      pos: -4.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 138
+    components:
+    - type: Transform
+      pos: -0.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 139
+    components:
+    - type: Transform
+      pos: -4.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 140
+    components:
+    - type: Transform
+      pos: -0.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 141
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 142
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 144
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 145
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 147
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 149
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 150
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 151
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 159
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 224
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 309
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 319
+    components:
+    - type: Transform
+      pos: -4.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 373
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 374
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 382
+    components:
+    - type: Transform
+      pos: -2.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 383
+    components:
+    - type: Transform
+      pos: -2.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 384
+    components:
+    - type: Transform
+      pos: -2.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 388
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 389
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 390
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 395
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 396
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 397
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 398
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 399
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 406
+    components:
+    - type: Transform
+      pos: -2.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 407
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 408
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 409
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 410
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 411
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 412
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 413
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeTJunction
+  entities:
+  - uid: 127
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 152
+    components:
+    - type: Transform
+      pos: -4.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 154
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 164
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 375
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 381
+    components:
+    - type: Transform
+      pos: -2.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 386
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 394
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 404
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 405
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPort
+  entities:
+  - uid: 153
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasVentPump
+  entities:
+  - uid: 155
+    components:
+    - type: Transform
+      pos: -4.5,11.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 89
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 156
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,0.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 426
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 157
+    components:
+    - type: Transform
+      pos: -0.5,11.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 423
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 158
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 160
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 161
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-3.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 425
+      - 427
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 162
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,0.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 425
+      - 427
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 377
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 379
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,8.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 424
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasVentScrubber
+  entities:
+  - uid: 376
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-4.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 425
+      - 427
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 378
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 380
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,8.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 424
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 392
+    components:
+    - type: Transform
+      pos: -1.5,11.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 423
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 393
+    components:
+    - type: Transform
+      pos: -3.5,11.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 89
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 400
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 401
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 402
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,1.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 425
+      - 427
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 403
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-0.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 426
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GeneratorBasic15kW
+  entities:
+  - uid: 163
+    components:
+    - type: Transform
+      pos: -5.5,-2.5
+      parent: 1
+  - uid: 339
+    components:
+    - type: Transform
+      pos: -6.5,-2.5
+      parent: 1
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 165
+    components:
+    - type: Transform
+      pos: -6.5,1.5
+      parent: 1
+- proto: Grille
+  entities:
+  - uid: 50
+    components:
+    - type: Transform
+      pos: -3.5,6.5
+      parent: 1
+  - uid: 95
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,6.5
+      parent: 1
+  - uid: 96
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 166
+    components:
+    - type: Transform
+      pos: -5.5,13.5
+      parent: 1
+  - uid: 167
+    components:
+    - type: Transform
+      pos: 0.5,13.5
+      parent: 1
+  - uid: 168
+    components:
+    - type: Transform
+      pos: -2.5,12.5
+      parent: 1
+  - uid: 169
+    components:
+    - type: Transform
+      pos: -7.5,6.5
+      parent: 1
+  - uid: 170
+    components:
+    - type: Transform
+      pos: -6.5,12.5
+      parent: 1
+  - uid: 171
+    components:
+    - type: Transform
+      pos: -6.5,13.5
+      parent: 1
+  - uid: 172
+    components:
+    - type: Transform
+      pos: -5.5,14.5
+      parent: 1
+  - uid: 173
+    components:
+    - type: Transform
+      pos: -4.5,14.5
+      parent: 1
+  - uid: 174
+    components:
+    - type: Transform
+      pos: -3.5,14.5
+      parent: 1
+  - uid: 175
+    components:
+    - type: Transform
+      pos: -1.5,14.5
+      parent: 1
+  - uid: 176
+    components:
+    - type: Transform
+      pos: -0.5,14.5
+      parent: 1
+  - uid: 177
+    components:
+    - type: Transform
+      pos: 0.5,14.5
+      parent: 1
+  - uid: 178
+    components:
+    - type: Transform
+      pos: 1.5,13.5
+      parent: 1
+  - uid: 179
+    components:
+    - type: Transform
+      pos: 1.5,12.5
+      parent: 1
+  - uid: 180
+    components:
+    - type: Transform
+      pos: -7.5,5.5
+      parent: 1
+  - uid: 181
+    components:
+    - type: Transform
+      pos: 2.5,6.5
+      parent: 1
+  - uid: 182
+    components:
+    - type: Transform
+      pos: -2.5,13.5
+      parent: 1
+  - uid: 183
+    components:
+    - type: Transform
+      pos: -2.5,11.5
+      parent: 1
+  - uid: 184
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 185
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 201
+    components:
+    - type: Transform
+      pos: -7.5,4.5
+      parent: 1
+  - uid: 301
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 1
+- proto: Gyroscope
+  entities:
+  - uid: 187
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,1.5
+      parent: 1
+- proto: HolopadUnlimitedRange
+  entities:
+  - uid: 497
+    components:
+    - type: MetaData
+      name: quantum entangling holopad (NT-Hephaestus)
+    - type: Transform
+      pos: -4.5,8.5
+      parent: 1
+    - type: Label
+      currentLabel: NT-Hephaestus
+    - type: NameModifier
+      baseName: quantum entangling holopad
+- proto: JanitorialTrolley
+  entities:
+  - uid: 449
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,8.5
+      parent: 1
+- proto: JetpackMiniFilled
+  entities:
+  - uid: 432
+    components:
+    - type: Transform
+      parent: 431
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 433
+    components:
+    - type: Transform
+      parent: 431
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 435
+    components:
+    - type: Transform
+      parent: 434
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 436
+    components:
+    - type: Transform
+      parent: 434
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: MopItem
+  entities:
+  - uid: 348
+    components:
+    - type: Transform
+      parent: 346
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 350
+    components:
+    - type: Transform
+      parent: 346
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: PlasmaReinforcedWindowDirectional
+  entities:
+  - uid: 453
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-3.5
+      parent: 1
+- proto: PortableGeneratorJrPacman
+  entities:
+  - uid: 452
+    components:
+    - type: Transform
+      pos: 0.5,11.5
+      parent: 1
+- proto: PortableGeneratorPacman
+  entities:
+  - uid: 341
+    components:
+    - type: Transform
+      pos: -1.5,12.5
+      parent: 1
+- proto: PortableGeneratorSuperPacman
+  entities:
+  - uid: 293
+    components:
+    - type: Transform
+      pos: -4.5,5.5
+      parent: 1
+  - uid: 313
+    components:
+    - type: Transform
+      pos: -4.5,6.5
+      parent: 1
+- proto: PosterContrabandBeachStarYamamoto
+  entities:
+  - uid: 438
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,2.5
+      parent: 1
+- proto: PosterContrabandLustyExomorph
+  entities:
+  - uid: 437
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,2.5
+      parent: 1
+- proto: PosterContrabandMissingGloves
+  entities:
+  - uid: 439
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-3.5
+      parent: 1
+- proto: PosterContrabandMissingSpacepen
+  entities:
+  - uid: 478
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,2.5
+      parent: 1
+- proto: PosterLegitBuild
+  entities:
+  - uid: 442
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,7.5
+      parent: 1
+- proto: PosterLegitCleanliness
+  entities:
+  - uid: 477
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,2.5
+      parent: 1
+- proto: PosterLegitMime
+  entities:
+  - uid: 440
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,7.5
+      parent: 1
+- proto: PosterLegitNanotrasenLogo
+  entities:
+  - uid: 188
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,10.5
+      parent: 1
+  - uid: 189
+    components:
+    - type: Transform
+      pos: -0.5,-5.5
+      parent: 1
+  - uid: 190
+    components:
+    - type: Transform
+      pos: -4.5,-5.5
+      parent: 1
+- proto: PowerCellRecharger
+  entities:
+  - uid: 355
+    components:
+    - type: Transform
+      pos: -2.5,9.5
+      parent: 1
+  - uid: 479
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,11.5
+      parent: 1
+- proto: Poweredlight
+  entities:
+  - uid: 191
+    components:
+    - type: Transform
+      pos: -2.5,9.5
+      parent: 1
+  - uid: 192
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-0.5
+      parent: 1
+  - uid: 194
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-1.5
+      parent: 1
+  - uid: 195
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,11.5
+      parent: 1
+  - uid: 196
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-4.5
+      parent: 1
+  - uid: 197
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,11.5
+      parent: 1
+  - uid: 296
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 303
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,4.5
+      parent: 1
+  - uid: 314
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,4.5
+      parent: 1
+- proto: Rack
+  entities:
+  - uid: 359
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 1
+- proto: RandomHumanoidSpawnerERTEngineerEVA
+  entities:
+  - uid: 482
+    components:
+    - type: Transform
+      pos: -5.5,4.5
+      parent: 1
+- proto: RandomHumanoidSpawnerERTEngineerEVATime
+  entities:
+  - uid: 481
+    components:
+    - type: Transform
+      pos: -5.5,5.5
+      parent: 1
+  - uid: 498
+    components:
+    - type: Transform
+      pos: -5.5,6.5
+      parent: 1
+- proto: RandomHumanoidSpawnerERTJanitorEVA
+  entities:
+  - uid: 480
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+- proto: RandomHumanoidSpawnerERTLeaderEVATime
+  entities:
+  - uid: 483
+    components:
+    - type: Transform
+      pos: -4.5,11.5
+      parent: 1
+- proto: RCD
+  entities:
+  - uid: 360
+    components:
+    - type: Transform
+      pos: 0.52021027,-1.2602577
+      parent: 1
+- proto: RCDAmmo
+  entities:
+  - uid: 364
+    components:
+    - type: Transform
+      pos: 0.33271027,-1.5102577
+      parent: 1
+  - uid: 365
+    components:
+    - type: Transform
+      pos: 0.58271027,-1.5571327
+      parent: 1
+- proto: SheetGlass
+  entities:
+  - uid: 385
+    components:
+    - type: Transform
+      parent: 92
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 418
+    components:
+    - type: Transform
+      parent: 92
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 419
+    components:
+    - type: Transform
+      parent: 92
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: SheetPlasma
+  entities:
+  - uid: 472
+    components:
+    - type: Transform
+      pos: -1.4645302,13.563813
+      parent: 1
+- proto: SheetPlasteel
+  entities:
+  - uid: 422
+    components:
+    - type: Transform
+      parent: 305
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 429
+    components:
+    - type: Transform
+      parent: 305
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: SheetPlastic
+  entities:
+  - uid: 430
+    components:
+    - type: Transform
+      parent: 107
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: SheetRGlass
+  entities:
+  - uid: 473
+    components:
+    - type: Transform
+      pos: -5.415328,12.417666
+      parent: 1
+- proto: SheetRPGlass
+  entities:
+  - uid: 474
+    components:
+    - type: Transform
+      pos: -5.5895305,12.584647
+      parent: 1
+- proto: SheetRUGlass
+  entities:
+  - uid: 475
+    components:
+    - type: Transform
+      pos: -5.5924115,12.188499
+      parent: 1
+- proto: SheetSteel
+  entities:
+  - uid: 441
+    components:
+    - type: Transform
+      parent: 306
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 443
+    components:
+    - type: Transform
+      parent: 306
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 444
+    components:
+    - type: Transform
+      parent: 306
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: SheetUranium
+  entities:
+  - uid: 254
+    components:
+    - type: Transform
+      pos: -4.6540985,4.681904
+      parent: 1
+  - uid: 317
+    components:
+    - type: Transform
+      pos: -4.422058,4.475544
+      parent: 1
+- proto: ShuttleWindow
+  entities:
+  - uid: 108
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,6.5
+      parent: 1
+  - uid: 109
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 128
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,6.5
+      parent: 1
+  - uid: 193
+    components:
+    - type: Transform
+      pos: -7.5,4.5
+      parent: 1
+  - uid: 202
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,6.5
+      parent: 1
+  - uid: 203
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,5.5
+      parent: 1
+  - uid: 204
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 205
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,6.5
+      parent: 1
+  - uid: 206
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,13.5
+      parent: 1
+  - uid: 207
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 208
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,12.5
+      parent: 1
+  - uid: 209
+    components:
+    - type: Transform
+      pos: 0.5,13.5
+      parent: 1
+  - uid: 210
+    components:
+    - type: Transform
+      pos: 1.5,13.5
+      parent: 1
+  - uid: 211
+    components:
+    - type: Transform
+      pos: 0.5,14.5
+      parent: 1
+  - uid: 212
+    components:
+    - type: Transform
+      pos: -0.5,14.5
+      parent: 1
+  - uid: 213
+    components:
+    - type: Transform
+      pos: -1.5,14.5
+      parent: 1
+  - uid: 214
+    components:
+    - type: Transform
+      pos: -4.5,14.5
+      parent: 1
+  - uid: 215
+    components:
+    - type: Transform
+      pos: -5.5,14.5
+      parent: 1
+  - uid: 216
+    components:
+    - type: Transform
+      pos: -6.5,13.5
+      parent: 1
+  - uid: 217
+    components:
+    - type: Transform
+      pos: -6.5,12.5
+      parent: 1
+  - uid: 218
+    components:
+    - type: Transform
+      pos: -3.5,14.5
+      parent: 1
+  - uid: 219
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,13.5
+      parent: 1
+  - uid: 220
+    components:
+    - type: Transform
+      pos: 1.5,12.5
+      parent: 1
+  - uid: 221
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,11.5
+      parent: 1
+  - uid: 294
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 1
+- proto: SinkWide
+  entities:
+  - uid: 457
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,5.5
+      parent: 1
+- proto: SMESAdvanced
+  entities:
+  - uid: 340
+    components:
+    - type: Transform
+      pos: -6.5,-1.5
+      parent: 1
+- proto: SubstationBasic
+  entities:
+  - uid: 223
+    components:
+    - type: Transform
+      pos: -6.5,0.5
+      parent: 1
+- proto: TableGlass
+  entities:
+  - uid: 321
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 322
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+- proto: TableReinforced
+  entities:
+  - uid: 318
+    components:
+    - type: Transform
+      pos: -4.5,4.5
+      parent: 1
+  - uid: 333
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 1
+  - uid: 336
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+  - uid: 342
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,12.5
+      parent: 1
+  - uid: 343
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,11.5
+      parent: 1
+  - uid: 349
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 354
+    components:
+    - type: Transform
+      pos: -2.5,9.5
+      parent: 1
+  - uid: 456
+    components:
+    - type: Transform
+      pos: -1.5,13.5
+      parent: 1
+- proto: Thruster
+  entities:
+  - uid: 225
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-5.5
+      parent: 1
+  - uid: 226
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-5.5
+      parent: 1
+  - uid: 227
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-4.5
+      parent: 1
+  - uid: 228
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-5.5
+      parent: 1
+  - uid: 229
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-4.5
+      parent: 1
+  - uid: 230
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,11.5
+      parent: 1
+  - uid: 231
+    components:
+    - type: Transform
+      pos: -7.5,12.5
+      parent: 1
+  - uid: 232
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,11.5
+      parent: 1
+  - uid: 233
+    components:
+    - type: Transform
+      pos: 2.5,12.5
+      parent: 1
+  - uid: 234
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,-5.5
+      parent: 1
+  - uid: 235
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,10.5
+      parent: 1
+  - uid: 236
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,10.5
+      parent: 1
+- proto: TrashBag
+  entities:
+  - uid: 446
+    components:
+    - type: Transform
+      parent: 352
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 448
+    components:
+    - type: Transform
+      parent: 352
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: TrashBagBlue
+  entities:
+  - uid: 445
+    components:
+    - type: Transform
+      parent: 352
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 447
+    components:
+    - type: Transform
+      parent: 352
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: TurboItemRecharger
+  entities:
+  - uid: 199
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 1
+  - uid: 417
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+- proto: VendingMachineEngivend
+  entities:
+  - uid: 358
+    components:
+    - type: Transform
+      pos: -6.5,8.5
+      parent: 1
+- proto: VendingMachineYouTool
+  entities:
+  - uid: 357
+    components:
+    - type: Transform
+      pos: -0.5,-1.5
+      parent: 1
+- proto: WallShuttle
+  entities:
+  - uid: 21
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,7.5
+      parent: 1
+  - uid: 124
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 135
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,7.5
+      parent: 1
+  - uid: 146
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,2.5
+      parent: 1
+  - uid: 237
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,10.5
+      parent: 1
+  - uid: 238
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 239
+    components:
+    - type: Transform
+      pos: 2.5,9.5
+      parent: 1
+  - uid: 240
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-2.5
+      parent: 1
+  - uid: 241
+    components:
+    - type: Transform
+      pos: -6.5,-3.5
+      parent: 1
+  - uid: 242
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 243
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-1.5
+      parent: 1
+  - uid: 244
+    components:
+    - type: Transform
+      pos: 2.5,-3.5
+      parent: 1
+  - uid: 245
+    components:
+    - type: Transform
+      pos: -5.5,-4.5
+      parent: 1
+  - uid: 246
+    components:
+    - type: Transform
+      pos: -7.5,7.5
+      parent: 1
+  - uid: 247
+    components:
+    - type: Transform
+      pos: 1.5,9.5
+      parent: 1
+  - uid: 248
+    components:
+    - type: Transform
+      pos: -6.5,9.5
+      parent: 1
+  - uid: 249
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,10.5
+      parent: 1
+  - uid: 251
+    components:
+    - type: Transform
+      pos: 1.5,-3.5
+      parent: 1
+  - uid: 252
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,2.5
+      parent: 1
+  - uid: 253
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 255
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,2.5
+      parent: 1
+  - uid: 256
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,2.5
+      parent: 1
+  - uid: 257
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-1.5
+      parent: 1
+  - uid: 258
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,8.5
+      parent: 1
+  - uid: 259
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,-0.5
+      parent: 1
+  - uid: 260
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,14.5
+      parent: 1
+  - uid: 261
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,-1.5
+      parent: 1
+  - uid: 262
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,3.5
+      parent: 1
+  - uid: 263
+    components:
+    - type: Transform
+      pos: -6.5,-4.5
+      parent: 1
+  - uid: 264
+    components:
+    - type: Transform
+      pos: 1.5,-4.5
+      parent: 1
+  - uid: 265
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,10.5
+      parent: 1
+  - uid: 266
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,-2.5
+      parent: 1
+  - uid: 267
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,2.5
+      parent: 1
+  - uid: 268
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,2.5
+      parent: 1
+  - uid: 269
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-4.5
+      parent: 1
+  - uid: 270
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-4.5
+      parent: 1
+  - uid: 271
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 272
+    components:
+    - type: Transform
+      pos: -7.5,-3.5
+      parent: 1
+  - uid: 273
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-3.5
+      parent: 1
+  - uid: 274
+    components:
+    - type: Transform
+      pos: -7.5,0.5
+      parent: 1
+  - uid: 275
+    components:
+    - type: Transform
+      pos: 2.5,7.5
+      parent: 1
+  - uid: 276
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-2.5
+      parent: 1
+  - uid: 277
+    components:
+    - type: Transform
+      pos: -7.5,8.5
+      parent: 1
+  - uid: 278
+    components:
+    - type: Transform
+      pos: -7.5,9.5
+      parent: 1
+  - uid: 279
+    components:
+    - type: Transform
+      pos: -6.5,10.5
+      parent: 1
+  - uid: 280
+    components:
+    - type: Transform
+      pos: -6.5,11.5
+      parent: 1
+  - uid: 281
+    components:
+    - type: Transform
+      pos: 1.5,11.5
+      parent: 1
+  - uid: 282
+    components:
+    - type: Transform
+      pos: 1.5,10.5
+      parent: 1
+  - uid: 283
+    components:
+    - type: Transform
+      pos: -4.5,-5.5
+      parent: 1
+  - uid: 284
+    components:
+    - type: Transform
+      pos: -0.5,-5.5
+      parent: 1
+  - uid: 285
+    components:
+    - type: Transform
+      pos: -2.5,-5.5
+      parent: 1
+  - uid: 286
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 1
+  - uid: 287
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,10.5
+      parent: 1
+  - uid: 288
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-0.5
+      parent: 1
+  - uid: 289
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,10.5
+      parent: 1
+  - uid: 290
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,1.5
+      parent: 1
+  - uid: 291
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,1.5
+      parent: 1
+  - uid: 292
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 295
+    components:
+    - type: Transform
+      pos: -5.5,7.5
+      parent: 1
+  - uid: 298
+    components:
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 1
+  - uid: 299
+    components:
+    - type: Transform
+      pos: -3.5,7.5
+      parent: 1
+  - uid: 300
+    components:
+    - type: Transform
+      pos: -6.5,7.5
+      parent: 1
+  - uid: 311
+    components:
+    - type: Transform
+      pos: 0.5,7.5
+      parent: 1
+  - uid: 312
+    components:
+    - type: Transform
+      pos: 1.5,7.5
+      parent: 1
+  - uid: 323
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,4.5
+      parent: 1
+- proto: WallWeaponCapacitorRecharger
+  entities:
+  - uid: 362
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 1
+- proto: WaterCooler
+  entities:
+  - uid: 331
+    components:
+    - type: Transform
+      pos: 1.5,-1.5
+      parent: 1
+- proto: WaterTankHighCapacity
+  entities:
+  - uid: 347
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 1
+- proto: WeldingFuelTankHighCapacity
+  entities:
+  - uid: 470
+    components:
+    - type: Transform
+      pos: 0.5,12.5
+      parent: 1
+...

--- a/Resources/Maps/_Harmony/Shuttles/ShuttleEvent/ERTEngiSmall.yml
+++ b/Resources/Maps/_Harmony/Shuttles/ShuttleEvent/ERTEngiSmall.yml
@@ -1,0 +1,2454 @@
+meta:
+  format: 6
+  postmapinit: false
+tilemap:
+  1: Space
+  6: FloorDarkMini
+  8: FloorDarkMono
+  5: FloorGrayConcrete
+  7: FloorShuttleWhite
+  3: FloorSteel
+  9: FloorTechMaint
+  4: Lattice
+  2: Plating
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: NT-Demiurge
+    - type: Transform
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        -1,0:
+          ind: -1,0
+          tiles: AQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAABQAAAAABBQAAAAADBQAAAAAAAwAAAAACAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAABQAAAAACBQAAAAADBQAAAAADAwAAAAACAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAABAwAAAAACAwAAAAADBQAAAAACAwAAAAADAwAAAAACAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAABgAAAAACBgAAAAAAAgAAAAAAAwAAAAABAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAABBgAAAAAABgAAAAADCAAAAAAAAwAAAAACAwAAAAADAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAABgAAAAADBgAAAAAAAgAAAAAAAwAAAAABAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAAABgAAAAACAwAAAAACAwAAAAAAAwAAAAADAwAAAAABAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAAAwAAAAACBwAAAAAACAAAAAAACAAAAAACAwAAAAACAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAABAAAAAAAAgAAAAAACAAAAAAAAgAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAAAgAAAAAAAgAAAAAAAgAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAA
+          version: 6
+        0,0:
+          ind: 0,0
+          tiles: AwAAAAADAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAABAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAABAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAABAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAABAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAA
+          version: 6
+        -1,-1:
+          ind: -1,-1
+          tiles: AQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAAAgAAAAAAAgAAAAAAAgAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAAAgAAAAAAAgAAAAAABAAAAAAAAgAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAgAAAAAACQAAAAAAAgAAAAAACQAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAACQAAAAAACQAAAAAAAgAAAAAACQAAAAAACQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAABQAAAAACBQAAAAADBQAAAAACAwAAAAABAwAAAAAD
+          version: 6
+        0,-1:
+          ind: 0,-1
+          tiles: AQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAACAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAA
+          version: 6
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: CargoShuttle
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            color: '#FFFFFF93'
+            id: Bot
+          decals:
+            36: -5,1
+            37: -4,1
+            38: -4,0
+            39: -5,0
+            40: -5,-1
+            41: -4,-1
+            42: -5,5
+            43: -4,5
+            44: -5,4
+            45: -5,3
+            46: -4,3
+            51: -5,-2
+        - node:
+            color: '#FFFFFFFF'
+            id: BotLeft
+          decals:
+            56: -4,-2
+        - node:
+            color: '#FFFFFF93'
+            id: Box
+          decals:
+            47: -1,4
+            48: -1,5
+            49: -1,6
+            50: -3,7
+        - node:
+            color: '#FFFFFFFF'
+            id: Box
+          decals:
+            57: -3,-3
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteCornerNe
+          decals:
+            12: -1,6
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteCornerNw
+          decals:
+            11: -2,6
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteCornerSe
+          decals:
+            13: -1,-1
+        - node:
+            color: '#334E6DC8'
+            id: BrickTileWhiteCornerSw
+          decals:
+            2: -3,7
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteCornerSw
+          decals:
+            14: -2,-1
+        - node:
+            color: '#334E6DC8'
+            id: BrickTileWhiteEndE
+          decals:
+            1: -2,7
+        - node:
+            color: '#334E6DC8'
+            id: BrickTileWhiteEndN
+          decals:
+            0: -3,8
+        - node:
+            color: '#334E6DC8'
+            id: BrickTileWhiteInnerNe
+          decals:
+            3: -3,7
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteLineE
+          decals:
+            15: -1,0
+            16: -1,1
+            17: -1,2
+            18: -1,3
+            19: -1,4
+            20: -1,5
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteLineW
+          decals:
+            21: -2,0
+            22: -2,1
+            23: -2,2
+            24: -2,3
+            25: -2,4
+            26: -2,5
+        - node:
+            color: '#EFB34196'
+            id: ConcreteTrimCornerSe
+          decals:
+            34: -3,-1
+        - node:
+            color: '#EFB34196'
+            id: ConcreteTrimCornerSw
+          decals:
+            33: -5,-1
+        - node:
+            color: '#EFB34196'
+            id: ConcreteTrimLineE
+          decals:
+            28: -3,2
+            29: -3,1
+            30: -3,0
+        - node:
+            color: '#EFB34196'
+            id: ConcreteTrimLineS
+          decals:
+            35: -4,-1
+        - node:
+            color: '#EFB34196'
+            id: ConcreteTrimLineW
+          decals:
+            31: -5,1
+            32: -5,0
+        - node:
+            color: '#EFB34196'
+            id: Delivery
+          decals:
+            27: -3,4
+        - node:
+            color: '#FFFFFF93'
+            id: Delivery
+          decals:
+            52: -4,-3
+            53: -2,-3
+        - node:
+            color: '#FFFFFFFF'
+            id: Delivery
+          decals:
+            54: -1,-2
+            55: -5,-2
+        - node:
+            color: '#EFB34196'
+            id: MiniTileWhiteBox
+          decals:
+            4: -5,6
+        - node:
+            color: '#EFB34196'
+            id: MiniTileWhiteCornerNe
+          decals:
+            6: -4,5
+        - node:
+            color: '#EFB34196'
+            id: MiniTileWhiteCornerNw
+          decals:
+            5: -5,5
+        - node:
+            color: '#EFB34196'
+            id: MiniTileWhiteCornerSe
+          decals:
+            8: -4,3
+        - node:
+            color: '#EFB34196'
+            id: MiniTileWhiteCornerSw
+          decals:
+            9: -5,3
+        - node:
+            color: '#EFB34196'
+            id: MiniTileWhiteLineE
+          decals:
+            7: -4,4
+        - node:
+            color: '#EFB34196'
+            id: MiniTileWhiteLineW
+          decals:
+            10: -5,4
+    - type: GridAtmosphere
+      version: 2
+      data:
+        tiles:
+          -2,0:
+            0: 32904
+          -2,1:
+            0: 2184
+            1: 16384
+          -2,2:
+            1: 140
+          -2,-1:
+            0: 34816
+            1: 4
+          -1,0:
+            0: 57087
+          -1,1:
+            0: 27871
+          -1,-1:
+            0: 65392
+            1: 2
+          -1,2:
+            0: 2
+            1: 136
+          0,0:
+            0: 4112
+          0,1:
+            1: 4096
+          0,2:
+            1: 1
+          -2,-2:
+            1: 32768
+          -1,-2:
+            1: 32768
+          0,-1:
+            1: 1
+        uniqueMixes:
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          immutable: True
+          moles:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        chunkSize: 4
+    - type: OccluderTree
+    - type: Shuttle
+    - type: GridPathfinding
+    - type: RadiationGridResistance
+    - type: SpreaderGrid
+    - type: GravityShake
+      shakeTimes: 10
+    - type: GasTileOverlay
+- proto: AirCanister
+  entities:
+  - uid: 126
+    components:
+    - type: Transform
+      pos: -3.5,1.5
+      parent: 1
+  - uid: 127
+    components:
+    - type: Transform
+      pos: -4.5,1.5
+      parent: 1
+  - uid: 130
+    components:
+    - type: Transform
+      anchored: True
+      pos: -3.5,-1.5
+      parent: 1
+    - type: Physics
+      bodyType: Static
+- proto: AirlockEngineeringGlassLocked
+  entities:
+  - uid: 283
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,4.5
+      parent: 1
+- proto: AirlockGlassShuttle
+  entities:
+  - uid: 4
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 5
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,3.5
+      parent: 1
+- proto: APCHyperCapacity
+  entities:
+  - uid: 6
+    components:
+    - type: Transform
+      pos: -0.5,7.5
+      parent: 1
+- proto: AtmosDeviceFanTiny
+  entities:
+  - uid: 7
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 8
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+- proto: CableApcExtension
+  entities:
+  - uid: 9
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 1
+  - uid: 10
+    components:
+    - type: Transform
+      pos: -2.5,7.5
+      parent: 1
+  - uid: 11
+    components:
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 1
+  - uid: 12
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 1
+  - uid: 13
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 1
+  - uid: 14
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 1
+  - uid: 15
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 1
+  - uid: 16
+    components:
+    - type: Transform
+      pos: -0.5,7.5
+      parent: 1
+  - uid: 17
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 1
+  - uid: 18
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 1
+  - uid: 19
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 20
+    components:
+    - type: Transform
+      pos: -0.5,1.5
+      parent: 1
+  - uid: 21
+    components:
+    - type: Transform
+      pos: -3.5,1.5
+      parent: 1
+  - uid: 22
+    components:
+    - type: Transform
+      pos: -4.5,1.5
+      parent: 1
+  - uid: 23
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 1
+  - uid: 24
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 25
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 1
+  - uid: 26
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 1
+  - uid: 27
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 28
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 1
+  - uid: 29
+    components:
+    - type: Transform
+      pos: -2.5,8.5
+      parent: 1
+  - uid: 30
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 1
+  - uid: 31
+    components:
+    - type: Transform
+      pos: -4.5,-3.5
+      parent: 1
+  - uid: 32
+    components:
+    - type: Transform
+      pos: -3.5,8.5
+      parent: 1
+  - uid: 33
+    components:
+    - type: Transform
+      pos: -4.5,8.5
+      parent: 1
+  - uid: 34
+    components:
+    - type: Transform
+      pos: -3.5,-3.5
+      parent: 1
+  - uid: 35
+    components:
+    - type: Transform
+      pos: -0.5,8.5
+      parent: 1
+  - uid: 36
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 1
+  - uid: 37
+    components:
+    - type: Transform
+      pos: -3.5,-1.5
+      parent: 1
+  - uid: 38
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 1
+- proto: CableHV
+  entities:
+  - uid: 40
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 1
+  - uid: 288
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 1
+  - uid: 289
+    components:
+    - type: Transform
+      pos: -3.5,-1.5
+      parent: 1
+  - uid: 290
+    components:
+    - type: Transform
+      pos: -4.5,-1.5
+      parent: 1
+- proto: CableMV
+  entities:
+  - uid: 39
+    components:
+    - type: Transform
+      pos: -3.5,-1.5
+      parent: 1
+  - uid: 42
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 1
+  - uid: 44
+    components:
+    - type: Transform
+      pos: -3.5,9.5
+      parent: 1
+  - uid: 45
+    components:
+    - type: Transform
+      pos: -2.5,7.5
+      parent: 1
+  - uid: 47
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 1
+  - uid: 48
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 1
+  - uid: 49
+    components:
+    - type: Transform
+      pos: -2.5,3.5
+      parent: 1
+  - uid: 50
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 51
+    components:
+    - type: Transform
+      pos: -2.5,9.5
+      parent: 1
+  - uid: 52
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 1
+  - uid: 53
+    components:
+    - type: Transform
+      pos: -0.5,7.5
+      parent: 1
+  - uid: 54
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 1
+  - uid: 55
+    components:
+    - type: Transform
+      pos: -2.5,2.5
+      parent: 1
+  - uid: 56
+    components:
+    - type: Transform
+      pos: -3.5,2.5
+      parent: 1
+  - uid: 57
+    components:
+    - type: Transform
+      pos: -4.5,2.5
+      parent: 1
+  - uid: 58
+    components:
+    - type: Transform
+      pos: -5.5,2.5
+      parent: 1
+  - uid: 59
+    components:
+    - type: Transform
+      pos: -5.5,3.5
+      parent: 1
+  - uid: 60
+    components:
+    - type: Transform
+      pos: -5.5,4.5
+      parent: 1
+  - uid: 61
+    components:
+    - type: Transform
+      pos: -5.5,5.5
+      parent: 1
+  - uid: 62
+    components:
+    - type: Transform
+      pos: -5.5,1.5
+      parent: 1
+  - uid: 63
+    components:
+    - type: Transform
+      pos: -5.5,0.5
+      parent: 1
+  - uid: 64
+    components:
+    - type: Transform
+      pos: -5.5,-0.5
+      parent: 1
+  - uid: 65
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 1
+  - uid: 67
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 1
+  - uid: 68
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 1
+  - uid: 70
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 1
+  - uid: 88
+    components:
+    - type: Transform
+      pos: -1.5,9.5
+      parent: 1
+  - uid: 129
+    components:
+    - type: Transform
+      pos: -3.5,8.5
+      parent: 1
+  - uid: 175
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 180
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 252
+    components:
+    - type: Transform
+      pos: -4.5,-1.5
+      parent: 1
+- proto: CableTerminal
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-2.5
+      parent: 1
+- proto: Catwalk
+  entities:
+  - uid: 74
+    components:
+    - type: Transform
+      pos: -4.5,-4.5
+      parent: 1
+  - uid: 75
+    components:
+    - type: Transform
+      pos: -5.5,-3.5
+      parent: 1
+  - uid: 77
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 1
+  - uid: 92
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 1
+  - uid: 244
+    components:
+    - type: Transform
+      pos: -0.5,-4.5
+      parent: 1
+  - uid: 301
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+  - uid: 302
+    components:
+    - type: Transform
+      pos: 0.5,8.5
+      parent: 1
+  - uid: 303
+    components:
+    - type: Transform
+      pos: -0.5,9.5
+      parent: 1
+  - uid: 304
+    components:
+    - type: Transform
+      pos: -4.5,9.5
+      parent: 1
+  - uid: 305
+    components:
+    - type: Transform
+      pos: -5.5,8.5
+      parent: 1
+- proto: ChairPilotSeat
+  entities:
+  - uid: 69
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,7.5
+      parent: 1
+  - uid: 243
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,6.5
+      parent: 1
+  - uid: 245
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,4.5
+      parent: 1
+  - uid: 247
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,5.5
+      parent: 1
+- proto: ClosetWall
+  entities:
+  - uid: 294
+    components:
+    - type: Transform
+      pos: -3.5,6.5
+      parent: 1
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 295
+          - 296
+          - 297
+          - 298
+          - 299
+- proto: ClosetWallFireFilledRandom
+  entities:
+  - uid: 291
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,6.5
+      parent: 1
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+- proto: ComputerShuttle
+  entities:
+  - uid: 72
+    components:
+    - type: Transform
+      pos: -2.5,8.5
+      parent: 1
+- proto: CrateMaterialGlass
+  entities:
+  - uid: 221
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 1
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14957
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 222
+          - 223
+          - 224
+          - 225
+          - 226
+          - 227
+          - 228
+          - 229
+          - 230
+          - 231
+          - 232
+          - 233
+          - 234
+          - 235
+          - 236
+          - 237
+          - 238
+          - 239
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+- proto: CrateMaterialPlasteel
+  entities:
+  - uid: 208
+    components:
+    - type: Transform
+      pos: -4.5,5.5
+      parent: 1
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.1496
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 209
+          - 210
+          - 211
+          - 212
+          - 213
+          - 214
+          - 215
+          - 216
+          - 217
+          - 218
+          - 219
+          - 220
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+- proto: CrateMaterialSteel
+  entities:
+  - uid: 182
+    components:
+    - type: Transform
+      pos: -4.5,3.5
+      parent: 1
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.1496
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 183
+          - 184
+          - 185
+          - 186
+          - 187
+          - 188
+          - 189
+          - 190
+          - 191
+          - 192
+          - 193
+          - 194
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+  - uid: 195
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 1
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.1496
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 196
+          - 197
+          - 198
+          - 199
+          - 200
+          - 201
+          - 202
+          - 203
+          - 204
+          - 205
+          - 206
+          - 207
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+- proto: CrateParticleDecelerators
+  entities:
+  - uid: 73
+    components:
+    - type: Transform
+      pos: -4.5,4.5
+      parent: 1
+- proto: FuelDispenser
+  entities:
+  - uid: 300
+    components:
+    - type: Transform
+      pos: -3.5,2.5
+      parent: 1
+- proto: GasPassiveVent
+  entities:
+  - uid: 253
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeBend
+  entities:
+  - uid: 78
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 260
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 261
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 262
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 263
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 264
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 265
+    components:
+    - type: Transform
+      pos: -0.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeStraight
+  entities:
+  - uid: 82
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 83
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 84
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 85
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 87
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 268
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 269
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 270
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 271
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 272
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 273
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 274
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 275
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 276
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 277
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 278
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 279
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 280
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 281
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 282
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeTJunction
+  entities:
+  - uid: 71
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 79
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 80
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 86
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 266
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 267
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPort
+  entities:
+  - uid: 251
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasVentPump
+  entities:
+  - uid: 89
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 90
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 255
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 259
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasVentScrubber
+  entities:
+  - uid: 254
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 256
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 257
+    components:
+    - type: Transform
+      pos: -4.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 258
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GeneratorBasic15kW
+  entities:
+  - uid: 66
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 1
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 81
+    components:
+    - type: Transform
+      pos: -0.5,-1.5
+      parent: 1
+- proto: Grille
+  entities:
+  - uid: 93
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 1
+  - uid: 94
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,3.5
+      parent: 1
+  - uid: 95
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,9.5
+      parent: 1
+  - uid: 96
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,9.5
+      parent: 1
+  - uid: 97
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,9.5
+      parent: 1
+  - uid: 98
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,3.5
+      parent: 1
+  - uid: 99
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,8.5
+      parent: 1
+  - uid: 100
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,0.5
+      parent: 1
+  - uid: 101
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,5.5
+      parent: 1
+  - uid: 102
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,8.5
+      parent: 1
+  - uid: 103
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-0.5
+      parent: 1
+  - uid: 104
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,1.5
+      parent: 1
+  - uid: 179
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+- proto: Gyroscope
+  entities:
+  - uid: 91
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-2.5
+      parent: 1
+- proto: InflatableDoorStack
+  entities:
+  - uid: 249
+    components:
+    - type: Transform
+      pos: -4.8995476,6.36635
+      parent: 1
+- proto: InflatableWallStack
+  entities:
+  - uid: 246
+    components:
+    - type: Transform
+      pos: -4.869606,6.6506567
+      parent: 1
+  - uid: 248
+    components:
+    - type: Transform
+      pos: -4.824692,6.815255
+      parent: 1
+- proto: JetpackMiniFilled
+  entities:
+  - uid: 295
+    components:
+    - type: Transform
+      parent: 294
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 296
+    components:
+    - type: Transform
+      parent: 294
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 297
+    components:
+    - type: Transform
+      parent: 294
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 298
+    components:
+    - type: Transform
+      parent: 294
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 299
+    components:
+    - type: Transform
+      parent: 294
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: NitrogenCanister
+  entities:
+  - uid: 41
+    components:
+    - type: Transform
+      pos: -4.5,-0.5
+      parent: 1
+  - uid: 43
+    components:
+    - type: Transform
+      pos: -3.5,-0.5
+      parent: 1
+- proto: OxygenCanister
+  entities:
+  - uid: 105
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 1
+  - uid: 113
+    components:
+    - type: Transform
+      pos: -4.5,0.5
+      parent: 1
+- proto: PlasmaReinforcedWindowDirectional
+  entities:
+  - uid: 46
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-3.5
+      parent: 1
+- proto: PottedPlant26
+  entities:
+  - uid: 106
+    components:
+    - type: Transform
+      pos: -2.2459946,2.2835855
+      parent: 1
+- proto: Poweredlight
+  entities:
+  - uid: 107
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 1
+  - uid: 108
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,2.5
+      parent: 1
+    - type: ApcPowerReceiver
+      powerLoad: 0
+  - uid: 109
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,7.5
+      parent: 1
+    - type: ApcPowerReceiver
+      powerLoad: 0
+  - uid: 110
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,7.5
+      parent: 1
+  - uid: 111
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-3.5
+      parent: 1
+- proto: Rack
+  entities:
+  - uid: 112
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,6.5
+      parent: 1
+- proto: RandomHumanoidSpawnerERTEngineerEVA
+  entities:
+  - uid: 293
+    components:
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 1
+- proto: RandomHumanoidSpawnerERTEngineerEVATime
+  entities:
+  - uid: 292
+    components:
+    - type: Transform
+      pos: -2.5,7.5
+      parent: 1
+- proto: RCD
+  entities:
+  - uid: 240
+    components:
+    - type: Transform
+      pos: -4.4076157,6.760563
+      parent: 1
+- proto: RCDAmmo
+  entities:
+  - uid: 241
+    components:
+    - type: Transform
+      pos: -4.4076157,6.5510736
+      parent: 1
+  - uid: 242
+    components:
+    - type: Transform
+      pos: -4.6172104,6.416402
+      parent: 1
+- proto: SheetPlasteel
+  entities:
+  - uid: 209
+    components:
+    - type: Transform
+      parent: 208
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 210
+    components:
+    - type: Transform
+      parent: 208
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 211
+    components:
+    - type: Transform
+      parent: 208
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 212
+    components:
+    - type: Transform
+      parent: 208
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 213
+    components:
+    - type: Transform
+      parent: 208
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 214
+    components:
+    - type: Transform
+      parent: 208
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 215
+    components:
+    - type: Transform
+      parent: 208
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 216
+    components:
+    - type: Transform
+      parent: 208
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 217
+    components:
+    - type: Transform
+      parent: 208
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 218
+    components:
+    - type: Transform
+      parent: 208
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 219
+    components:
+    - type: Transform
+      parent: 208
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 220
+    components:
+    - type: Transform
+      parent: 208
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: SheetRGlass
+  entities:
+  - uid: 227
+    components:
+    - type: Transform
+      parent: 221
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 229
+    components:
+    - type: Transform
+      parent: 221
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 230
+    components:
+    - type: Transform
+      parent: 221
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 231
+    components:
+    - type: Transform
+      parent: 221
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 232
+    components:
+    - type: Transform
+      parent: 221
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 233
+    components:
+    - type: Transform
+      parent: 221
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 234
+    components:
+    - type: Transform
+      parent: 221
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 235
+    components:
+    - type: Transform
+      parent: 221
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 236
+    components:
+    - type: Transform
+      parent: 221
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 237
+    components:
+    - type: Transform
+      parent: 221
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 238
+    components:
+    - type: Transform
+      parent: 221
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 239
+    components:
+    - type: Transform
+      parent: 221
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: SheetRPGlass
+  entities:
+  - uid: 222
+    components:
+    - type: Transform
+      parent: 221
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 223
+    components:
+    - type: Transform
+      parent: 221
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 224
+    components:
+    - type: Transform
+      parent: 221
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 225
+    components:
+    - type: Transform
+      parent: 221
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 226
+    components:
+    - type: Transform
+      parent: 221
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 228
+    components:
+    - type: Transform
+      parent: 221
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: SheetSteel
+  entities:
+  - uid: 183
+    components:
+    - type: Transform
+      parent: 182
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 184
+    components:
+    - type: Transform
+      parent: 182
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 185
+    components:
+    - type: Transform
+      parent: 182
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 186
+    components:
+    - type: Transform
+      parent: 182
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 187
+    components:
+    - type: Transform
+      parent: 182
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 188
+    components:
+    - type: Transform
+      parent: 182
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 189
+    components:
+    - type: Transform
+      parent: 182
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 190
+    components:
+    - type: Transform
+      parent: 182
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 191
+    components:
+    - type: Transform
+      parent: 182
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 192
+    components:
+    - type: Transform
+      parent: 182
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 193
+    components:
+    - type: Transform
+      parent: 182
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 194
+    components:
+    - type: Transform
+      parent: 182
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 196
+    components:
+    - type: Transform
+      parent: 195
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 197
+    components:
+    - type: Transform
+      parent: 195
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 198
+    components:
+    - type: Transform
+      parent: 195
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 199
+    components:
+    - type: Transform
+      parent: 195
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 200
+    components:
+    - type: Transform
+      parent: 195
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 201
+    components:
+    - type: Transform
+      parent: 195
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 202
+    components:
+    - type: Transform
+      parent: 195
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 203
+    components:
+    - type: Transform
+      parent: 195
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 204
+    components:
+    - type: Transform
+      parent: 195
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 205
+    components:
+    - type: Transform
+      parent: 195
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 206
+    components:
+    - type: Transform
+      parent: 195
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 207
+    components:
+    - type: Transform
+      parent: 195
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: ShuttleWindow
+  entities:
+  - uid: 114
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 1
+  - uid: 115
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,0.5
+      parent: 1
+  - uid: 116
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,1.5
+      parent: 1
+  - uid: 117
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,3.5
+      parent: 1
+  - uid: 118
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,5.5
+      parent: 1
+  - uid: 119
+    components:
+    - type: Transform
+      pos: -3.5,8.5
+      parent: 1
+  - uid: 120
+    components:
+    - type: Transform
+      pos: -3.5,9.5
+      parent: 1
+  - uid: 121
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,3.5
+      parent: 1
+  - uid: 122
+    components:
+    - type: Transform
+      pos: -2.5,9.5
+      parent: 1
+  - uid: 123
+    components:
+    - type: Transform
+      pos: -1.5,9.5
+      parent: 1
+  - uid: 124
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 1
+  - uid: 125
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-0.5
+      parent: 1
+  - uid: 165
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+- proto: SMESAdvanced
+  entities:
+  - uid: 163
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 1
+- proto: SubstationBasic
+  entities:
+  - uid: 157
+    components:
+    - type: Transform
+      pos: -4.5,-1.5
+      parent: 1
+- proto: TableReinforced
+  entities:
+  - uid: 128
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-0.5
+      parent: 1
+- proto: Thruster
+  entities:
+  - uid: 131
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,8.5
+      parent: 1
+  - uid: 132
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-4.5
+      parent: 1
+  - uid: 133
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-4.5
+      parent: 1
+  - uid: 134
+    components:
+    - type: Transform
+      pos: -0.5,9.5
+      parent: 1
+  - uid: 135
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,8.5
+      parent: 1
+  - uid: 136
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-3.5
+      parent: 1
+  - uid: 137
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-3.5
+      parent: 1
+  - uid: 138
+    components:
+    - type: Transform
+      pos: -4.5,9.5
+      parent: 1
+- proto: TurboItemRecharger
+  entities:
+  - uid: 76
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 1
+- proto: VendingMachineEngivend
+  entities:
+  - uid: 250
+    components:
+    - type: Transform
+      pos: -0.5,-0.5
+      parent: 1
+- proto: WallShuttle
+  entities:
+  - uid: 139
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,2.5
+      parent: 1
+  - uid: 140
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,2.5
+      parent: 1
+  - uid: 141
+    components:
+    - type: Transform
+      pos: -5.5,4.5
+      parent: 1
+  - uid: 142
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 143
+    components:
+    - type: Transform
+      pos: -2.5,6.5
+      parent: 1
+  - uid: 144
+    components:
+    - type: Transform
+      pos: -4.5,7.5
+      parent: 1
+  - uid: 145
+    components:
+    - type: Transform
+      pos: -4.5,8.5
+      parent: 1
+  - uid: 146
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 147
+    components:
+    - type: Transform
+      pos: -3.5,7.5
+      parent: 1
+  - uid: 148
+    components:
+    - type: Transform
+      pos: -5.5,7.5
+      parent: 1
+  - uid: 149
+    components:
+    - type: Transform
+      pos: -0.5,7.5
+      parent: 1
+  - uid: 150
+    components:
+    - type: Transform
+      pos: -3.5,6.5
+      parent: 1
+  - uid: 151
+    components:
+    - type: Transform
+      pos: -0.5,8.5
+      parent: 1
+  - uid: 152
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 1
+  - uid: 153
+    components:
+    - type: Transform
+      pos: -5.5,-1.5
+      parent: 1
+  - uid: 154
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 1
+  - uid: 155
+    components:
+    - type: Transform
+      pos: 0.5,7.5
+      parent: 1
+  - uid: 156
+    components:
+    - type: Transform
+      pos: -5.5,6.5
+      parent: 1
+  - uid: 158
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 1
+  - uid: 159
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 160
+    components:
+    - type: Transform
+      pos: -2.5,-4.5
+      parent: 1
+  - uid: 161
+    components:
+    - type: Transform
+      pos: -5.5,2.5
+      parent: 1
+  - uid: 164
+    components:
+    - type: Transform
+      pos: -3.5,-4.5
+      parent: 1
+  - uid: 166
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 1
+  - uid: 167
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 1
+  - uid: 168
+    components:
+    - type: Transform
+      pos: -4.5,-3.5
+      parent: 1
+  - uid: 169
+    components:
+    - type: Transform
+      pos: -0.5,-2.5
+      parent: 1
+  - uid: 170
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 1
+  - uid: 171
+    components:
+    - type: Transform
+      pos: -3.5,-3.5
+      parent: 1
+  - uid: 172
+    components:
+    - type: Transform
+      pos: -5.5,-2.5
+      parent: 1
+  - uid: 173
+    components:
+    - type: Transform
+      pos: -4.5,-2.5
+      parent: 1
+  - uid: 174
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 1
+- proto: WallShuttleDiagonal
+  entities:
+  - uid: 162
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,2.5
+      parent: 1
+- proto: WindoorSecureCentralCommandLocked
+  entities:
+  - uid: 177
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 1
+  - uid: 178
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,6.5
+      parent: 1
+- proto: WindoorSecureEngineeringLocked
+  entities:
+  - uid: 3
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,1.5
+      parent: 1
+  - uid: 176
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,3.5
+      parent: 1
+- proto: WindowReinforcedDirectional
+  entities:
+  - uid: 284
+    components:
+    - type: Transform
+      pos: -3.5,-0.5
+      parent: 1
+  - uid: 285
+    components:
+    - type: Transform
+      pos: -4.5,-0.5
+      parent: 1
+  - uid: 286
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 1
+  - uid: 287
+    components:
+    - type: Transform
+      pos: -0.5,-0.5
+      parent: 1
+- proto: Wrench
+  entities:
+  - uid: 181
+    components:
+    - type: Transform
+      pos: -1.4998802,-1.4998802
+      parent: 1
+...

--- a/Resources/Maps/_Harmony/Shuttles/ShuttleEvent/ERTJaniSmall.yml
+++ b/Resources/Maps/_Harmony/Shuttles/ShuttleEvent/ERTJaniSmall.yml
@@ -1,0 +1,2568 @@
+meta:
+  format: 6
+  postmapinit: false
+tilemap:
+  5: Space
+  7: FloorDark
+  6: FloorMetalDiamond
+  2: FloorSteelCheckerDark
+  4: Lattice
+  3: Plating
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: NT-Saviour
+    - type: Transform
+      pos: 0.5,0.5
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        0,0:
+          ind: 0,0
+          tiles: AgAAAAACAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAAAwAAAAAAAwAAAAAABgAAAAAAAwAAAAAAAwAAAAAABAAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABAAAAAAAAwAAAAAABwAAAAACBwAAAAADAwAAAAAABAAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAAAwAAAAAABwAAAAADBwAAAAACAwAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABAAAAAAAAwAAAAAAAwAAAAAABAAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAA
+          version: 6
+        0,-1:
+          ind: 0,-1
+          tiles: BQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABAAAAAAABAAAAAAABAAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAAAgAAAAABAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABwAAAAABBgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAA
+          version: 6
+        -1,0:
+          ind: -1,0
+          tiles: BQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABgAAAAAABwAAAAABAgAAAAADBwAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABAAAAAAABAAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAA
+          version: 6
+        -1,-1:
+          ind: -1,-1
+          tiles: BQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABAAAAAAABAAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAAAwAAAAAABwAAAAAAAgAAAAADBwAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAAAwAAAAAAAgAAAAADBwAAAAAAAgAAAAAA
+          version: 6
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: SpreaderGrid
+      updateAccumulator: 0.53744984
+    - type: Shuttle
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            angle: -1.5707963267948966 rad
+            color: '#FFFFFFFF'
+            id: Arrows
+          decals:
+            61: -1,-2
+        - node:
+            angle: 1.5707963267948966 rad
+            color: '#FFFFFFFF'
+            id: Bot
+          decals:
+            60: 0,-2
+        - node:
+            angle: 1.5707963267948966 rad
+            color: '#FFFFFFFF'
+            id: Delivery
+          decals:
+            59: 0,-1
+        - node:
+            cleanable: True
+            color: '#FFFFFFFF'
+            id: DirtHeavy
+          decals:
+            43: -2,0
+            67: 2,2
+            69: 2,-1
+        - node:
+            cleanable: True
+            color: '#FFFFFFFF'
+            id: DirtHeavyMonotile
+          decals:
+            44: -3,-1
+            47: -1,-1
+            48: 2,0
+            50: 3,3
+            62: -3,0
+            64: 0,-1
+            68: 3,2
+            71: 2,0
+            72: 3,0
+            73: 3,-2
+            74: -4,0
+            75: 1,-1
+            76: 2,1
+        - node:
+            cleanable: True
+            color: '#FFFFFFFF'
+            id: DirtLight
+          decals:
+            63: 0,-2
+            70: 2,-2
+        - node:
+            cleanable: True
+            color: '#FFFFFFFF'
+            id: DirtMedium
+          decals:
+            52: 0,0
+        - node:
+            color: '#9D9D97FF'
+            id: HalfTileOverlayGreyscale180
+          decals:
+            65: 2,2
+            66: 3,2
+        - node:
+            angle: 1.5707963267948966 rad
+            color: '#FFFFFFFF'
+            id: LoadingArea
+          decals:
+            58: -3,0
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnCornerSE
+          decals:
+            2: 3,-2
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnCornerSmallNW
+          decals:
+            5: 3,-2
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnEndN
+          decals:
+            1: 3,0
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnEndW
+          decals:
+            0: 2,-2
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineE
+          decals:
+            3: 3,-1
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineS
+          decals:
+            4: 3,-1
+    - type: GridAtmosphere
+      version: 2
+      data:
+        tiles:
+          0,0:
+            0: 52301
+            1: 256
+          0,-1:
+            0: 64768
+            1: 7
+          -1,0:
+            0: 15
+            1: 3072
+          0,1:
+            1: 2
+          1,1:
+            1: 1
+          1,0:
+            1: 546
+          -1,-1:
+            1: 28
+            0: 60928
+          1,-1:
+            1: 16
+        uniqueMixes:
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          immutable: True
+          moles:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+  - uid: 4
+    components:
+    - type: MetaData
+      name: solution - steel
+    - type: Transform
+      parent: 3
+    - type: Solution
+      solution:
+        maxVol: 10
+        name: steel
+        reagents:
+        - data: []
+          ReagentId: Iron
+          Quantity: 9
+        - data: []
+          ReagentId: Carbon
+          Quantity: 1
+    - type: ContainedSolution
+      containerName: steel
+      container: 3
+  - uid: 9
+    components:
+    - type: MetaData
+      name: solution - steel
+    - type: Transform
+      parent: 8
+    - type: Solution
+      solution:
+        maxVol: 10
+        name: steel
+        reagents:
+        - data: []
+          ReagentId: Iron
+          Quantity: 9
+        - data: []
+          ReagentId: Carbon
+          Quantity: 1
+    - type: ContainedSolution
+      containerName: steel
+      container: 8
+  - uid: 14
+    components:
+    - type: MetaData
+      name: solution - steel
+    - type: Transform
+      parent: 13
+    - type: Solution
+      solution:
+        maxVol: 10
+        name: steel
+        reagents:
+        - data: []
+          ReagentId: Iron
+          Quantity: 9
+        - data: []
+          ReagentId: Carbon
+          Quantity: 1
+    - type: ContainedSolution
+      containerName: steel
+      container: 13
+  - uid: 19
+    components:
+    - type: MetaData
+      name: solution - steel
+    - type: Transform
+      parent: 18
+    - type: Solution
+      solution:
+        maxVol: 10
+        name: steel
+        reagents:
+        - data: []
+          ReagentId: Iron
+          Quantity: 9
+        - data: []
+          ReagentId: Carbon
+          Quantity: 1
+    - type: ContainedSolution
+      containerName: steel
+      container: 18
+  - uid: 24
+    components:
+    - type: MetaData
+      name: solution - steel
+    - type: Transform
+      parent: 23
+    - type: Solution
+      solution:
+        maxVol: 10
+        name: steel
+        reagents:
+        - data: []
+          ReagentId: Iron
+          Quantity: 9
+        - data: []
+          ReagentId: Carbon
+          Quantity: 1
+    - type: ContainedSolution
+      containerName: steel
+      container: 23
+  - uid: 29
+    components:
+    - type: MetaData
+      name: solution - steel
+    - type: Transform
+      parent: 28
+    - type: Solution
+      solution:
+        maxVol: 10
+        name: steel
+        reagents:
+        - data: []
+          ReagentId: Iron
+          Quantity: 9
+        - data: []
+          ReagentId: Carbon
+          Quantity: 1
+    - type: ContainedSolution
+      containerName: steel
+      container: 28
+  - uid: 34
+    components:
+    - type: MetaData
+      name: solution - glass
+    - type: Transform
+      parent: 33
+    - type: Solution
+      solution:
+        maxVol: 10
+        name: glass
+        reagents:
+        - data: []
+          ReagentId: Silicon
+          Quantity: 10
+    - type: ContainedSolution
+      containerName: glass
+      container: 33
+  - uid: 39
+    components:
+    - type: MetaData
+      name: solution - tank
+    - type: Transform
+      parent: 38
+    - type: Solution
+      solution:
+        maxVol: 5000
+        name: tank
+        reagents:
+        - data: []
+          ReagentId: SpaceCleaner
+          Quantity: 5000
+    - type: ContainedSolution
+      containerName: tank
+      container: 38
+  - uid: 41
+    components:
+    - type: MetaData
+      name: solution - bucket
+    - type: Transform
+      parent: 40
+    - type: Solution
+      solution:
+        maxVol: 800
+        name: bucket
+        reagents:
+        - data: []
+          ReagentId: Water
+          Quantity: 600
+    - type: ContainedSolution
+      containerName: bucket
+      container: 40
+  - uid: 50
+    components:
+    - type: MetaData
+      name: solution - battery
+    - type: Transform
+      parent: 49
+    - type: Solution
+      solution:
+        maxVol: 5
+        name: battery
+        reagents: []
+    - type: ContainedSolution
+      containerName: battery
+      container: 49
+- proto: AdvMopItem
+  entities:
+  - uid: 53
+    components:
+    - type: Transform
+      pos: -2.026918,-1.4104509
+      parent: 1
+- proto: AirCanister
+  entities:
+  - uid: 54
+    components:
+    - type: Transform
+      pos: 2.5,-1.5
+      parent: 1
+- proto: AirlockCentralCommandLocked
+  entities:
+  - uid: 55
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-0.5
+      parent: 1
+    - type: WiresPanelSecurity
+      wiresAccessible: False
+      examine: wires-panel-component-on-examine-security-level2
+    - type: AccessReader
+      accessLog:
+      - accessor: Unknown
+        accessTime: 383.4647601
+      - accessor: Unknown
+        accessTime: 400.23141
+      - accessor: Unknown
+        accessTime: 408.5314017
+      - accessor: Unknown
+        accessTime: 415.2647283
+      - accessor: Unknown
+        accessTime: 423.1313871
+      - accessor: Unknown
+        accessTime: 1081.797395
+      - accessor: Unknown
+        accessTime: 1763.2967136
+      - accessor: Unknown
+        accessTime: 1856.5299537
+    - type: ContainerContainer
+      containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 56
+    - type: Airlock
+      powered: True
+    - type: DoorBolt
+      powered: True
+    - type: DeviceNetwork
+      address: 035C-4475
+      receiveFrequency: 1280
+    - type: Construction
+      node: medSecurity
+  - uid: 57
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,1.5
+      parent: 1
+    - type: WiresPanelSecurity
+      wiresAccessible: False
+      examine: wires-panel-component-on-examine-security-level2
+    - type: AccessReader
+      accessLog:
+      - accessor: Unknown
+        accessTime: 383.6980932
+      - accessor: Unknown
+        accessTime: 399.9314103
+      - accessor: Unknown
+        accessTime: 408.7647348
+      - accessor: Unknown
+        accessTime: 415.5980613
+      - accessor: Unknown
+        accessTime: 423.4647201
+      - accessor: Unknown
+        accessTime: 1082.0307282
+      - accessor: Unknown
+        accessTime: 1763.56338
+      - accessor: Unknown
+        accessTime: 1856.8632867
+    - type: ContainerContainer
+      containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 58
+    - type: Airlock
+      powered: True
+    - type: DoorBolt
+      powered: True
+    - type: DeviceNetwork
+      address: 56D0-AA7D
+      receiveFrequency: 1280
+    - type: Construction
+      node: medSecurity
+- proto: AirlockShuttle
+  entities:
+  - uid: 59
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,0.5
+      parent: 1
+    - type: AccessReader
+      accessLog:
+      - accessor: Unknown
+        accessTime: 1762.8300474
+      - accessor: Unknown
+        accessTime: 1857.3632862
+    - type: ContainerContainer
+      containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 60
+    - type: Airlock
+      powered: True
+    - type: DoorBolt
+      powered: True
+    - type: DeviceNetwork
+      address: 7C33-E23C
+      receiveFrequency: 1280
+- proto: APCHighCapacity
+  entities:
+  - uid: 61
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,2.5
+      parent: 1
+    - type: PowerNetworkBattery
+      loadingNetworkDemand: 7825
+      currentReceiving: 7825.0854
+      currentSupply: 7825
+  - uid: 62
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 1
+    - type: PowerNetworkBattery
+      loadingNetworkDemand: 4140
+      currentReceiving: 4140.004
+      currentSupply: 4140
+- proto: AtmosDeviceFanDirectional
+  entities:
+  - uid: 63
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,0.5
+      parent: 1
+- proto: BoxCleanerGrenades
+  entities:
+  - uid: 65
+    components:
+    - type: Transform
+      parent: 64
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 70
+    components:
+    - type: Transform
+      parent: 64
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: BoxLightbulb
+  entities:
+  - uid: 75
+    components:
+    - type: Transform
+      parent: 64
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 88
+    components:
+    - type: Transform
+      parent: 64
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: BoxLighttube
+  entities:
+  - uid: 101
+    components:
+    - type: Transform
+      parent: 64
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 114
+    components:
+    - type: Transform
+      parent: 64
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: CableApcExtension
+  entities:
+  - uid: 127
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 128
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 129
+    components:
+    - type: Transform
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 130
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 131
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 132
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 133
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 134
+    components:
+    - type: Transform
+      pos: -0.5,-0.5
+      parent: 1
+  - uid: 135
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 1
+  - uid: 136
+    components:
+    - type: Transform
+      pos: 2.5,-1.5
+      parent: 1
+  - uid: 137
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 1
+  - uid: 138
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 139
+    components:
+    - type: Transform
+      pos: 2.5,-0.5
+      parent: 1
+- proto: CableHV
+  entities:
+  - uid: 140
+    components:
+    - type: Transform
+      pos: 2.5,-1.5
+      parent: 1
+  - uid: 141
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 1
+  - uid: 142
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 143
+    components:
+    - type: Transform
+      pos: 3.5,-1.5
+      parent: 1
+- proto: CableMV
+  entities:
+  - uid: 144
+    components:
+    - type: Transform
+      pos: 2.5,-1.5
+      parent: 1
+  - uid: 145
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 1
+  - uid: 146
+    components:
+    - type: Transform
+      pos: 2.5,-0.5
+      parent: 1
+  - uid: 147
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 1
+  - uid: 148
+    components:
+    - type: Transform
+      pos: 1.5,-0.5
+      parent: 1
+  - uid: 149
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 150
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 151
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 152
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 1
+  - uid: 153
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 154
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 155
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 156
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 157
+    components:
+    - type: Transform
+      pos: -0.5,-0.5
+      parent: 1
+- proto: CapacitorStockPart
+  entities:
+  - uid: 5
+    components:
+    - type: Transform
+      parent: 2
+    - type: Stack
+      count: 4
+    - type: Physics
+      canCollide: False
+  - uid: 10
+    components:
+    - type: Transform
+      parent: 7
+    - type: Stack
+      count: 4
+    - type: Physics
+      canCollide: False
+  - uid: 15
+    components:
+    - type: Transform
+      parent: 12
+    - type: Stack
+      count: 4
+    - type: Physics
+      canCollide: False
+  - uid: 20
+    components:
+    - type: Transform
+      parent: 17
+    - type: Stack
+      count: 4
+    - type: Physics
+      canCollide: False
+  - uid: 25
+    components:
+    - type: Transform
+      parent: 22
+    - type: Stack
+      count: 4
+    - type: Physics
+      canCollide: False
+  - uid: 30
+    components:
+    - type: Transform
+      parent: 27
+    - type: Stack
+      count: 4
+    - type: Physics
+      canCollide: False
+  - uid: 35
+    components:
+    - type: Transform
+      parent: 32
+    - type: Physics
+      canCollide: False
+  - uid: 51
+    components:
+    - type: Transform
+      parent: 48
+    - type: Physics
+      canCollide: False
+- proto: Catwalk
+  entities:
+  - uid: 66
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-3.5
+      parent: 1
+  - uid: 67
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-3.5
+      parent: 1
+  - uid: 68
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-3.5
+      parent: 1
+  - uid: 69
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,1.5
+      parent: 1
+  - uid: 71
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 72
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,2.5
+      parent: 1
+  - uid: 158
+    components:
+    - type: Transform
+      pos: 2.5,-0.5
+      parent: 1
+  - uid: 159
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+- proto: ChairPilotSeat
+  entities:
+  - uid: 160
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,2.5
+      parent: 1
+- proto: CleanerDispenser
+  entities:
+  - uid: 38
+    components:
+    - type: Transform
+      pos: -0.5,1.5
+      parent: 1
+    - type: SolutionContainerManager
+      solutions: null
+      containers:
+      - tank
+    - type: ContainerContainer
+      containers:
+        solution@tank: !type:ContainerSlot
+          ent: 39
+- proto: ClosetWallMixed
+  entities:
+  - uid: 64
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.1461
+        moles:
+        - 1.7937167
+        - 6.773962
+        - 0.0069574933
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 114
+          - 88
+          - 70
+          - 75
+          - 65
+          - 101
+- proto: ComputerShuttle
+  entities:
+  - uid: 161
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 1
+    - type: PointLight
+      enabled: True
+    - type: ContainerContainer
+      containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 162
+        disk_slot: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+- proto: CrateTrashCartJani
+  entities:
+  - uid: 163
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 1
+    - type: AccessReader
+      accessLog:
+      - accessor: Unknown
+        accessTime: 939.0308712
+      - accessor: Unknown
+        accessTime: 941.3308689
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14606
+        moles:
+        - 1.3301911
+        - 5.004053
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+- proto: DisposalBend
+  entities:
+  - uid: 164
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-1.5
+      parent: 1
+- proto: DisposalPipe
+  entities:
+  - uid: 165
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-1.5
+      parent: 1
+  - uid: 166
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-1.5
+      parent: 1
+  - uid: 167
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 1
+- proto: DisposalTrunk
+  entities:
+  - uid: 168
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-1.5
+      parent: 1
+- proto: DisposalUnit
+  entities:
+  - uid: 169
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 1
+    - type: DisposalUnit
+      powered: True
+      air:
+        volume: 2500
+        immutable: False
+        temperature: 293.15
+        moles:
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+- proto: DoorElectronics
+  entities:
+  - uid: 60
+    components:
+    - type: Transform
+      parent: 59
+    - type: Physics
+      canCollide: False
+- proto: DoorElectronicsCentralCommand
+  entities:
+  - uid: 56
+    components:
+    - type: Transform
+      parent: 55
+    - type: Physics
+      canCollide: False
+  - uid: 58
+    components:
+    - type: Transform
+      parent: 57
+    - type: Physics
+      canCollide: False
+- proto: FaxMachineBase
+  entities:
+  - uid: 170
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+    - type: FaxMachine
+      name: NT-Saviour
+- proto: FloorDrain
+  entities:
+  - uid: 171
+    components:
+    - type: Transform
+      pos: -0.5,-0.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: GasPassiveVent
+  entities:
+  - uid: 85
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-3.5
+      parent: 1
+- proto: GasPipeBend
+  entities:
+  - uid: 77
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-0.5
+      parent: 1
+  - uid: 84
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-3.5
+      parent: 1
+- proto: GasPipeStraight
+  entities:
+  - uid: 78
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-0.5
+      parent: 1
+  - uid: 79
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-0.5
+      parent: 1
+  - uid: 80
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 81
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 82
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-1.5
+      parent: 1
+  - uid: 83
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-2.5
+      parent: 1
+- proto: GasPipeTJunction
+  entities:
+  - uid: 76
+    components:
+    - type: Transform
+      pos: -0.5,-0.5
+      parent: 1
+- proto: GasVentScrubber
+  entities:
+  - uid: 73
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-0.5
+      parent: 1
+  - uid: 74
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
+- proto: GeneratorBasic15kW
+  entities:
+  - uid: 172
+    components:
+    - type: Transform
+      pos: 3.5,-1.5
+      parent: 1
+    - type: PowerSupplier
+      supplyRampPosition: 11966.262
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 173
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+- proto: Grille
+  entities:
+  - uid: 174
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-0.5
+      parent: 1
+  - uid: 175
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 176
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 177
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 178
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 179
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-2.5
+      parent: 1
+- proto: GrilleDiagonal
+  entities:
+  - uid: 180
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 181
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,4.5
+      parent: 1
+- proto: Gyroscope
+  entities:
+  - uid: 32
+    components:
+    - type: Transform
+      pos: 3.5,-0.5
+      parent: 1
+    - type: PointLight
+      enabled: True
+    - type: ContainerContainer
+      containers:
+        machine_board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 36
+        machine_parts: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 37
+          - 35
+          - 33
+- proto: GyroscopeMachineCircuitboard
+  entities:
+  - uid: 36
+    components:
+    - type: Transform
+      parent: 32
+    - type: Physics
+      canCollide: False
+- proto: JanitorialTrolley
+  entities:
+  - uid: 40
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-1.5
+      parent: 1
+    - type: SolutionContainerManager
+      solutions: null
+      containers:
+      - bucket
+    - type: ContainerContainer
+      containers:
+        storagebase: !type:Container
+          showEnts: False
+          occludes: True
+          ents: []
+        mop_slot: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+        trashbag_slot: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: 43
+        bucket_slot: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+        plunger_slot: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: 42
+        wetfloorsign_slot4: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: 44
+        wetfloorsign_slot3: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: 45
+        wetfloorsign_slot2: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: 46
+        wetfloorsign_slot1: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: 47
+        lightreplacer_slot: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+        spraybottle_slot: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+        solution@bucket: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: 41
+    - type: Pullable
+      prevFixedRotation: True
+- proto: LightBulb
+  entities:
+  - uid: 186
+    components:
+    - type: Transform
+      parent: 185
+    - type: Physics
+      canCollide: False
+  - uid: 187
+    components:
+    - type: Transform
+      parent: 185
+    - type: Physics
+      canCollide: False
+  - uid: 188
+    components:
+    - type: Transform
+      parent: 185
+    - type: Physics
+      canCollide: False
+  - uid: 189
+    components:
+    - type: Transform
+      parent: 185
+    - type: Physics
+      canCollide: False
+  - uid: 190
+    components:
+    - type: Transform
+      parent: 185
+    - type: Physics
+      canCollide: False
+  - uid: 191
+    components:
+    - type: Transform
+      parent: 185
+    - type: Physics
+      canCollide: False
+  - uid: 192
+    components:
+    - type: Transform
+      parent: 185
+    - type: Physics
+      canCollide: False
+  - uid: 193
+    components:
+    - type: Transform
+      parent: 185
+    - type: Physics
+      canCollide: False
+  - uid: 194
+    components:
+    - type: Transform
+      parent: 185
+    - type: Physics
+      canCollide: False
+  - uid: 195
+    components:
+    - type: Transform
+      parent: 185
+    - type: Physics
+      canCollide: False
+  - uid: 196
+    components:
+    - type: Transform
+      parent: 185
+    - type: Physics
+      canCollide: False
+  - uid: 197
+    components:
+    - type: Transform
+      parent: 185
+    - type: Physics
+      canCollide: False
+  - uid: 198
+    components:
+    - type: Transform
+      parent: 185
+    - type: Physics
+      canCollide: False
+  - uid: 199
+    components:
+    - type: Transform
+      parent: 185
+    - type: Physics
+      canCollide: False
+  - uid: 200
+    components:
+    - type: Transform
+      parent: 185
+    - type: Physics
+      canCollide: False
+  - uid: 201
+    components:
+    - type: Transform
+      parent: 185
+    - type: Physics
+      canCollide: False
+  - uid: 202
+    components:
+    - type: Transform
+      parent: 185
+    - type: Physics
+      canCollide: False
+- proto: LightReplacer
+  entities:
+  - uid: 185
+    components:
+    - type: Transform
+      rot: 6.283185307179586 rad
+      pos: -1.3706677,-1.3948157
+      parent: 1
+    - type: ContainerContainer
+      containers:
+        light_replacer_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 203
+          - 204
+          - 205
+          - 206
+          - 207
+          - 208
+          - 209
+          - 210
+          - 186
+          - 187
+          - 188
+          - 189
+          - 190
+          - 191
+          - 192
+          - 193
+          - 194
+          - 195
+          - 196
+          - 197
+          - 198
+          - 199
+          - 200
+          - 201
+          - 202
+          - 211
+          - 212
+          - 213
+          - 214
+          - 215
+          - 216
+          - 217
+          - 218
+          - 219
+          - 220
+          - 221
+          - 222
+    - type: Physics
+      canCollide: False
+- proto: LightTube
+  entities:
+  - uid: 203
+    components:
+    - type: Transform
+      parent: 185
+    - type: Physics
+      canCollide: False
+  - uid: 204
+    components:
+    - type: Transform
+      parent: 185
+    - type: Physics
+      canCollide: False
+  - uid: 205
+    components:
+    - type: Transform
+      parent: 185
+    - type: Physics
+      canCollide: False
+  - uid: 206
+    components:
+    - type: Transform
+      parent: 185
+    - type: Physics
+      canCollide: False
+  - uid: 207
+    components:
+    - type: Transform
+      parent: 185
+    - type: Physics
+      canCollide: False
+  - uid: 208
+    components:
+    - type: Transform
+      parent: 185
+    - type: Physics
+      canCollide: False
+  - uid: 209
+    components:
+    - type: Transform
+      parent: 185
+    - type: Physics
+      canCollide: False
+  - uid: 210
+    components:
+    - type: Transform
+      parent: 185
+    - type: Physics
+      canCollide: False
+  - uid: 211
+    components:
+    - type: Transform
+      parent: 185
+    - type: Physics
+      canCollide: False
+  - uid: 212
+    components:
+    - type: Transform
+      parent: 185
+    - type: Physics
+      canCollide: False
+  - uid: 213
+    components:
+    - type: Transform
+      parent: 185
+    - type: Physics
+      canCollide: False
+  - uid: 214
+    components:
+    - type: Transform
+      parent: 185
+    - type: Physics
+      canCollide: False
+  - uid: 215
+    components:
+    - type: Transform
+      parent: 185
+    - type: Physics
+      canCollide: False
+  - uid: 216
+    components:
+    - type: Transform
+      parent: 185
+    - type: Physics
+      canCollide: False
+  - uid: 217
+    components:
+    - type: Transform
+      parent: 185
+    - type: Physics
+      canCollide: False
+  - uid: 218
+    components:
+    - type: Transform
+      parent: 185
+    - type: Physics
+      canCollide: False
+  - uid: 219
+    components:
+    - type: Transform
+      parent: 185
+    - type: Physics
+      canCollide: False
+  - uid: 220
+    components:
+    - type: Transform
+      parent: 185
+    - type: Physics
+      canCollide: False
+  - uid: 221
+    components:
+    - type: Transform
+      parent: 185
+    - type: Physics
+      canCollide: False
+  - uid: 222
+    components:
+    - type: Transform
+      parent: 185
+    - type: Physics
+      canCollide: False
+- proto: MegaSprayBottle
+  entities:
+  - uid: 224
+    components:
+    - type: Transform
+      pos: -2.542543,-1.4260874
+      parent: 1
+- proto: MicroManipulatorStockPart
+  entities:
+  - uid: 37
+    components:
+    - type: Transform
+      parent: 32
+    - type: Stack
+      count: 2
+    - type: Physics
+      canCollide: False
+- proto: Plunger
+  entities:
+  - uid: 42
+    components:
+    - type: Transform
+      parent: 40
+    - type: Physics
+      canCollide: False
+- proto: PowerCellSmall
+  entities:
+  - uid: 49
+    components:
+    - type: Transform
+      parent: 48
+    - type: SolutionContainerManager
+      solutions: null
+      containers:
+      - battery
+    - type: Physics
+      canCollide: False
+    - type: ContainerContainer
+      containers:
+        solution@battery: !type:ContainerSlot
+          ent: 50
+- proto: Poweredlight
+  entities:
+  - uid: 223
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,2.5
+      parent: 1
+- proto: PoweredSmallLight
+  entities:
+  - uid: 182
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 183
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 184
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-1.5
+      parent: 1
+- proto: RandomHumanoidSpawnerERTJanitorEVA
+  entities:
+  - uid: 86
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
+- proto: SheetGlass1
+  entities:
+  - uid: 33
+    components:
+    - type: Transform
+      parent: 32
+    - type: Stack
+      count: 2
+    - type: SolutionContainerManager
+      solutions: null
+      containers:
+      - glass
+    - type: Physics
+      canCollide: False
+    - type: ContainerContainer
+      containers:
+        solution@glass: !type:ContainerSlot
+          ent: 34
+- proto: SheetSteel1
+  entities:
+  - uid: 3
+    components:
+    - type: Transform
+      parent: 2
+    - type: Stack
+      count: 5
+    - type: SolutionContainerManager
+      solutions: null
+      containers:
+      - steel
+    - type: Physics
+      canCollide: False
+    - type: ContainerContainer
+      containers:
+        solution@steel: !type:ContainerSlot
+          ent: 4
+  - uid: 8
+    components:
+    - type: Transform
+      parent: 7
+    - type: Stack
+      count: 5
+    - type: SolutionContainerManager
+      solutions: null
+      containers:
+      - steel
+    - type: Physics
+      canCollide: False
+    - type: ContainerContainer
+      containers:
+        solution@steel: !type:ContainerSlot
+          ent: 9
+  - uid: 13
+    components:
+    - type: Transform
+      parent: 12
+    - type: Stack
+      count: 5
+    - type: SolutionContainerManager
+      solutions: null
+      containers:
+      - steel
+    - type: Physics
+      canCollide: False
+    - type: ContainerContainer
+      containers:
+        solution@steel: !type:ContainerSlot
+          ent: 14
+  - uid: 18
+    components:
+    - type: Transform
+      parent: 17
+    - type: Stack
+      count: 5
+    - type: SolutionContainerManager
+      solutions: null
+      containers:
+      - steel
+    - type: Physics
+      canCollide: False
+    - type: ContainerContainer
+      containers:
+        solution@steel: !type:ContainerSlot
+          ent: 19
+  - uid: 23
+    components:
+    - type: Transform
+      parent: 22
+    - type: Stack
+      count: 5
+    - type: SolutionContainerManager
+      solutions: null
+      containers:
+      - steel
+    - type: Physics
+      canCollide: False
+    - type: ContainerContainer
+      containers:
+        solution@steel: !type:ContainerSlot
+          ent: 24
+  - uid: 28
+    components:
+    - type: Transform
+      parent: 27
+    - type: Stack
+      count: 5
+    - type: SolutionContainerManager
+      solutions: null
+      containers:
+      - steel
+    - type: Physics
+      canCollide: False
+    - type: ContainerContainer
+      containers:
+        solution@steel: !type:ContainerSlot
+          ent: 29
+- proto: ShuttleConsoleCircuitboard
+  entities:
+  - uid: 162
+    components:
+    - type: Transform
+      parent: 161
+    - type: Physics
+      canCollide: False
+- proto: ShuttleWindow
+  entities:
+  - uid: 225
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-2.5
+      parent: 1
+  - uid: 226
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 227
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 228
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 229
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 230
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-0.5
+      parent: 1
+- proto: ShuttleWindowDiagonal
+  entities:
+  - uid: 231
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 232
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,4.5
+      parent: 1
+- proto: SignBio
+  entities:
+  - uid: 233
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 1
+- proto: SignElectricalMed
+  entities:
+  - uid: 234
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+- proto: SignJanitor
+  entities:
+  - uid: 235
+    components:
+    - type: Transform
+      pos: -3.5,-0.5
+      parent: 1
+- proto: SinkWide
+  entities:
+  - uid: 236
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 1
+- proto: Stool
+  entities:
+  - uid: 237
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 1
+- proto: SubstationWallBasic
+  entities:
+  - uid: 48
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-2.5
+      parent: 1
+    - type: ContainerContainer
+      containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 52
+        capacitor: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 51
+        powercell: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 49
+    - type: PowerNetworkBattery
+      loadingNetworkDemand: 11965.09
+      currentReceiving: 11966.262
+      currentSupply: 11965.09
+- proto: Table
+  entities:
+  - uid: 238
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-1.5
+      parent: 1
+  - uid: 239
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 240
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 1
+- proto: TableReinforced
+  entities:
+  - uid: 241
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+- proto: Thruster
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 1
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PolygonShape
+            radius: 0.01
+            vertices:
+            - -0.45,-0.45
+            - 0.45,-0.45
+            - 0.45,0.45
+            - -0.45,0.45
+          mask:
+          - Impassable
+          - TableLayer
+          - LowImpassable
+          layer:
+          - TableLayer
+          - LowImpassable
+          - BulletImpassable
+          - Opaque
+          density: 60
+          hard: True
+          restitution: 0
+          friction: 0.4
+        thruster-burn:
+          shape: !type:PolygonShape
+            radius: 0.01
+            vertices:
+            - -0.4,0.5
+            - 0.4,0.5
+            - 0.1,1.2
+            - -0.1,1.2
+          mask: []
+          layer:
+          - Impassable
+          - TableLayer
+          - HighImpassable
+          - LowImpassable
+          - InteractImpassable
+          density: 1
+          hard: False
+          restitution: 0
+          friction: 0.4
+    - type: ContainerContainer
+      containers:
+        machine_board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 6
+        machine_parts: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 5
+          - 3
+  - uid: 7
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PolygonShape
+            radius: 0.01
+            vertices:
+            - -0.45,-0.45
+            - 0.45,-0.45
+            - 0.45,0.45
+            - -0.45,0.45
+          mask:
+          - Impassable
+          - TableLayer
+          - LowImpassable
+          layer:
+          - TableLayer
+          - LowImpassable
+          - BulletImpassable
+          - Opaque
+          density: 60
+          hard: True
+          restitution: 0
+          friction: 0.4
+        thruster-burn:
+          shape: !type:PolygonShape
+            radius: 0.01
+            vertices:
+            - -0.4,0.5
+            - 0.4,0.5
+            - 0.1,1.2
+            - -0.1,1.2
+          mask: []
+          layer:
+          - Impassable
+          - TableLayer
+          - HighImpassable
+          - LowImpassable
+          - InteractImpassable
+          density: 1
+          hard: False
+          restitution: 0
+          friction: 0.4
+    - type: ContainerContainer
+      containers:
+        machine_board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 11
+        machine_parts: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 10
+          - 8
+  - uid: 12
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-3.5
+      parent: 1
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PolygonShape
+            radius: 0.01
+            vertices:
+            - -0.45,-0.45
+            - 0.45,-0.45
+            - 0.45,0.45
+            - -0.45,0.45
+          mask:
+          - Impassable
+          - TableLayer
+          - LowImpassable
+          layer:
+          - TableLayer
+          - LowImpassable
+          - BulletImpassable
+          - Opaque
+          density: 60
+          hard: True
+          restitution: 0
+          friction: 0.4
+        thruster-burn:
+          shape: !type:PolygonShape
+            radius: 0.01
+            vertices:
+            - -0.4,0.5
+            - 0.4,0.5
+            - 0.1,1.2
+            - -0.1,1.2
+          mask: []
+          layer:
+          - Impassable
+          - TableLayer
+          - HighImpassable
+          - LowImpassable
+          - InteractImpassable
+          density: 1
+          hard: False
+          restitution: 0
+          friction: 0.4
+    - type: ContainerContainer
+      containers:
+        machine_board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 16
+        machine_parts: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 15
+          - 13
+  - uid: 17
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-3.5
+      parent: 1
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PolygonShape
+            radius: 0.01
+            vertices:
+            - -0.45,-0.45
+            - 0.45,-0.45
+            - 0.45,0.45
+            - -0.45,0.45
+          mask:
+          - Impassable
+          - TableLayer
+          - LowImpassable
+          layer:
+          - TableLayer
+          - LowImpassable
+          - BulletImpassable
+          - Opaque
+          density: 60
+          hard: True
+          restitution: 0
+          friction: 0.4
+        thruster-burn:
+          shape: !type:PolygonShape
+            radius: 0.01
+            vertices:
+            - -0.4,0.5
+            - 0.4,0.5
+            - 0.1,1.2
+            - -0.1,1.2
+          mask: []
+          layer:
+          - Impassable
+          - TableLayer
+          - HighImpassable
+          - LowImpassable
+          - InteractImpassable
+          density: 1
+          hard: False
+          restitution: 0
+          friction: 0.4
+    - type: ContainerContainer
+      containers:
+        machine_board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 21
+        machine_parts: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 20
+          - 18
+  - uid: 22
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,1.5
+      parent: 1
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PolygonShape
+            radius: 0.01
+            vertices:
+            - -0.45,-0.45
+            - 0.45,-0.45
+            - 0.45,0.45
+            - -0.45,0.45
+          mask:
+          - Impassable
+          - TableLayer
+          - LowImpassable
+          layer:
+          - TableLayer
+          - LowImpassable
+          - BulletImpassable
+          - Opaque
+          density: 60
+          hard: True
+          restitution: 0
+          friction: 0.4
+        thruster-burn:
+          shape: !type:PolygonShape
+            radius: 0.01
+            vertices:
+            - -0.4,0.5
+            - 0.4,0.5
+            - 0.1,1.2
+            - -0.1,1.2
+          mask: []
+          layer:
+          - Impassable
+          - TableLayer
+          - HighImpassable
+          - LowImpassable
+          - InteractImpassable
+          density: 1
+          hard: False
+          restitution: 0
+          friction: 0.4
+    - type: ContainerContainer
+      containers:
+        machine_board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 26
+        machine_parts: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 25
+          - 23
+  - uid: 27
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-3.5
+      parent: 1
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PolygonShape
+            radius: 0.01
+            vertices:
+            - -0.45,-0.45
+            - 0.45,-0.45
+            - 0.45,0.45
+            - -0.45,0.45
+          mask:
+          - Impassable
+          - TableLayer
+          - LowImpassable
+          layer:
+          - TableLayer
+          - LowImpassable
+          - BulletImpassable
+          - Opaque
+          density: 60
+          hard: True
+          restitution: 0
+          friction: 0.4
+        thruster-burn:
+          shape: !type:PolygonShape
+            radius: 0.01
+            vertices:
+            - -0.4,0.5
+            - 0.4,0.5
+            - 0.1,1.2
+            - -0.1,1.2
+          mask: []
+          layer:
+          - Impassable
+          - TableLayer
+          - HighImpassable
+          - LowImpassable
+          - InteractImpassable
+          density: 1
+          hard: False
+          restitution: 0
+          friction: 0.4
+    - type: ContainerContainer
+      containers:
+        machine_board: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 31
+        machine_parts: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 30
+          - 28
+- proto: ThrusterMachineCircuitboard
+  entities:
+  - uid: 6
+    components:
+    - type: Transform
+      parent: 2
+    - type: Physics
+      canCollide: False
+  - uid: 11
+    components:
+    - type: Transform
+      parent: 7
+    - type: Physics
+      canCollide: False
+  - uid: 16
+    components:
+    - type: Transform
+      parent: 12
+    - type: Physics
+      canCollide: False
+  - uid: 21
+    components:
+    - type: Transform
+      parent: 17
+    - type: Physics
+      canCollide: False
+  - uid: 26
+    components:
+    - type: Transform
+      parent: 22
+    - type: Physics
+      canCollide: False
+  - uid: 31
+    components:
+    - type: Transform
+      parent: 27
+    - type: Physics
+      canCollide: False
+- proto: TrashBag
+  entities:
+  - uid: 43
+    components:
+    - type: Transform
+      parent: 40
+    - type: UseDelay
+      delays:
+        default:
+          endTime: 0
+          startTime: 0
+          length: 0.5
+        quickInsert:
+          endTime: 0
+          startTime: 0
+          length: 0.5
+        storage:
+          endTime: 0
+          startTime: 0
+          length: 0
+    - type: Physics
+      canCollide: False
+- proto: WallmountSubstationElectronics
+  entities:
+  - uid: 52
+    components:
+    - type: Transform
+      parent: 48
+    - type: Physics
+      canCollide: False
+- proto: WallShuttle
+  entities:
+  - uid: 242
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 243
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-2.5
+      parent: 1
+  - uid: 244
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 245
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 1
+  - uid: 246
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 247
+    components:
+    - type: Transform
+      pos: -0.5,1.5
+      parent: 1
+  - uid: 248
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 249
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 250
+    components:
+    - type: Transform
+      pos: 4.5,1.5
+      parent: 1
+  - uid: 251
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 1
+  - uid: 252
+    components:
+    - type: Transform
+      pos: 4.5,2.5
+      parent: 1
+  - uid: 253
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 1
+  - uid: 254
+    components:
+    - type: Transform
+      pos: -0.5,-2.5
+      parent: 1
+  - uid: 255
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 1
+  - uid: 256
+    components:
+    - type: Transform
+      pos: 1.5,-1.5
+      parent: 1
+  - uid: 257
+    components:
+    - type: Transform
+      pos: 1.5,-2.5
+      parent: 1
+  - uid: 258
+    components:
+    - type: Transform
+      pos: 3.5,-2.5
+      parent: 1
+  - uid: 259
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 260
+    components:
+    - type: Transform
+      pos: 4.5,-1.5
+      parent: 1
+  - uid: 261
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-3.5
+      parent: 1
+  - uid: 262
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-0.5
+      parent: 1
+  - uid: 263
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,1.5
+      parent: 1
+  - uid: 264
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-1.5
+      parent: 1
+- proto: WallShuttleDiagonal
+  entities:
+  - uid: 265
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 1
+  - uid: 266
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-2.5
+      parent: 1
+  - uid: 267
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,2.5
+      parent: 1
+  - uid: 268
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,0.5
+      parent: 1
+  - uid: 269
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-3.5
+      parent: 1
+  - uid: 270
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-2.5
+      parent: 1
+- proto: WetFloorSign
+  entities:
+  - uid: 44
+    components:
+    - type: Transform
+      parent: 40
+    - type: Physics
+      canCollide: False
+  - uid: 45
+    components:
+    - type: Transform
+      parent: 40
+    - type: Physics
+      canCollide: False
+  - uid: 46
+    components:
+    - type: Transform
+      parent: 40
+    - type: Physics
+      canCollide: False
+  - uid: 47
+    components:
+    - type: Transform
+      parent: 40
+    - type: Physics
+      canCollide: False
+...

--- a/Resources/Maps/_Harmony/Shuttles/ShuttleEvent/ERTMedMedium.yml
+++ b/Resources/Maps/_Harmony/Shuttles/ShuttleEvent/ERTMedMedium.yml
@@ -1,0 +1,4294 @@
+meta:
+  format: 6
+  postmapinit: false
+tilemap:
+  0: Space
+  23: FloorDark
+  22: FloorDarkMono
+  20: FloorGrayConcreteMono
+  15: FloorSteel
+  26: FloorSteelMono
+  18: FloorTechMaint
+  25: FloorWhiteMini
+  19: FloorWhiteMono
+  24: FloorWhitePavement
+  27: FloorWhitePavementVertical
+  21: FloorWhitePlastic
+  17: Lattice
+  16: Plating
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: NT-Asclepius
+    - type: Transform
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        -1,0:
+          ind: -1,0
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwAAAAADEgAAAAAAFAAAAAABFAAAAAACFgAAAAACDwAAAAAAEwAAAAADEwAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwAAAAADEgAAAAAAEgAAAAAAEgAAAAAADwAAAAAADwAAAAACGAAAAAAAGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwAAAAADDwAAAAADDwAAAAABDwAAAAABDwAAAAACDwAAAAAADwAAAAABDwAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAEwAAAAADFQAAAAADFQAAAAACEwAAAAACDwAAAAABDwAAAAABEwAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwAAAAABEwAAAAABFQAAAAABEwAAAAAADwAAAAABDwAAAAABDwAAAAACEwAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAEwAAAAABFQAAAAABEwAAAAADEAAAAAAADwAAAAAADwAAAAACEwAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAEwAAAAAAFQAAAAABEwAAAAAAEAAAAAAADwAAAAABDwAAAAAAEwAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwAAAAAADwAAAAADEwAAAAABDwAAAAADDwAAAAADDwAAAAAADwAAAAACDwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwAAAAAADwAAAAACDwAAAAABDwAAAAAADwAAAAACDwAAAAADEAAAAAAAGQAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwAAAAAADwAAAAACDwAAAAADDwAAAAACDwAAAAADDwAAAAADEAAAAAAAGQAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEQAAAAAADwAAAAAADwAAAAABFgAAAAACDwAAAAAADwAAAAADDwAAAAACGQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEQAAAAAADwAAAAABFgAAAAAAFwAAAAAAFwAAAAADDwAAAAAAGQAAAAABGQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEQAAAAAAEAAAAAAAFgAAAAAAFwAAAAADFwAAAAAAEAAAAAAAGQAAAAADGQAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAEAAAAAAAFgAAAAADFgAAAAAAEAAAAAAAGQAAAAADGQAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAADwAAAAADEAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          version: 6
+        -1,-1:
+          ind: -1,-1
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEQAAAAAAEQAAAAAADwAAAAABDwAAAAADDwAAAAADDwAAAAAADwAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEQAAAAAADwAAAAACDwAAAAAADwAAAAABFwAAAAABFwAAAAACFwAAAAAADwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwAAAAACDwAAAAABEQAAAAAADwAAAAABFwAAAAAAFwAAAAABFwAAAAAAEwAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwAAAAABEgAAAAAAEgAAAAAADwAAAAACDwAAAAAADwAAAAABDwAAAAADDwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwAAAAABEgAAAAAAFAAAAAABFAAAAAADDwAAAAAADwAAAAADDwAAAAABGgAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwAAAAADEgAAAAAAFAAAAAABFAAAAAACDwAAAAABDwAAAAABDwAAAAACDwAAAAAC
+          version: 6
+        0,-1:
+          ind: 0,-1
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEQAAAAAAEQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwAAAAAADwAAAAAAEQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEwAAAAABDwAAAAADDwAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwAAAAAADwAAAAABDwAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwAAAAAADwAAAAAADwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwAAAAACDwAAAAAADwAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          version: 6
+        0,0:
+          ind: 0,0
+          tiles: EwAAAAADEwAAAAADDwAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGAAAAAACGAAAAAADDwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEwAAAAAADwAAAAACDwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGwAAAAABEwAAAAACEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGwAAAAAAEwAAAAABDwAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGwAAAAADEwAAAAADEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGwAAAAADEwAAAAADEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGwAAAAACDwAAAAADDwAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGQAAAAACGQAAAAACDwAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGQAAAAABDwAAAAACDwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGQAAAAABDwAAAAAAEQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGQAAAAABDwAAAAABEQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGQAAAAABEAAAAAAAEQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          version: 6
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            color: '#D4D4D496'
+            id: Arrows
+          decals:
+            75: 0,-3
+        - node:
+            color: '#FFFFFFFF'
+            id: Bot
+          decals:
+            134: -5,8
+        - node:
+            color: '#52B4E996'
+            id: BotLeftGreyscale
+          decals:
+            73: -1,0
+        - node:
+            color: '#334E6DC8'
+            id: BrickTileWhiteCornerNe
+          decals:
+            103: -4,13
+        - node:
+            color: '#52B4E996'
+            id: BrickTileWhiteCornerNe
+          decals:
+            14: 1,-1
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileWhiteCornerNe
+          decals:
+            31: -2,-4
+        - node:
+            color: '#334E6DC8'
+            id: BrickTileWhiteCornerNw
+          decals:
+            104: -5,13
+        - node:
+            color: '#52B4E996'
+            id: BrickTileWhiteCornerNw
+          decals:
+            22: -3,-1
+        - node:
+            color: '#52B4E9A4'
+            id: BrickTileWhiteCornerNw
+          decals:
+            80: -2,1
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileWhiteCornerNw
+          decals:
+            29: -4,-4
+        - node:
+            color: '#334E6DC8'
+            id: BrickTileWhiteCornerSe
+          decals:
+            105: -4,11
+        - node:
+            color: '#52B4E996'
+            id: BrickTileWhiteCornerSe
+          decals:
+            15: 1,-3
+        - node:
+            color: '#D4D4D428'
+            id: BrickTileWhiteCornerSe
+          decals:
+            82: -8,-4
+        - node:
+            color: '#F9FFFEFF'
+            id: BrickTileWhiteCornerSe
+          decals:
+            86: -2,-5
+        - node:
+            color: '#334E6DC8'
+            id: BrickTileWhiteCornerSw
+          decals:
+            106: -5,11
+        - node:
+            color: '#52B4E996'
+            id: BrickTileWhiteCornerSw
+          decals:
+            21: -3,-3
+            61: -6,3
+        - node:
+            color: '#52B4E9A4'
+            id: BrickTileWhiteCornerSw
+          decals:
+            81: -2,0
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileWhiteCornerSw
+          decals:
+            30: -4,-5
+        - node:
+            color: '#52B4E996'
+            id: BrickTileWhiteEndE
+          decals:
+            60: -5,3
+        - node:
+            color: '#52B4E996'
+            id: BrickTileWhiteEndN
+          decals:
+            63: -6,6
+        - node:
+            color: '#52B4E996'
+            id: BrickTileWhiteInnerNe
+          decals:
+            62: -6,3
+        - node:
+            color: '#334E6DC8'
+            id: BrickTileWhiteLineE
+          decals:
+            102: -4,12
+        - node:
+            color: '#52B4E996'
+            id: BrickTileWhiteLineE
+          decals:
+            18: 1,-2
+            58: -6,5
+            59: -6,4
+        - node:
+            color: '#52B4E996'
+            id: BrickTileWhiteLineN
+          decals:
+            16: 0,-1
+            28: -2,-1
+            83: 1,1
+            115: -1,-1
+        - node:
+            color: '#52B4E9A4'
+            id: BrickTileWhiteLineN
+          decals:
+            76: -1,1
+            77: 0,1
+        - node:
+            color: '#FFFFFFE7'
+            id: BrickTileWhiteLineN
+          decals:
+            37: -3,-4
+        - node:
+            color: '#52B4E996'
+            id: BrickTileWhiteLineS
+          decals:
+            19: 0,-3
+            26: -2,-3
+            27: -1,-3
+        - node:
+            color: '#52B4E9A4'
+            id: BrickTileWhiteLineS
+          decals:
+            78: -1,0
+            79: 0,0
+        - node:
+            color: '#FFFFFFE7'
+            id: BrickTileWhiteLineS
+          decals:
+            36: -3,-5
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileWhiteLineS
+          decals:
+            48: 0,2
+        - node:
+            color: '#334E6DC8'
+            id: BrickTileWhiteLineW
+          decals:
+            101: -5,12
+        - node:
+            color: '#52B4E996'
+            id: BrickTileWhiteLineW
+          decals:
+            23: -3,-2
+            56: -6,4
+            57: -6,5
+        - node:
+            color: '#52B4E992'
+            id: CheckerNESW
+          decals:
+            51: -3,7
+        - node:
+            color: '#52B4E996'
+            id: CheckerNESW
+          decals:
+            1: -3,9
+            2: -4,8
+            3: -6,8
+            5: -5,9
+            11: -3,1
+            12: -3,3
+            13: -3,5
+        - node:
+            color: '#52B4E996'
+            id: CheckerNWSE
+          decals:
+            0: -3,8
+            4: -5,8
+            6: -6,9
+            7: -4,9
+            8: -3,4
+            9: -3,2
+            10: -3,0
+        - node:
+            color: '#52B4E998'
+            id: CheckerNWSE
+          decals:
+            50: -3,6
+        - node:
+            color: '#EFB34196'
+            id: ConcreteTrimCornerNe
+          decals:
+            114: -5,0
+        - node:
+            color: '#EFB34196'
+            id: ConcreteTrimCornerNw
+          decals:
+            109: -6,0
+        - node:
+            color: '#EFB34196'
+            id: ConcreteTrimCornerSe
+          decals:
+            111: -5,-2
+        - node:
+            color: '#EFB34196'
+            id: ConcreteTrimCornerSw
+          decals:
+            110: -6,-2
+        - node:
+            color: '#EFB34196'
+            id: ConcreteTrimLineE
+          decals:
+            112: -5,-1
+        - node:
+            color: '#EFB34196'
+            id: ConcreteTrimLineW
+          decals:
+            113: -6,-1
+        - node:
+            angle: 4.71238898038469 rad
+            color: '#FFFFFFFF'
+            id: Delivery
+          decals:
+            97: -4,-6
+            98: -2,-6
+            99: 2,-3
+            100: 2,-1
+        - node:
+            color: '#52B4E996'
+            id: DeliveryGreyscale
+          decals:
+            71: 1,4
+        - node:
+            color: '#334E6DC8'
+            id: FullTileOverlayGreyscale
+          decals:
+            107: -6,12
+            108: -6,11
+        - node:
+            color: '#52B4E9A4'
+            id: FullTileOverlayGreyscale
+          decals:
+            72: -7,8
+        - node:
+            color: '#1D1D217F'
+            id: HalfTileOverlayGreyscale
+          decals:
+            85: -3,-5
+        - node:
+            color: '#52B4E996'
+            id: HalfTileOverlayGreyscale
+          decals:
+            25: -1,-3
+        - node:
+            color: '#D4D4D496'
+            id: HalfTileOverlayGreyscale
+          decals:
+            39: -3,-5
+        - node:
+            color: '#D4D4D4C1'
+            id: HalfTileOverlayGreyscale
+          decals:
+            40: -3,-5
+        - node:
+            color: '#1D1D217F'
+            id: HalfTileOverlayGreyscale180
+          decals:
+            84: -3,-4
+        - node:
+            color: '#52B4E996'
+            id: HalfTileOverlayGreyscale180
+          decals:
+            116: -1,-1
+        - node:
+            color: '#D4D4D496'
+            id: HalfTileOverlayGreyscale180
+          decals:
+            38: -3,-4
+        - node:
+            color: '#D4D4D4C1'
+            id: HalfTileOverlayGreyscale180
+          decals:
+            41: -3,-4
+        - node:
+            color: '#52B4E996'
+            id: HalfTileOverlayGreyscale270
+          decals:
+            24: 0,-2
+        - node:
+            color: '#52B4E996'
+            id: HalfTileOverlayGreyscale90
+          decals:
+            45: -2,-2
+        - node:
+            angle: 3.141592653589793 rad
+            color: '#FFFFFFFF'
+            id: LoadingArea
+          decals:
+            32: -4,-5
+            46: -4,-5
+            93: -4,-5
+            94: -2,-5
+        - node:
+            angle: 4.71238898038469 rad
+            color: '#FFFFFFFF'
+            id: LoadingArea
+          decals:
+            95: 1,-1
+            96: 1,-3
+        - node:
+            color: '#52B4E996'
+            id: MiniTileWhiteCornerNe
+          decals:
+            119: -1,13
+            130: 0,12
+        - node:
+            color: '#52B4E996'
+            id: MiniTileWhiteCornerNw
+          decals:
+            120: -2,13
+        - node:
+            color: '#52B4E996'
+            id: MiniTileWhiteCornerSw
+          decals:
+            122: -2,11
+            124: -1,8
+        - node:
+            color: '#52B4E996'
+            id: MiniTileWhiteEndE
+          decals:
+            131: 1,8
+        - node:
+            color: '#52B4E996'
+            id: MiniTileWhiteInnerNe
+          decals:
+            128: -1,12
+            133: 0,8
+        - node:
+            color: '#52B4E996'
+            id: MiniTileWhiteInnerSw
+          decals:
+            127: -1,11
+        - node:
+            color: '#52B4E996'
+            id: MiniTileWhiteLineE
+          decals:
+            118: 0,11
+            125: 0,9
+            126: 0,10
+        - node:
+            color: '#FFFFFFFF'
+            id: MiniTileWhiteLineN
+          decals:
+            47: 0,2
+        - node:
+            color: '#52B4E996'
+            id: MiniTileWhiteLineS
+          decals:
+            132: 0,8
+        - node:
+            color: '#FFFFFFFF'
+            id: MiniTileWhiteLineS
+          decals:
+            49: 0,2
+        - node:
+            color: '#52B4E996'
+            id: MiniTileWhiteLineW
+          decals:
+            121: -2,12
+            123: -1,10
+            129: -1,9
+        - node:
+            color: '#52B4E996'
+            id: MonoOverlay
+          decals:
+            117: -1,-2
+        - node:
+            color: '#52B4E9A4'
+            id: MonoOverlay
+          decals:
+            64: -5,6
+            65: -5,5
+            66: -5,4
+            67: -7,6
+            68: -7,5
+            69: -7,4
+            70: -7,3
+        - node:
+            color: '#1D1D217C'
+            id: QuarterTileOverlayGreyscale
+          decals:
+            88: -2,-5
+            89: -2,-5
+        - node:
+            color: '#F9FFFEFF'
+            id: QuarterTileOverlayGreyscale
+          decals:
+            87: -2,-5
+        - node:
+            color: '#1D1D217C'
+            id: QuarterTileOverlayGreyscale180
+          decals:
+            92: -4,-4
+        - node:
+            color: '#D4D4D496'
+            id: QuarterTileOverlayGreyscale180
+          decals:
+            34: -4,-4
+        - node:
+            color: '#D4D4D4C1'
+            id: QuarterTileOverlayGreyscale180
+          decals:
+            42: -4,-4
+        - node:
+            color: '#1D1D217C'
+            id: QuarterTileOverlayGreyscale270
+          decals:
+            90: -2,-4
+        - node:
+            color: '#D4D4D496'
+            id: QuarterTileOverlayGreyscale270
+          decals:
+            35: -2,-4
+        - node:
+            color: '#D4D4D4C1'
+            id: QuarterTileOverlayGreyscale270
+          decals:
+            43: -2,-4
+        - node:
+            color: '#1D1D217C'
+            id: QuarterTileOverlayGreyscale90
+          decals:
+            91: -4,-5
+        - node:
+            color: '#D4D4D496'
+            id: QuarterTileOverlayGreyscale90
+          decals:
+            33: -4,-5
+        - node:
+            color: '#D4D4D4C1'
+            id: QuarterTileOverlayGreyscale90
+          decals:
+            44: -4,-5
+        - node:
+            color: '#FFFFFFFF'
+            id: StandClear
+          decals:
+            17: 0,-1
+        - node:
+            color: '#D4D4D496'
+            id: WarnBox
+          decals:
+            20: -3,2
+            74: 0,-4
+        - node:
+            color: '#FFFFFF41'
+            id: WarnBox
+          decals:
+            52: -3,7
+            53: -3,7
+            54: -3,7
+            55: -3,2
+    - type: GridAtmosphere
+      version: 2
+      data:
+        tiles:
+          -2,0:
+            0: 57582
+          -2,1:
+            0: 20206
+          -2,2:
+            0: 51406
+            1: 4352
+          -2,3:
+            1: 1
+            0: 140
+          -2,-1:
+            0: 61024
+            1: 4
+          -1,0:
+            0: 45807
+          -1,2:
+            0: 55483
+          -1,3:
+            0: 221
+          -1,1:
+            0: 10922
+          -1,-1:
+            0: 61167
+          0,0:
+            0: 12595
+          0,1:
+            0: 4915
+          0,2:
+            0: 4371
+            1: 17408
+          0,3:
+            0: 1
+            1: 4
+          -2,-2:
+            1: 5632
+          -1,-2:
+            0: 29952
+          0,-2:
+            1: 17152
+          0,-1:
+            0: 29553
+        uniqueMixes:
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          immutable: True
+          moles:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        chunkSize: 4
+    - type: OccluderTree
+    - type: Shuttle
+    - type: RadiationGridResistance
+    - type: GravityShake
+      shakeTimes: 10
+    - type: GasTileOverlay
+    - type: SpreaderGrid
+    - type: GridPathfinding
+- proto: AirAlarm
+  entities:
+  - uid: 125
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,10.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 470
+      - 167
+      - 501
+  - uid: 212
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,10.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 169
+      - 499
+      - 350
+  - uid: 277
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-3.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 173
+      - 485
+      - 121
+      - 368
+      - 469
+  - uid: 320
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,1.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 486
+      - 168
+      - 121
+  - uid: 340
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,7.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 176
+      - 334
+      - 470
+      - 311
+      - 332
+  - uid: 384
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,2.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 341
+      - 516
+      - 339
+      - 332
+  - uid: 390
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,4.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 515
+      - 172
+      - 469
+      - 350
+- proto: AirCanister
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      anchored: True
+      pos: -4.5,-1.5
+      parent: 1
+    - type: Physics
+      bodyType: Static
+- proto: AirlockCentralCommandGlassLocked
+  entities:
+  - uid: 5
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,10.5
+      parent: 1
+- proto: AirlockCentralCommandLocked
+  entities:
+  - uid: 4
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,0.5
+      parent: 1
+- proto: AirlockChemistryGlassLocked
+  entities:
+  - uid: 10
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,7.5
+      parent: 1
+- proto: AirlockGlassShuttle
+  entities:
+  - uid: 6
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-0.5
+      parent: 1
+  - uid: 8
+    components:
+    - type: Transform
+      pos: -1.5,-5.5
+      parent: 1
+  - uid: 9
+    components:
+    - type: Transform
+      pos: -3.5,-5.5
+      parent: 1
+  - uid: 325
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-2.5
+      parent: 1
+- proto: AirlockMedicalGlass
+  entities:
+  - uid: 124
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,3.5
+      parent: 1
+  - uid: 329
+    components:
+    - type: Transform
+      pos: -5.5,7.5
+      parent: 1
+- proto: AirlockMedicalLocked
+  entities:
+  - uid: 77
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,2.5
+      parent: 1
+- proto: APCBasic
+  entities:
+  - uid: 89
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-2.5
+      parent: 1
+  - uid: 543
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,9.5
+      parent: 1
+- proto: AtmosDeviceFanTiny
+  entities:
+  - uid: 7
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-2.5
+      parent: 1
+  - uid: 13
+    components:
+    - type: Transform
+      pos: -3.5,-5.5
+      parent: 1
+  - uid: 14
+    components:
+    - type: Transform
+      pos: -1.5,-5.5
+      parent: 1
+  - uid: 123
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-0.5
+      parent: 1
+- proto: BedsheetMedical
+  entities:
+  - uid: 94
+    components:
+    - type: Transform
+      pos: -4.5,6.5
+      parent: 1
+  - uid: 362
+    components:
+    - type: Transform
+      pos: -6.5,5.5
+      parent: 1
+  - uid: 365
+    components:
+    - type: Transform
+      pos: -4.5,5.5
+      parent: 1
+  - uid: 385
+    components:
+    - type: Transform
+      pos: -6.5,6.5
+      parent: 1
+  - uid: 386
+    components:
+    - type: Transform
+      pos: -6.5,4.5
+      parent: 1
+  - uid: 437
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,4.5
+      parent: 1
+- proto: BiomassReclaimer
+  entities:
+  - uid: 344
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+- proto: BoxBeaker
+  entities:
+  - uid: 419
+    components:
+    - type: Transform
+      pos: -1.3405991,13.607021
+      parent: 1
+- proto: BoxBodyBag
+  entities:
+  - uid: 425
+    components:
+    - type: Transform
+      pos: -1.5639114,0.42734146
+      parent: 1
+  - uid: 427
+    components:
+    - type: Transform
+      pos: -1.2670364,0.63046646
+      parent: 1
+- proto: BoxBottle
+  entities:
+  - uid: 266
+    components:
+    - type: Transform
+      pos: -1.6517105,13.299473
+      parent: 1
+- proto: BoxFlare
+  entities:
+  - uid: 434
+    components:
+    - type: Transform
+      pos: -3.6823273,11.696819
+      parent: 1
+- proto: BoxLatexGloves
+  entities:
+  - uid: 321
+    components:
+    - type: Transform
+      pos: -0.712883,6.8120537
+      parent: 1
+- proto: BoxNitrileGloves
+  entities:
+  - uid: 364
+    components:
+    - type: Transform
+      pos: -0.36862183,6.6973534
+      parent: 1
+- proto: BoxSyringe
+  entities:
+  - uid: 433
+    components:
+    - type: Transform
+      pos: -1.3407669,13.044521
+      parent: 1
+- proto: BoxZiptie
+  entities:
+  - uid: 435
+    components:
+    - type: Transform
+      pos: -3.2839966,11.436718
+      parent: 1
+- proto: CableApcExtension
+  entities:
+  - uid: 15
+    components:
+    - type: Transform
+      pos: 0.5,11.5
+      parent: 1
+  - uid: 16
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 1
+  - uid: 17
+    components:
+    - type: Transform
+      pos: -4.5,11.5
+      parent: 1
+  - uid: 18
+    components:
+    - type: Transform
+      pos: -5.5,5.5
+      parent: 1
+  - uid: 19
+    components:
+    - type: Transform
+      pos: -5.5,-4.5
+      parent: 1
+  - uid: 20
+    components:
+    - type: Transform
+      pos: -6.5,9.5
+      parent: 1
+  - uid: 22
+    components:
+    - type: Transform
+      pos: -5.5,6.5
+      parent: 1
+  - uid: 23
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 25
+    components:
+    - type: Transform
+      pos: -5.5,12.5
+      parent: 1
+  - uid: 26
+    components:
+    - type: Transform
+      pos: -4.5,9.5
+      parent: 1
+  - uid: 27
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 1
+  - uid: 28
+    components:
+    - type: Transform
+      pos: -2.5,6.5
+      parent: 1
+  - uid: 29
+    components:
+    - type: Transform
+      pos: -5.5,11.5
+      parent: 1
+  - uid: 30
+    components:
+    - type: Transform
+      pos: -2.5,14.5
+      parent: 1
+  - uid: 31
+    components:
+    - type: Transform
+      pos: -1.5,14.5
+      parent: 1
+  - uid: 32
+    components:
+    - type: Transform
+      pos: -0.5,14.5
+      parent: 1
+  - uid: 33
+    components:
+    - type: Transform
+      pos: 0.5,14.5
+      parent: 1
+  - uid: 34
+    components:
+    - type: Transform
+      pos: 1.5,13.5
+      parent: 1
+  - uid: 35
+    components:
+    - type: Transform
+      pos: 1.5,12.5
+      parent: 1
+  - uid: 36
+    components:
+    - type: Transform
+      pos: -3.5,14.5
+      parent: 1
+  - uid: 37
+    components:
+    - type: Transform
+      pos: -4.5,14.5
+      parent: 1
+  - uid: 38
+    components:
+    - type: Transform
+      pos: -5.5,14.5
+      parent: 1
+  - uid: 39
+    components:
+    - type: Transform
+      pos: -6.5,13.5
+      parent: 1
+  - uid: 40
+    components:
+    - type: Transform
+      pos: -6.5,12.5
+      parent: 1
+  - uid: 41
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 1
+  - uid: 44
+    components:
+    - type: Transform
+      pos: -5.5,7.5
+      parent: 1
+  - uid: 46
+    components:
+    - type: Transform
+      pos: -0.5,-2.5
+      parent: 1
+  - uid: 47
+    components:
+    - type: Transform
+      pos: -0.5,8.5
+      parent: 1
+  - uid: 48
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 50
+    components:
+    - type: Transform
+      pos: -3.5,8.5
+      parent: 1
+  - uid: 51
+    components:
+    - type: Transform
+      pos: -5.5,4.5
+      parent: 1
+  - uid: 52
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 53
+    components:
+    - type: Transform
+      pos: -5.5,-2.5
+      parent: 1
+  - uid: 54
+    components:
+    - type: Transform
+      pos: -0.5,11.5
+      parent: 1
+  - uid: 55
+    components:
+    - type: Transform
+      pos: -4.5,8.5
+      parent: 1
+  - uid: 56
+    components:
+    - type: Transform
+      pos: -6.5,8.5
+      parent: 1
+  - uid: 58
+    components:
+    - type: Transform
+      pos: 0.5,12.5
+      parent: 1
+  - uid: 61
+    components:
+    - type: Transform
+      pos: -6.5,1.5
+      parent: 1
+  - uid: 62
+    components:
+    - type: Transform
+      pos: -4.5,0.5
+      parent: 1
+  - uid: 63
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 64
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 1
+  - uid: 65
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 1
+  - uid: 66
+    components:
+    - type: Transform
+      pos: -4.5,10.5
+      parent: 1
+  - uid: 67
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 1
+  - uid: 68
+    components:
+    - type: Transform
+      pos: -5.5,0.5
+      parent: 1
+  - uid: 69
+    components:
+    - type: Transform
+      pos: 1.5,-4.5
+      parent: 1
+  - uid: 70
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+  - uid: 71
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 1
+  - uid: 72
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 1
+  - uid: 73
+    components:
+    - type: Transform
+      pos: -6.5,-4.5
+      parent: 1
+  - uid: 74
+    components:
+    - type: Transform
+      pos: -5.5,8.5
+      parent: 1
+  - uid: 75
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 1
+  - uid: 76
+    components:
+    - type: Transform
+      pos: -5.5,13.5
+      parent: 1
+  - uid: 78
+    components:
+    - type: Transform
+      pos: 0.5,13.5
+      parent: 1
+  - uid: 79
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 1
+  - uid: 80
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 1
+  - uid: 93
+    components:
+    - type: Transform
+      pos: -6.5,-2.5
+      parent: 1
+  - uid: 106
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 1
+  - uid: 130
+    components:
+    - type: Transform
+      pos: 0.5,10.5
+      parent: 1
+  - uid: 135
+    components:
+    - type: Transform
+      pos: -2.5,8.5
+      parent: 1
+  - uid: 148
+    components:
+    - type: Transform
+      pos: 0.5,9.5
+      parent: 1
+  - uid: 154
+    components:
+    - type: Transform
+      pos: -1.5,9.5
+      parent: 1
+  - uid: 307
+    components:
+    - type: Transform
+      pos: -2.5,7.5
+      parent: 1
+  - uid: 330
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 1
+  - uid: 335
+    components:
+    - type: Transform
+      pos: -6.5,-3.5
+      parent: 1
+  - uid: 337
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 1
+  - uid: 338
+    components:
+    - type: Transform
+      pos: -2.5,-4.5
+      parent: 1
+  - uid: 357
+    components:
+    - type: Transform
+      pos: 0.5,7.5
+      parent: 1
+  - uid: 372
+    components:
+    - type: Transform
+      pos: 0.5,8.5
+      parent: 1
+  - uid: 429
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 1
+  - uid: 430
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 1
+  - uid: 431
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 1
+  - uid: 474
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 1
+  - uid: 522
+    components:
+    - type: Transform
+      pos: 2.5,6.5
+      parent: 1
+  - uid: 523
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 524
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 525
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 526
+    components:
+    - type: Transform
+      pos: -6.5,4.5
+      parent: 1
+  - uid: 527
+    components:
+    - type: Transform
+      pos: -7.5,4.5
+      parent: 1
+  - uid: 528
+    components:
+    - type: Transform
+      pos: -7.5,3.5
+      parent: 1
+  - uid: 529
+    components:
+    - type: Transform
+      pos: -7.5,5.5
+      parent: 1
+  - uid: 530
+    components:
+    - type: Transform
+      pos: -7.5,6.5
+      parent: 1
+  - uid: 531
+    components:
+    - type: Transform
+      pos: -3.5,6.5
+      parent: 1
+  - uid: 532
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 1
+  - uid: 533
+    components:
+    - type: Transform
+      pos: -2.5,13.5
+      parent: 1
+  - uid: 534
+    components:
+    - type: Transform
+      pos: -2.5,12.5
+      parent: 1
+  - uid: 535
+    components:
+    - type: Transform
+      pos: -6.5,0.5
+      parent: 1
+  - uid: 536
+    components:
+    - type: Transform
+      pos: -4.5,-0.5
+      parent: 1
+  - uid: 537
+    components:
+    - type: Transform
+      pos: -4.5,-1.5
+      parent: 1
+  - uid: 538
+    components:
+    - type: Transform
+      pos: -4.5,-2.5
+      parent: 1
+- proto: CableHV
+  entities:
+  - uid: 11
+    components:
+    - type: Transform
+      pos: -4.5,-2.5
+      parent: 1
+  - uid: 83
+    components:
+    - type: Transform
+      pos: -5.5,-2.5
+      parent: 1
+  - uid: 84
+    components:
+    - type: Transform
+      pos: -6.5,-1.5
+      parent: 1
+  - uid: 85
+    components:
+    - type: Transform
+      pos: -6.5,-0.5
+      parent: 1
+  - uid: 86
+    components:
+    - type: Transform
+      pos: -6.5,0.5
+      parent: 1
+  - uid: 87
+    components:
+    - type: Transform
+      pos: -6.5,-2.5
+      parent: 1
+  - uid: 539
+    components:
+    - type: Transform
+      pos: -4.5,-1.5
+      parent: 1
+  - uid: 540
+    components:
+    - type: Transform
+      pos: -4.5,-0.5
+      parent: 1
+  - uid: 541
+    components:
+    - type: Transform
+      pos: -4.5,0.5
+      parent: 1
+  - uid: 542
+    components:
+    - type: Transform
+      pos: -4.5,1.5
+      parent: 1
+- proto: CableMV
+  entities:
+  - uid: 42
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 1
+  - uid: 45
+    components:
+    - type: Transform
+      pos: -2.5,2.5
+      parent: 1
+  - uid: 49
+    components:
+    - type: Transform
+      pos: -4.5,-1.5
+      parent: 1
+  - uid: 57
+    components:
+    - type: Transform
+      pos: -2.5,3.5
+      parent: 1
+  - uid: 90
+    components:
+    - type: Transform
+      pos: -4.5,-2.5
+      parent: 1
+  - uid: 91
+    components:
+    - type: Transform
+      pos: -4.5,8.5
+      parent: 1
+  - uid: 92
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 1
+  - uid: 97
+    components:
+    - type: Transform
+      pos: -5.5,0.5
+      parent: 1
+  - uid: 98
+    components:
+    - type: Transform
+      pos: -6.5,8.5
+      parent: 1
+  - uid: 99
+    components:
+    - type: Transform
+      pos: -4.5,-0.5
+      parent: 1
+  - uid: 100
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 1
+  - uid: 102
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 1
+  - uid: 104
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 109
+    components:
+    - type: Transform
+      pos: -2.5,6.5
+      parent: 1
+  - uid: 110
+    components:
+    - type: Transform
+      pos: -4.5,0.5
+      parent: 1
+  - uid: 111
+    components:
+    - type: Transform
+      pos: -6.5,9.5
+      parent: 1
+  - uid: 213
+    components:
+    - type: Transform
+      pos: -5.5,8.5
+      parent: 1
+  - uid: 343
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 1
+  - uid: 370
+    components:
+    - type: Transform
+      pos: -3.5,8.5
+      parent: 1
+  - uid: 373
+    components:
+    - type: Transform
+      pos: -2.5,8.5
+      parent: 1
+  - uid: 379
+    components:
+    - type: Transform
+      pos: -2.5,7.5
+      parent: 1
+  - uid: 471
+    components:
+    - type: Transform
+      pos: -6.5,0.5
+      parent: 1
+- proto: CableTerminal
+  entities:
+  - uid: 112
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,-2.5
+      parent: 1
+- proto: Catwalk
+  entities:
+  - uid: 549
+    components:
+    - type: Transform
+      pos: -6.5,-5.5
+      parent: 1
+  - uid: 550
+    components:
+    - type: Transform
+      pos: -5.5,-5.5
+      parent: 1
+  - uid: 551
+    components:
+    - type: Transform
+      pos: -7.5,-4.5
+      parent: 1
+  - uid: 552
+    components:
+    - type: Transform
+      pos: 0.5,-5.5
+      parent: 1
+  - uid: 553
+    components:
+    - type: Transform
+      pos: 1.5,-5.5
+      parent: 1
+  - uid: 554
+    components:
+    - type: Transform
+      pos: 2.5,-4.5
+      parent: 1
+  - uid: 555
+    components:
+    - type: Transform
+      pos: -7.5,10.5
+      parent: 1
+  - uid: 556
+    components:
+    - type: Transform
+      pos: -7.5,11.5
+      parent: 1
+  - uid: 557
+    components:
+    - type: Transform
+      pos: -7.5,12.5
+      parent: 1
+  - uid: 558
+    components:
+    - type: Transform
+      pos: 2.5,12.5
+      parent: 1
+  - uid: 559
+    components:
+    - type: Transform
+      pos: 2.5,11.5
+      parent: 1
+  - uid: 560
+    components:
+    - type: Transform
+      pos: 2.5,10.5
+      parent: 1
+- proto: ChairFoldingSpawnFolded
+  entities:
+  - uid: 113
+    components:
+    - type: Transform
+      pos: -5.634156,0.81392413
+      parent: 1
+  - uid: 114
+    components:
+    - type: Transform
+      pos: -5.4049897,0.49100745
+      parent: 1
+- proto: ChairOfficeDark
+  entities:
+  - uid: 115
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-0.5
+      parent: 1
+- proto: ChairOfficeLight
+  entities:
+  - uid: 359
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 374
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,12.5
+      parent: 1
+- proto: ChairPilotSeat
+  entities:
+  - uid: 116
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,12.5
+      parent: 1
+  - uid: 233
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,12.5
+      parent: 1
+  - uid: 445
+    components:
+    - type: Transform
+      pos: -3.5,9.5
+      parent: 1
+  - uid: 446
+    components:
+    - type: Transform
+      pos: -2.5,9.5
+      parent: 1
+  - uid: 448
+    components:
+    - type: Transform
+      pos: -5.5,9.5
+      parent: 1
+- proto: ChemDispenser
+  entities:
+  - uid: 327
+    components:
+    - type: Transform
+      pos: -0.5,13.5
+      parent: 1
+- proto: ChemistryHotplate
+  entities:
+  - uid: 351
+    components:
+    - type: Transform
+      pos: -1.5,12.5
+      parent: 1
+- proto: ChemMaster
+  entities:
+  - uid: 333
+    components:
+    - type: Transform
+      pos: 0.5,12.5
+      parent: 1
+- proto: CloningPod
+  entities:
+  - uid: 394
+    components:
+    - type: Transform
+      pos: -0.5,-1.5
+      parent: 1
+- proto: ClothingBeltUtilityEngineering
+  entities:
+  - uid: 480
+    components:
+    - type: Transform
+      pos: -5.538275,-1.3559046
+      parent: 1
+- proto: ClothingOuterHospitalGown
+  entities:
+  - uid: 347
+    components:
+    - type: Transform
+      pos: -0.6774597,-3.3940887
+      parent: 1
+  - uid: 452
+    components:
+    - type: Transform
+      pos: -0.22608185,-3.312954
+      parent: 1
+  - uid: 455
+    components:
+    - type: Transform
+      pos: -0.460701,-3.6744652
+      parent: 1
+- proto: ClothingOuterStraightjacket
+  entities:
+  - uid: 336
+    components:
+    - type: Transform
+      pos: -0.34114075,6.5431633
+      parent: 1
+  - uid: 472
+    components:
+    - type: Transform
+      pos: -0.7364044,6.7215843
+      parent: 1
+- proto: ComputerCloningConsole
+  entities:
+  - uid: 402
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,0.5
+      parent: 1
+- proto: ComputerComms
+  entities:
+  - uid: 118
+    components:
+    - type: Transform
+      pos: -3.5,13.5
+      parent: 1
+- proto: ComputerPowerMonitoring
+  entities:
+  - uid: 119
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-0.5
+      parent: 1
+- proto: ComputerShuttle
+  entities:
+  - uid: 120
+    components:
+    - type: Transform
+      pos: -4.5,13.5
+      parent: 1
+- proto: CrateFoodMRE
+  entities:
+  - uid: 458
+    components:
+    - type: Transform
+      pos: 1.5573349,4.3805504
+      parent: 1
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.1496
+        moles:
+        - 1.8856695
+        - 7.0937095
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 459
+          - 460
+          - 461
+          - 462
+          - 463
+          - 464
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+- proto: DefibrillatorCabinetFilled
+  entities:
+  - uid: 326
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 1
+  - uid: 355
+    components:
+    - type: Transform
+      pos: -6.5,7.5
+      parent: 1
+- proto: DrinkDoctorsDelightGlass
+  entities:
+  - uid: 420
+    components:
+    - type: Transform
+      rot: 6.283185307179586 rad
+      pos: -5.8276978,11.879101
+      parent: 1
+- proto: DrinkWaterBottleFull
+  entities:
+  - uid: 459
+    components:
+    - type: Transform
+      parent: 458
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 460
+    components:
+    - type: Transform
+      parent: 458
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 461
+    components:
+    - type: Transform
+      parent: 458
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 462
+    components:
+    - type: Transform
+      parent: 458
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 463
+    components:
+    - type: Transform
+      parent: 458
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 464
+    components:
+    - type: Transform
+      parent: 458
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: ExtinguisherCabinetFilled
+  entities:
+  - uid: 389
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 1
+- proto: FireAlarm
+  entities:
+  - uid: 12
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,2.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 339
+      - 332
+  - uid: 153
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,10.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 470
+      - 167
+      - 501
+  - uid: 209
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-0.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 368
+      - 121
+      - 387
+  - uid: 358
+    components:
+    - type: Transform
+      pos: -0.5,7.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 350
+      - 469
+  - uid: 366
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,7.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 332
+      - 311
+      - 470
+  - uid: 443
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,3.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 368
+      - 311
+      - 339
+  - uid: 447
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,1.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 469
+      - 387
+  - uid: 466
+    components:
+    - type: Transform
+      pos: 1.5,9.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 350
+- proto: FirelockEdge
+  entities:
+  - uid: 387
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,1.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 209
+      - 447
+- proto: FirelockGlass
+  entities:
+  - uid: 121
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 277
+      - 320
+      - 209
+  - uid: 311
+    components:
+    - type: Transform
+      pos: -2.5,7.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 340
+      - 443
+      - 366
+  - uid: 332
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,7.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 340
+      - 384
+      - 12
+      - 366
+  - uid: 339
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,3.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 384
+      - 443
+      - 12
+  - uid: 350
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,7.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 212
+      - 390
+      - 358
+      - 466
+  - uid: 368
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,2.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 277
+      - 209
+      - 443
+  - uid: 469
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,2.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 277
+      - 390
+      - 447
+      - 358
+  - uid: 470
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,10.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 125
+      - 153
+      - 340
+      - 366
+- proto: FloorDrain
+  entities:
+  - uid: 24
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,11.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 473
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: FoodMealFriesCheesy
+  entities:
+  - uid: 456
+    components:
+    - type: Transform
+      pos: -5.4728775,11.70351
+      parent: 1
+- proto: ForkPlastic
+  entities:
+  - uid: 468
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.50753,11.236103
+      parent: 1
+- proto: GasPassiveVent
+  entities:
+  - uid: 481
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeBend
+  entities:
+  - uid: 117
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 174
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 506
+    components:
+    - type: Transform
+      pos: 0.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 517
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeStraight
+  entities:
+  - uid: 103
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 129
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 132
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 136
+    components:
+    - type: Transform
+      pos: -4.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 137
+    components:
+    - type: Transform
+      pos: -0.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 138
+    components:
+    - type: Transform
+      pos: -4.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 139
+    components:
+    - type: Transform
+      pos: -0.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 141
+    components:
+    - type: Transform
+      pos: -5.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 144
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 146
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 157
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,8.5
+      parent: 1
+  - uid: 166
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 305
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 310
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 312
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 313
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 342
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 378
+    components:
+    - type: Transform
+      pos: -5.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 388
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 395
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 482
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 483
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 487
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 488
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 493
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 494
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 495
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 497
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 502
+    components:
+    - type: Transform
+      pos: -3.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 503
+    components:
+    - type: Transform
+      pos: -1.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 504
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 505
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 508
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 509
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 510
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 512
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 513
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 514
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 519
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 520
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 521
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeTJunction
+  entities:
+  - uid: 127
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 142
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 147
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 163
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 164
+    components:
+    - type: Transform
+      pos: -4.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 170
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 171
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 210
+    components:
+    - type: Transform
+      anchored: False
+      rot: 3.141592653589793 rad
+      pos: -1.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+    - type: Physics
+      canCollide: True
+      bodyType: Dynamic
+  - uid: 211
+    components:
+    - type: Transform
+      pos: -2.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 236
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 315
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 484
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 489
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 492
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 496
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 498
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 507
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 511
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPort
+  entities:
+  - uid: 165
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasVentPump
+  entities:
+  - uid: 128
+    components:
+    - type: Transform
+      pos: -0.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 167
+    components:
+    - type: Transform
+      pos: -4.5,11.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 125
+      - 153
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 168
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,0.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 320
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 169
+    components:
+    - type: Transform
+      pos: -0.5,11.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 212
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 172
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,5.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 390
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 173
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-3.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 277
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 176
+    components:
+    - type: Transform
+      pos: -3.5,9.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 340
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 341
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,5.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 384
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 490
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasVentScrubber
+  entities:
+  - uid: 334
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,9.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 340
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 485
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-4.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 277
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 486
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-0.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 320
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 491
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 499
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,9.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 212
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 500
+    components:
+    - type: Transform
+      pos: -1.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 501
+    components:
+    - type: Transform
+      pos: -3.5,11.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 125
+      - 153
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 515
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,4.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 390
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 516
+    components:
+    - type: Transform
+      pos: -5.5,4.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 384
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 518
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GeneratorBasic15kW
+  entities:
+  - uid: 3
+    components:
+    - type: Transform
+      pos: -4.5,1.5
+      parent: 1
+  - uid: 82
+    components:
+    - type: Transform
+      pos: -6.5,-2.5
+      parent: 1
+  - uid: 175
+    components:
+    - type: Transform
+      pos: -5.5,-2.5
+      parent: 1
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 177
+    components:
+    - type: Transform
+      pos: -6.5,1.5
+      parent: 1
+- proto: Grille
+  entities:
+  - uid: 95
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,3.5
+      parent: 1
+  - uid: 96
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 107
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 1
+  - uid: 158
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,8.5
+      parent: 1
+  - uid: 159
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,9.5
+      parent: 1
+  - uid: 178
+    components:
+    - type: Transform
+      pos: -5.5,13.5
+      parent: 1
+  - uid: 179
+    components:
+    - type: Transform
+      pos: 0.5,13.5
+      parent: 1
+  - uid: 180
+    components:
+    - type: Transform
+      pos: -2.5,12.5
+      parent: 1
+  - uid: 181
+    components:
+    - type: Transform
+      pos: -7.5,6.5
+      parent: 1
+  - uid: 182
+    components:
+    - type: Transform
+      pos: -6.5,12.5
+      parent: 1
+  - uid: 183
+    components:
+    - type: Transform
+      pos: -6.5,13.5
+      parent: 1
+  - uid: 184
+    components:
+    - type: Transform
+      pos: -5.5,14.5
+      parent: 1
+  - uid: 185
+    components:
+    - type: Transform
+      pos: -4.5,14.5
+      parent: 1
+  - uid: 186
+    components:
+    - type: Transform
+      pos: -3.5,14.5
+      parent: 1
+  - uid: 187
+    components:
+    - type: Transform
+      pos: -1.5,14.5
+      parent: 1
+  - uid: 188
+    components:
+    - type: Transform
+      pos: -0.5,14.5
+      parent: 1
+  - uid: 189
+    components:
+    - type: Transform
+      pos: 0.5,14.5
+      parent: 1
+  - uid: 190
+    components:
+    - type: Transform
+      pos: 1.5,13.5
+      parent: 1
+  - uid: 191
+    components:
+    - type: Transform
+      pos: 1.5,12.5
+      parent: 1
+  - uid: 192
+    components:
+    - type: Transform
+      pos: -7.5,5.5
+      parent: 1
+  - uid: 193
+    components:
+    - type: Transform
+      pos: 2.5,6.5
+      parent: 1
+  - uid: 197
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 231
+    components:
+    - type: Transform
+      pos: -2.5,13.5
+      parent: 1
+  - uid: 306
+    components:
+    - type: Transform
+      pos: -3.5,6.5
+      parent: 1
+- proto: Gyroscope
+  entities:
+  - uid: 199
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,1.5
+      parent: 1
+    - type: Thruster
+      enabled: False
+- proto: HolopadUnlimitedRange
+  entities:
+  - uid: 561
+    components:
+    - type: MetaData
+      name: quantum entangling holopad (NT-Asclepius)
+    - type: Transform
+      pos: -4.5,8.5
+      parent: 1
+    - type: Label
+      currentLabel: NT-Asclepius
+    - type: NameModifier
+      baseName: quantum entangling holopad
+- proto: KitchenReagentGrinder
+  entities:
+  - uid: 380
+    components:
+    - type: Transform
+      pos: -1.5,11.5
+      parent: 1
+- proto: LockerChemistryFilled
+  entities:
+  - uid: 160
+    components:
+    - type: Transform
+      pos: 1.5,8.5
+      parent: 1
+- proto: LockerWallMedicalFilled
+  entities:
+  - uid: 162
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,6.5
+      parent: 1
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+  - uid: 354
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 1
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.1496
+        moles:
+        - 1.8856695
+        - 7.0937095
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+- proto: MachineCentrifuge
+  entities:
+  - uid: 155
+    components:
+    - type: Transform
+      pos: 0.5,10.5
+      parent: 1
+- proto: MachineElectrolysisUnit
+  entities:
+  - uid: 196
+    components:
+    - type: Transform
+      pos: 0.5,9.5
+      parent: 1
+- proto: MaterialBiomass
+  entities:
+  - uid: 346
+    components:
+    - type: Transform
+      pos: -0.55737305,0.53671265
+      parent: 1
+  - uid: 348
+    components:
+    - type: Transform
+      pos: -0.6848831,0.68964386
+      parent: 1
+  - uid: 454
+    components:
+    - type: Transform
+      pos: -0.6848831,0.42201614
+      parent: 1
+- proto: MaterialCloth
+  entities:
+  - uid: 439
+    components:
+    - type: Transform
+      pos: 1.609436,5.377186
+      parent: 1
+- proto: MaterialCloth1
+  entities:
+  - uid: 453
+    components:
+    - type: Transform
+      pos: -5.491905,11.986103
+      parent: 1
+- proto: MedicalBed
+  entities:
+  - uid: 108
+    components:
+    - type: Transform
+      pos: -4.5,6.5
+      parent: 1
+  - uid: 356
+    components:
+    - type: Transform
+      pos: -6.5,4.5
+      parent: 1
+  - uid: 360
+    components:
+    - type: Transform
+      pos: -6.5,5.5
+      parent: 1
+  - uid: 361
+    components:
+    - type: Transform
+      pos: -4.5,5.5
+      parent: 1
+  - uid: 363
+    components:
+    - type: Transform
+      pos: -6.5,6.5
+      parent: 1
+  - uid: 440
+    components:
+    - type: Transform
+      pos: -4.5,4.5
+      parent: 1
+- proto: MedicalScanner
+  entities:
+  - uid: 418
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+- proto: MedicalTechFab
+  entities:
+  - uid: 371
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 1
+- proto: MedkitAdvancedFilled
+  entities:
+  - uid: 412
+    components:
+    - type: Transform
+      pos: -0.80139923,5.4593315
+      parent: 1
+  - uid: 413
+    components:
+    - type: Transform
+      pos: -0.27509308,5.440914
+      parent: 1
+  - uid: 414
+    components:
+    - type: Transform
+      pos: -0.7957306,5.2214317
+      parent: 1
+  - uid: 415
+    components:
+    - type: Transform
+      pos: -0.2687149,5.2214317
+      parent: 1
+  - uid: 416
+    components:
+    - type: Transform
+      pos: -0.7787323,4.994869
+      parent: 1
+  - uid: 417
+    components:
+    - type: Transform
+      pos: -0.24604797,5.000538
+      parent: 1
+- proto: MedkitBruteFilled
+  entities:
+  - uid: 331
+    components:
+    - type: Transform
+      pos: -0.73905945,6.1163673
+      parent: 1
+  - uid: 403
+    components:
+    - type: Transform
+      pos: -0.353714,6.093708
+      parent: 1
+- proto: MedkitBurnFilled
+  entities:
+  - uid: 404
+    components:
+    - type: Transform
+      pos: -0.7787323,5.8671455
+      parent: 1
+  - uid: 405
+    components:
+    - type: Transform
+      pos: -0.350914,5.9033775
+      parent: 1
+- proto: MedkitCombatFilled
+  entities:
+  - uid: 406
+    components:
+    - type: Transform
+      pos: -0.6880646,4.473774
+      parent: 1
+- proto: MedkitFilled
+  entities:
+  - uid: 407
+    components:
+    - type: Transform
+      pos: -0.30838013,4.485096
+      parent: 1
+- proto: MedkitOxygenFilled
+  entities:
+  - uid: 408
+    components:
+    - type: Transform
+      pos: -0.80139923,5.6689034
+      parent: 1
+  - uid: 409
+    components:
+    - type: Transform
+      pos: -0.319664,5.7158775
+      parent: 1
+- proto: MedkitRadiationFilled
+  entities:
+  - uid: 410
+    components:
+    - type: Transform
+      pos: -0.7277298,4.7399864
+      parent: 1
+- proto: MedkitToxinFilled
+  entities:
+  - uid: 411
+    components:
+    - type: Transform
+      pos: -0.28004456,4.756977
+      parent: 1
+- proto: Multitool
+  entities:
+  - uid: 349
+    components:
+    - type: Transform
+      pos: -0.37753296,0.57138443
+      parent: 1
+- proto: PlasmaReinforcedWindowDirectional
+  entities:
+  - uid: 441
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-3.5
+      parent: 1
+- proto: PosterLegitAnatomyPoster
+  entities:
+  - uid: 449
+    components:
+    - type: Transform
+      pos: 1.5,7.5
+      parent: 1
+- proto: PosterLegitHelpOthers
+  entities:
+  - uid: 322
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+- proto: PosterLegitNanotrasenLogo
+  entities:
+  - uid: 200
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,10.5
+      parent: 1
+  - uid: 201
+    components:
+    - type: Transform
+      pos: -0.5,-5.5
+      parent: 1
+  - uid: 202
+    components:
+    - type: Transform
+      pos: -4.5,-5.5
+      parent: 1
+  - uid: 423
+    components:
+    - type: Transform
+      pos: -3.5,-1.5
+      parent: 1
+- proto: PosterLegitSafetyMothEpi
+  entities:
+  - uid: 81
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,2.5
+      parent: 1
+- proto: PosterLegitSafetyMothMeth
+  entities:
+  - uid: 59
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,2.5
+      parent: 1
+- proto: PowerCellRecharger
+  entities:
+  - uid: 450
+    components:
+    - type: Transform
+      pos: -6.5,3.5
+      parent: 1
+  - uid: 451
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+- proto: Poweredlight
+  entities:
+  - uid: 150
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,10.5
+      parent: 1
+  - uid: 203
+    components:
+    - type: Transform
+      pos: -2.5,9.5
+      parent: 1
+  - uid: 204
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-0.5
+      parent: 1
+  - uid: 205
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 206
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-1.5
+      parent: 1
+  - uid: 207
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,11.5
+      parent: 1
+  - uid: 208
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-4.5
+      parent: 1
+  - uid: 353
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,4.5
+      parent: 1
+  - uid: 393
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,11.5
+      parent: 1
+  - uid: 465
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,4.5
+      parent: 1
+- proto: Rack
+  entities:
+  - uid: 105
+    components:
+    - type: Transform
+      pos: -3.5,11.5
+      parent: 1
+  - uid: 314
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,0.5
+      parent: 1
+  - uid: 345
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 1
+  - uid: 369
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 401
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 1
+- proto: RadioHandheld
+  entities:
+  - uid: 476
+    components:
+    - type: Transform
+      pos: -5.715358,-1.6475713
+      parent: 1
+  - uid: 477
+    components:
+    - type: Transform
+      pos: -5.715358,-1.6475713
+      parent: 1
+  - uid: 478
+    components:
+    - type: Transform
+      pos: -5.4236913,-1.5225713
+      parent: 1
+  - uid: 479
+    components:
+    - type: Transform
+      pos: -5.2049413,-1.3975713
+      parent: 1
+- proto: RandomHumanoidSpawnerERTLeaderEVALecterTime
+  entities:
+  - uid: 547
+    components:
+    - type: Transform
+      pos: -4.5,11.5
+      parent: 1
+- proto: RandomHumanoidSpawnerERTMedicalEVA
+  entities:
+  - uid: 544
+    components:
+    - type: Transform
+      pos: -5.5,5.5
+      parent: 1
+  - uid: 548
+    components:
+    - type: Transform
+      pos: -0.5,1.5
+      parent: 1
+- proto: RandomHumanoidSpawnerERTMedicalEVATime
+  entities:
+  - uid: 545
+    components:
+    - type: Transform
+      pos: -0.5,10.5
+      parent: 1
+  - uid: 546
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+- proto: ReagentContainerMayo
+  entities:
+  - uid: 126
+    components:
+    - type: Transform
+      pos: -1.7147208,13.71626
+      parent: 1
+- proto: SheetGlass
+  entities:
+  - uid: 442
+    components:
+    - type: Transform
+      pos: 1.7120972,5.5867043
+      parent: 1
+- proto: SheetPlastic
+  entities:
+  - uid: 438
+    components:
+    - type: Transform
+      pos: 1.3935776,5.756199
+      parent: 1
+- proto: SheetSteel
+  entities:
+  - uid: 367
+    components:
+    - type: Transform
+      pos: 1.457367,5.5087395
+      parent: 1
+- proto: ShuttleWindow
+  entities:
+  - uid: 145
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 1
+  - uid: 149
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,9.5
+      parent: 1
+  - uid: 156
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,8.5
+      parent: 1
+  - uid: 194
+    components:
+    - type: Transform
+      pos: -2.5,13.5
+      parent: 1
+  - uid: 214
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,6.5
+      parent: 1
+  - uid: 215
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,5.5
+      parent: 1
+  - uid: 216
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 217
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,6.5
+      parent: 1
+  - uid: 218
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,13.5
+      parent: 1
+  - uid: 220
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,12.5
+      parent: 1
+  - uid: 221
+    components:
+    - type: Transform
+      pos: 0.5,13.5
+      parent: 1
+  - uid: 222
+    components:
+    - type: Transform
+      pos: 1.5,13.5
+      parent: 1
+  - uid: 223
+    components:
+    - type: Transform
+      pos: 0.5,14.5
+      parent: 1
+  - uid: 224
+    components:
+    - type: Transform
+      pos: -0.5,14.5
+      parent: 1
+  - uid: 225
+    components:
+    - type: Transform
+      pos: -1.5,14.5
+      parent: 1
+  - uid: 226
+    components:
+    - type: Transform
+      pos: -4.5,14.5
+      parent: 1
+  - uid: 227
+    components:
+    - type: Transform
+      pos: -5.5,14.5
+      parent: 1
+  - uid: 228
+    components:
+    - type: Transform
+      pos: -6.5,13.5
+      parent: 1
+  - uid: 229
+    components:
+    - type: Transform
+      pos: -6.5,12.5
+      parent: 1
+  - uid: 230
+    components:
+    - type: Transform
+      pos: -3.5,14.5
+      parent: 1
+  - uid: 232
+    components:
+    - type: Transform
+      pos: 1.5,12.5
+      parent: 1
+  - uid: 250
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 274
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,3.5
+      parent: 1
+  - uid: 309
+    components:
+    - type: Transform
+      pos: -3.5,6.5
+      parent: 1
+- proto: SignMedical
+  entities:
+  - uid: 436
+    components:
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 1
+- proto: SinkWide
+  entities:
+  - uid: 21
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,3.5
+      parent: 1
+  - uid: 422
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,11.5
+      parent: 1
+- proto: SMESBasic
+  entities:
+  - uid: 234
+    components:
+    - type: Transform
+      pos: -6.5,-1.5
+      parent: 1
+- proto: SubstationBasic
+  entities:
+  - uid: 235
+    components:
+    - type: Transform
+      pos: -6.5,0.5
+      parent: 1
+- proto: TableReinforced
+  entities:
+  - uid: 134
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,3.5
+      parent: 1
+  - uid: 151
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,10.5
+      parent: 1
+  - uid: 152
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,9.5
+      parent: 1
+  - uid: 317
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 1
+  - uid: 319
+    components:
+    - type: Transform
+      pos: -1.5,11.5
+      parent: 1
+  - uid: 324
+    components:
+    - type: Transform
+      pos: -1.5,12.5
+      parent: 1
+  - uid: 375
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,13.5
+      parent: 1
+  - uid: 376
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,12.5
+      parent: 1
+  - uid: 377
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,11.5
+      parent: 1
+  - uid: 381
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 1
+  - uid: 382
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 391
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,3.5
+      parent: 1
+- proto: TableReinforcedGlass
+  entities:
+  - uid: 475
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-1.5
+      parent: 1
+- proto: Thruster
+  entities:
+  - uid: 237
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-5.5
+      parent: 1
+  - uid: 238
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-4.5
+      parent: 1
+  - uid: 239
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-5.5
+      parent: 1
+  - uid: 240
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-5.5
+      parent: 1
+  - uid: 241
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,-5.5
+      parent: 1
+  - uid: 242
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,11.5
+      parent: 1
+  - uid: 243
+    components:
+    - type: Transform
+      pos: 2.5,12.5
+      parent: 1
+  - uid: 244
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,11.5
+      parent: 1
+  - uid: 245
+    components:
+    - type: Transform
+      pos: -7.5,12.5
+      parent: 1
+  - uid: 246
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-4.5
+      parent: 1
+  - uid: 247
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,10.5
+      parent: 1
+  - uid: 248
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,10.5
+      parent: 1
+- proto: VendingMachineMedical
+  entities:
+  - uid: 328
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 1
+  - uid: 421
+    components:
+    - type: Transform
+      pos: -6.5,8.5
+      parent: 1
+- proto: VendingMachineWallMedical
+  entities:
+  - uid: 122
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 1
+- proto: WallShuttle
+  entities:
+  - uid: 43
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 88
+    components:
+    - type: Transform
+      pos: -6.5,7.5
+      parent: 1
+  - uid: 131
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,7.5
+      parent: 1
+  - uid: 133
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,2.5
+      parent: 1
+  - uid: 140
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 1
+  - uid: 143
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,4.5
+      parent: 1
+  - uid: 161
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,7.5
+      parent: 1
+  - uid: 195
+    components:
+    - type: Transform
+      pos: -2.5,11.5
+      parent: 1
+  - uid: 198
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,7.5
+      parent: 1
+  - uid: 219
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,7.5
+      parent: 1
+  - uid: 249
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,10.5
+      parent: 1
+  - uid: 251
+    components:
+    - type: Transform
+      pos: 2.5,9.5
+      parent: 1
+  - uid: 252
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-2.5
+      parent: 1
+  - uid: 253
+    components:
+    - type: Transform
+      pos: -6.5,-3.5
+      parent: 1
+  - uid: 254
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 255
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-1.5
+      parent: 1
+  - uid: 256
+    components:
+    - type: Transform
+      pos: 2.5,-3.5
+      parent: 1
+  - uid: 257
+    components:
+    - type: Transform
+      pos: -5.5,-4.5
+      parent: 1
+  - uid: 258
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 259
+    components:
+    - type: Transform
+      pos: 1.5,9.5
+      parent: 1
+  - uid: 260
+    components:
+    - type: Transform
+      pos: -6.5,9.5
+      parent: 1
+  - uid: 261
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,10.5
+      parent: 1
+  - uid: 262
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,2.5
+      parent: 1
+  - uid: 263
+    components:
+    - type: Transform
+      pos: 1.5,-3.5
+      parent: 1
+  - uid: 264
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,2.5
+      parent: 1
+  - uid: 265
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 267
+    components:
+    - type: Transform
+      pos: -3.5,2.5
+      parent: 1
+  - uid: 268
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,2.5
+      parent: 1
+  - uid: 269
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-1.5
+      parent: 1
+  - uid: 270
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,8.5
+      parent: 1
+  - uid: 271
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,-0.5
+      parent: 1
+  - uid: 272
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,14.5
+      parent: 1
+  - uid: 273
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,-1.5
+      parent: 1
+  - uid: 275
+    components:
+    - type: Transform
+      pos: -6.5,-4.5
+      parent: 1
+  - uid: 276
+    components:
+    - type: Transform
+      pos: 1.5,-4.5
+      parent: 1
+  - uid: 278
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,-2.5
+      parent: 1
+  - uid: 279
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,2.5
+      parent: 1
+  - uid: 280
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,2.5
+      parent: 1
+  - uid: 281
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-4.5
+      parent: 1
+  - uid: 282
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-4.5
+      parent: 1
+  - uid: 283
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 284
+    components:
+    - type: Transform
+      pos: -7.5,-3.5
+      parent: 1
+  - uid: 285
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-3.5
+      parent: 1
+  - uid: 286
+    components:
+    - type: Transform
+      pos: -7.5,0.5
+      parent: 1
+  - uid: 287
+    components:
+    - type: Transform
+      pos: -7.5,4.5
+      parent: 1
+  - uid: 288
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-2.5
+      parent: 1
+  - uid: 289
+    components:
+    - type: Transform
+      pos: -7.5,8.5
+      parent: 1
+  - uid: 290
+    components:
+    - type: Transform
+      pos: -7.5,9.5
+      parent: 1
+  - uid: 291
+    components:
+    - type: Transform
+      pos: -6.5,10.5
+      parent: 1
+  - uid: 292
+    components:
+    - type: Transform
+      pos: -6.5,11.5
+      parent: 1
+  - uid: 293
+    components:
+    - type: Transform
+      pos: 1.5,11.5
+      parent: 1
+  - uid: 294
+    components:
+    - type: Transform
+      pos: 1.5,10.5
+      parent: 1
+  - uid: 295
+    components:
+    - type: Transform
+      pos: -4.5,-5.5
+      parent: 1
+  - uid: 296
+    components:
+    - type: Transform
+      pos: -0.5,-5.5
+      parent: 1
+  - uid: 297
+    components:
+    - type: Transform
+      pos: -2.5,-5.5
+      parent: 1
+  - uid: 298
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 1
+  - uid: 299
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,10.5
+      parent: 1
+  - uid: 300
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-0.5
+      parent: 1
+  - uid: 301
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,10.5
+      parent: 1
+  - uid: 302
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,1.5
+      parent: 1
+  - uid: 303
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,1.5
+      parent: 1
+  - uid: 304
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 308
+    components:
+    - type: Transform
+      pos: -3.5,7.5
+      parent: 1
+  - uid: 316
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,7.5
+      parent: 1
+  - uid: 318
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,7.5
+      parent: 1
+  - uid: 323
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 383
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,6.5
+      parent: 1
+- proto: WallWeaponCapacitorRecharger
+  entities:
+  - uid: 398
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,7.5
+      parent: 1
+- proto: WeaponCapacitorRecharger
+  entities:
+  - uid: 397
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,12.5
+      parent: 1
+- proto: WindoorSecureMedicalLocked
+  entities:
+  - uid: 101
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-0.5
+      parent: 1
+  - uid: 352
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 432
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-0.5
+      parent: 1
+  - uid: 444
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-2.5
+      parent: 1
+  - uid: 457
+    components:
+    - type: Transform
+      pos: -3.5,-4.5
+      parent: 1
+  - uid: 467
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 1
+- proto: WindowReinforcedDirectional
+  entities:
+  - uid: 392
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 1
+  - uid: 396
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 399
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 400
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 424
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 426
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 428
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,0.5
+      parent: 1
+- proto: Wrench
+  entities:
+  - uid: 60
+    components:
+    - type: Transform
+      pos: -5.5520835,-1.3958334
+      parent: 1
+...

--- a/Resources/Maps/_Harmony/Shuttles/ShuttleEvent/ERTMedSecLarge.yml
+++ b/Resources/Maps/_Harmony/Shuttles/ShuttleEvent/ERTMedSecLarge.yml
@@ -1,0 +1,7668 @@
+meta:
+  format: 6
+  postmapinit: false
+tilemap:
+  1: Space
+  9: FloorDark
+  8: FloorDarkMono
+  12: FloorGrass
+  4: FloorSteel
+  13: FloorSteelDirty
+  7: FloorWhite
+  5: FloorWhiteMono
+  10: FloorWhitePavement
+  6: FloorWhitePavementVertical
+  11: FloorWood
+  3: Lattice
+  2: Plating
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: NT-Hygieia
+    - type: Transform
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        -1,0:
+          ind: -1,0
+          tiles: AQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAABAAAAAADBgAAAAAACQAAAAABBAAAAAAABwAAAAADBwAAAAACBAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAABQAAAAADBgAAAAACBQAAAAACCQAAAAACBwAAAAABBwAAAAAABAAAAAADAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAABQAAAAACBgAAAAAABQAAAAAABAAAAAADBwAAAAABBwAAAAAABAAAAAADAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAABQAAAAACBgAAAAADBQAAAAAACQAAAAAABwAAAAACBwAAAAAABAAAAAACAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAABAAAAAABBgAAAAAABgAAAAABBgAAAAADBwAAAAAABwAAAAABBAAAAAABAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAABQAAAAADBgAAAAACBQAAAAAACQAAAAAABwAAAAAABwAAAAAABAAAAAABAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAABQAAAAABBgAAAAABCgAAAAADCgAAAAADBwAAAAABBwAAAAAABAAAAAADAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAABQAAAAABBQAAAAAABQAAAAABBAAAAAAABwAAAAADBwAAAAAABAAAAAACAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAABAAAAAADBAAAAAADBAAAAAADBAAAAAABBwAAAAABBwAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAABQAAAAABBQAAAAACBQAAAAACBQAAAAABCQAAAAAACQAAAAACCAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAABQAAAAAABwAAAAADBwAAAAADBQAAAAACCQAAAAACCQAAAAAACQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAABQAAAAADBwAAAAAABwAAAAADBwAAAAADCQAAAAADCQAAAAADCQAAAAACAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAABQAAAAABBwAAAAADBwAAAAAABQAAAAABCQAAAAADCQAAAAACCAAAAAADAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAAAAgAAAAAACAAAAAACCQAAAAABCQAAAAACCQAAAAACCQAAAAABCwAAAAADAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAAAAgAAAAAACAAAAAAACQAAAAABCQAAAAACCQAAAAAACQAAAAABCwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAAAAgAAAAAAAgAAAAAACAAAAAAACAAAAAAACAAAAAADCAAAAAAACwAAAAAC
+          version: 6
+        -1,-1:
+          ind: -1,-1
+          tiles: AQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAAAAgAAAAAABAAAAAACBAAAAAADBAAAAAADBAAAAAACBAAAAAACBAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAAABAAAAAACBAAAAAABBAAAAAACBAAAAAABBAAAAAACBAAAAAAABAAAAAABAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAABAAAAAAABAAAAAAABAAAAAABBAAAAAACBAAAAAAABAAAAAABBAAAAAABAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAABAAAAAACBAAAAAACBAAAAAAABAAAAAACBAAAAAACBAAAAAACBAAAAAABAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAABAAAAAAABAAAAAADBAAAAAAABAAAAAACBAAAAAABAwAAAAAABAAAAAABAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAABAAAAAACBAAAAAABBAAAAAABBAAAAAAABAAAAAADBAAAAAADBAAAAAABAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAACQAAAAACBAAAAAABBAAAAAADBAAAAAABBAAAAAABBAAAAAADBAAAAAABAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAABAAAAAAABAAAAAACCQAAAAABCQAAAAACBAAAAAACCQAAAAAACQAAAAACAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAABAAAAAACBAAAAAACDAAAAAAADAAAAAAABAAAAAABDAAAAAAADAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAABAAAAAAABAAAAAADCQAAAAAACQAAAAAABAAAAAADCQAAAAAACQAAAAACAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAACQAAAAADBAAAAAAABAAAAAADBAAAAAACBAAAAAADBAAAAAACBAAAAAAD
+          version: 6
+        0,-1:
+          ind: 0,-1
+          tiles: AQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAACAgAAAAAABAAAAAADAwAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAABBAAAAAACBAAAAAADAgAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAADBAAAAAABBAAAAAABCwAAAAAAAgAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAACBAAAAAABBAAAAAACCwAAAAAACwAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAACBAAAAAADBAAAAAACCwAAAAADCwAAAAABAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAADBAAAAAADBAAAAAAACwAAAAADCwAAAAACAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAABAAAAAABBAAAAAACCwAAAAADCwAAAAABAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAABAAAAAABBAAAAAADCwAAAAAACwAAAAADAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAADBAAAAAABBAAAAAADBAAAAAAACQAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAABCQAAAAABCQAAAAABBAAAAAADBAAAAAADAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAABDAAAAAAADAAAAAAABAAAAAADBAAAAAACAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAACCQAAAAACCQAAAAAABAAAAAACBAAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAADBAAAAAACBAAAAAAABAAAAAADCQAAAAADAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAA
+          version: 6
+        0,0:
+          ind: 0,0
+          tiles: CQAAAAACCQAAAAADBAAAAAAABAAAAAACBAAAAAADAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAACQAAAAAACQAAAAACCQAAAAAADQAAAAAADQAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAACQAAAAADCQAAAAADCQAAAAADDQAAAAAADQAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAACQAAAAACCQAAAAADBAAAAAAABAAAAAACBAAAAAACAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAACQAAAAADCQAAAAAACQAAAAACDQAAAAAADQAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAACQAAAAACCQAAAAADCQAAAAACDQAAAAAADQAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAACQAAAAADCQAAAAABBAAAAAADBAAAAAACBAAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAACQAAAAAACQAAAAAACQAAAAAADQAAAAAADQAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAACQAAAAACCQAAAAADCQAAAAABDQAAAAAADQAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAACQAAAAABCQAAAAAABAAAAAAABAAAAAABBAAAAAADAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAACQAAAAAACQAAAAABCQAAAAAACAAAAAAACAAAAAABAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAACQAAAAAACQAAAAACCQAAAAAACAAAAAABCAAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAACAAAAAADCQAAAAAACQAAAAAACAAAAAABCAAAAAADAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAACwAAAAACCwAAAAABCwAAAAACCwAAAAABAgAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAACwAAAAACCwAAAAACCwAAAAABCwAAAAABAgAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAACwAAAAAACwAAAAAACwAAAAADAgAAAAAAAgAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAA
+          version: 6
+        -1,1:
+          ind: -1,1
+          tiles: AQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAA
+          version: 6
+        0,1:
+          ind: 0,1
+          tiles: AgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAA
+          version: 6
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            color: '#FFFFFFFF'
+            id: Bot
+          decals:
+            138: 0,-7
+            139: 0,-8
+            269: -2,11
+            270: 0,-9
+        - node:
+            color: '#FFFFFFFF'
+            id: Box
+          decals:
+            181: 2,10
+        - node:
+            color: '#FFFFFFD9'
+            id: BrickTileDarkInnerNe
+          decals:
+            225: 3,-2
+            226: 0,-5
+            242: -3,-5
+            243: -6,-5
+        - node:
+            color: '#FFFFFFD9'
+            id: BrickTileDarkInnerNw
+          decals:
+            222: 0,-5
+            223: 3,-5
+            224: -6,-2
+            245: -3,-5
+        - node:
+            color: '#FFFFFFD9'
+            id: BrickTileDarkInnerSe
+          decals:
+            214: -3,-1
+            215: 0,-1
+            216: 3,-4
+            228: -6,-1
+        - node:
+            color: '#FFFFFFD9'
+            id: BrickTileDarkInnerSw
+          decals:
+            219: -3,-1
+            220: 0,-1
+            221: 3,-1
+            244: -6,-4
+        - node:
+            color: '#FFFFFFD9'
+            id: BrickTileDarkLineE
+          decals:
+            197: 0,-4
+            198: 0,-3
+            199: 0,-2
+            200: -3,-2
+            201: -3,-3
+            202: -3,-4
+            203: -6,-3
+            204: -6,-2
+            205: 3,-1
+            206: 3,-5
+            241: -6,-4
+        - node:
+            color: '#FFFFFFD9'
+            id: BrickTileDarkLineN
+          decals:
+            190: -7,-2
+            191: -5,-5
+            192: -4,-5
+            193: -2,-5
+            194: -1,-5
+            195: 2,-5
+            196: 4,-2
+            227: 1,-5
+        - node:
+            color: '#FFFFFFD9'
+            id: BrickTileDarkLineS
+          decals:
+            183: -4,-1
+            184: -5,-1
+            185: -2,-1
+            186: -1,-1
+            187: 1,-1
+            188: 2,-1
+            189: 4,-4
+            240: -7,-4
+        - node:
+            color: '#FFFFFFD9'
+            id: BrickTileDarkLineW
+          decals:
+            207: 3,-4
+            208: 0,-4
+            209: 0,-3
+            210: 0,-2
+            211: -3,-2
+            212: -3,-3
+            213: -3,-4
+            217: 3,-3
+            218: 3,-2
+            229: -6,-1
+            239: -6,-5
+        - node:
+            color: '#00FFFFFF'
+            id: BrickTileSteelCornerNe
+          decals:
+            171: 4,5
+        - node:
+            color: '#32CD32FF'
+            id: BrickTileSteelCornerNe
+          decals:
+            167: 4,2
+        - node:
+            color: '#A020F0FF'
+            id: BrickTileSteelCornerNe
+          decals:
+            176: 4,8
+        - node:
+            color: '#DE3A3ADC'
+            id: BrickTileSteelCornerNe
+          decals:
+            165: 4,-1
+        - node:
+            color: '#00FFFFFF'
+            id: BrickTileSteelCornerNw
+          decals:
+            174: 3,5
+        - node:
+            color: '#32CD32FF'
+            id: BrickTileSteelCornerNw
+          decals:
+            168: 3,2
+        - node:
+            color: '#52B4E9CD'
+            id: BrickTileSteelCornerNw
+          decals:
+            157: -7,-1
+        - node:
+            color: '#A020F0FF'
+            id: BrickTileSteelCornerNw
+          decals:
+            175: 3,8
+        - node:
+            color: '#00FFFFFF'
+            id: BrickTileSteelCornerSe
+          decals:
+            173: 4,4
+        - node:
+            color: '#32CD32FF'
+            id: BrickTileSteelCornerSe
+          decals:
+            170: 4,1
+        - node:
+            color: '#A020F0FF'
+            id: BrickTileSteelCornerSe
+          decals:
+            177: 4,7
+        - node:
+            color: '#00FFFFFF'
+            id: BrickTileSteelCornerSw
+          decals:
+            172: 3,4
+        - node:
+            color: '#32CD32FF'
+            id: BrickTileSteelCornerSw
+          decals:
+            169: 3,1
+        - node:
+            color: '#A020F0FF'
+            id: BrickTileSteelCornerSw
+          decals:
+            178: 3,7
+        - node:
+            color: '#52B4E996'
+            id: BrickTileSteelLineN
+          decals:
+            230: -6,-1
+            231: -6,-1
+        - node:
+            color: '#52B4E9CD'
+            id: BrickTileSteelLineN
+          decals:
+            158: -3,-1
+            159: -4,-1
+            160: -5,-1
+            161: -2,-1
+        - node:
+            color: '#DE3A3A96'
+            id: BrickTileSteelLineN
+          decals:
+            232: 3,-1
+            233: 3,-1
+        - node:
+            color: '#DE3A3ADC'
+            id: BrickTileSteelLineN
+          decals:
+            162: 0,-1
+            163: 1,-1
+            164: 2,-1
+        - node:
+            color: '#334E6DC8'
+            id: BrickTileWhiteCornerNe
+          decals:
+            7: -2,14
+            13: 2,12
+        - node:
+            color: '#52B4E9E3'
+            id: BrickTileWhiteCornerNe
+          decals:
+            97: -2,7
+        - node:
+            color: '#DE3A3A96'
+            id: BrickTileWhiteCornerNe
+          decals:
+            61: 1,8
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteCornerNe
+          decals:
+            124: -3,-7
+        - node:
+            color: '#F9801DE6'
+            id: BrickTileWhiteCornerNe
+          decals:
+            90: -4,12
+        - node:
+            color: '#334E6DC8'
+            id: BrickTileWhiteCornerNw
+          decals:
+            6: -5,14
+            12: 1,12
+        - node:
+            color: '#52B4E9E3'
+            id: BrickTileWhiteCornerNw
+          decals:
+            98: -3,7
+            119: -5,5
+        - node:
+            color: '#DE3A3A96'
+            id: BrickTileWhiteCornerNw
+          decals:
+            60: 0,8
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteCornerNw
+          decals:
+            123: -7,-7
+        - node:
+            color: '#F9801DEC'
+            id: BrickTileWhiteCornerNw
+          decals:
+            76: -6,12
+        - node:
+            color: '#334E6DC8'
+            id: BrickTileWhiteCornerSe
+          decals:
+            9: -2,9
+            10: 2,10
+        - node:
+            color: '#52B4E9E3'
+            id: BrickTileWhiteCornerSe
+          decals:
+            109: -2,1
+        - node:
+            color: '#9FED5896'
+            id: BrickTileWhiteCornerSe
+          decals:
+            248: 4,-5
+        - node:
+            color: '#DE3A3A96'
+            id: BrickTileWhiteCornerSe
+          decals:
+            62: 1,1
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteCornerSe
+          decals:
+            132: -3,-11
+        - node:
+            color: '#F9801DEC'
+            id: BrickTileWhiteCornerSe
+          decals:
+            78: -4,9
+        - node:
+            color: '#334E6DC8'
+            id: BrickTileWhiteCornerSw
+          decals:
+            8: -3,9
+            11: -5,13
+        - node:
+            color: '#52B4E9E3'
+            id: BrickTileWhiteCornerSw
+          decals:
+            110: -3,1
+        - node:
+            color: '#DE3A3A96'
+            id: BrickTileWhiteCornerSw
+          decals:
+            63: 0,1
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteCornerSw
+          decals:
+            133: -6,-11
+            134: -7,-10
+            247: -7,-5
+        - node:
+            color: '#F9801DE6'
+            id: BrickTileWhiteCornerSw
+          decals:
+            95: -6,9
+        - node:
+            color: '#334E6DC8'
+            id: BrickTileWhiteInnerNe
+          decals:
+            30: -2,11
+        - node:
+            color: '#334E6DC8'
+            id: BrickTileWhiteInnerNw
+          decals:
+            29: 1,11
+        - node:
+            color: '#334E6DC8'
+            id: BrickTileWhiteInnerSe
+          decals:
+            28: -2,10
+        - node:
+            color: '#52B4E9E3'
+            id: BrickTileWhiteInnerSe
+          decals:
+            122: -7,7
+        - node:
+            color: '#9FED5896'
+            id: BrickTileWhiteInnerSe
+          decals:
+            141: 2,-5
+        - node:
+            color: '#334E6DC8'
+            id: BrickTileWhiteInnerSw
+          decals:
+            31: -3,13
+        - node:
+            color: '#9FED5896'
+            id: BrickTileWhiteInnerSw
+          decals:
+            182: 0,-5
+        - node:
+            color: '#334E6DC8'
+            id: BrickTileWhiteLineE
+          decals:
+            25: -2,12
+            26: -2,13
+            27: 2,11
+        - node:
+            color: '#52B4E9E3'
+            id: BrickTileWhiteLineE
+          decals:
+            99: -2,6
+            100: -2,5
+            101: -2,4
+            102: -2,3
+            103: -2,2
+            111: -7,5
+            112: -7,6
+            113: -7,3
+            114: -7,2
+            115: -7,1
+        - node:
+            color: '#9FED5896'
+            id: BrickTileWhiteLineE
+          decals:
+            143: 2,-6
+            144: 2,-7
+            145: 2,-11
+            146: 2,-12
+            147: 2,-10
+            148: 2,-9
+            149: 2,-8
+        - node:
+            color: '#DE3A3A96'
+            id: BrickTileWhiteLineE
+          decals:
+            64: 1,2
+            65: 1,3
+            66: 1,4
+            67: 1,5
+            68: 1,6
+            69: 1,7
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteLineE
+          decals:
+            125: -3,-8
+            126: -3,-9
+            127: -3,-10
+        - node:
+            color: '#F9801DE6'
+            id: BrickTileWhiteLineE
+          decals:
+            92: -4,11
+            93: -4,10
+        - node:
+            color: '#334E6DC8'
+            id: BrickTileWhiteLineN
+          decals:
+            17: 0,11
+            18: -1,11
+            19: -3,14
+            20: -4,14
+            166: -1,-1
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteLineN
+          decals:
+            129: -6,-7
+            130: -5,-7
+            131: -4,-7
+        - node:
+            color: '#F9801DE6'
+            id: BrickTileWhiteLineN
+          decals:
+            91: -5,12
+        - node:
+            color: '#334E6DC8'
+            id: BrickTileWhiteLineS
+          decals:
+            14: -1,10
+            15: 0,10
+            16: 1,10
+            21: -4,13
+        - node:
+            color: '#52B4E9E3'
+            id: BrickTileWhiteLineS
+          decals:
+            120: -5,7
+            121: -6,7
+        - node:
+            color: '#9FED5896'
+            id: BrickTileWhiteLineS
+          decals:
+            179: -2,-5
+            180: -1,-5
+            234: 3,-5
+            235: 3,-5
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteLineS
+          decals:
+            136: -4,-11
+            137: -5,-11
+            236: -3,-5
+            237: -4,-5
+            238: -5,-5
+            246: -6,-5
+        - node:
+            color: '#F9801DE6'
+            id: BrickTileWhiteLineS
+          decals:
+            96: -5,9
+        - node:
+            color: '#334E6DC8'
+            id: BrickTileWhiteLineW
+          decals:
+            22: -3,10
+            23: -3,11
+            24: -3,12
+        - node:
+            color: '#52B4E9E3'
+            id: BrickTileWhiteLineW
+          decals:
+            104: -3,6
+            105: -3,5
+            106: -3,4
+            107: -3,3
+            108: -3,2
+            116: -5,1
+            117: -5,2
+            118: -5,3
+        - node:
+            color: '#9FED5896'
+            id: BrickTileWhiteLineW
+          decals:
+            150: 0,-12
+            151: 0,-11
+            152: 0,-10
+            153: 0,-9
+            154: 0,-8
+            155: 0,-6
+            156: 0,-7
+        - node:
+            color: '#DE3A3A96'
+            id: BrickTileWhiteLineW
+          decals:
+            70: 0,2
+            71: 0,3
+            72: 0,4
+            73: 0,5
+            74: 0,6
+            75: 0,7
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteLineW
+          decals:
+            128: -7,-8
+            135: -7,-9
+            258: -6,-10
+        - node:
+            color: '#F9801DE6'
+            id: BrickTileWhiteLineW
+          decals:
+            94: -6,10
+        - node:
+            color: '#F9801DEC'
+            id: BrickTileWhiteLineW
+          decals:
+            77: -6,11
+        - node:
+            angle: 3.141592653589793 rad
+            color: '#FFFFFFFF'
+            id: Caution
+          decals:
+            142: 1,-12
+        - node:
+            angle: 4.71238898038469 rad
+            color: '#FFFFFFFF'
+            id: Caution
+          decals:
+            140: 4,-3
+        - node:
+            color: '#52B4E996'
+            id: DeliveryGreyscale
+          decals:
+            253: -3,0
+            254: -2,0
+            255: -3,8
+            256: -2,8
+        - node:
+            color: '#DE3A3A7F'
+            id: DeliveryGreyscale
+          decals:
+            249: 0,9
+            250: 1,9
+            251: 0,0
+            252: 1,0
+        - node:
+            color: '#FFFFFFFF'
+            id: FlowersBRTwo
+          decals:
+            0: -4,-3
+        - node:
+            color: '#FFFFFFFF'
+            id: Flowersbr1
+          decals:
+            4: 2,-3
+        - node:
+            color: '#FFFFFFFF'
+            id: Flowerspv1
+          decals:
+            5: -2,-3
+        - node:
+            color: '#FFFFFFFF'
+            id: Flowerspv3
+          decals:
+            2: 1,-3
+        - node:
+            color: '#FFFFFFFF'
+            id: Flowersy3
+          decals:
+            1: -5,-3
+        - node:
+            color: '#FFFFFFFF'
+            id: Flowersy4
+          decals:
+            3: -1,-3
+        - node:
+            color: '#EFB34196'
+            id: FullTileOverlayGreyscale
+          decals:
+            257: -7,-10
+        - node:
+            color: '#F9801DC0'
+            id: FullTileOverlayGreyscale
+          decals:
+            87: -6,9
+            88: -5,10
+            89: -4,11
+        - node:
+            color: '#334E6DC8'
+            id: MiniTileWhiteBox
+          decals:
+            33: -6,13
+            34: -6,14
+            35: -5,15
+            36: -4,15
+            37: -3,15
+            38: -2,15
+        - node:
+            color: '#334E6DC8'
+            id: MonoOverlay
+          decals:
+            32: -1,9
+            39: -1,12
+            40: 0,12
+        - node:
+            color: '#F9801DC0'
+            id: ThreeQuarterTileOverlayGreyscale
+          decals:
+            85: -5,9
+            86: -4,10
+        - node:
+            color: '#F9801DC0'
+            id: ThreeQuarterTileOverlayGreyscale180
+          decals:
+            82: -4,12
+            83: -5,11
+            84: -6,10
+        - node:
+            color: '#D4D4D496'
+            id: WarnFullGreyscale
+          decals:
+            56: 3,12
+        - node:
+            color: '#DE3A3A96'
+            id: WarnFullGreyscale
+          decals:
+            57: 2,8
+            58: 2,5
+            59: 2,2
+        - node:
+            color: '#F9801DEC'
+            id: WarnFullGreyscale
+          decals:
+            79: -7,10
+            80: -7,9
+            81: -7,11
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinCornerNe
+          decals:
+            50: 2,15
+            265: 4,-6
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinCornerNw
+          decals:
+            42: -1,15
+            259: 3,-6
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinCornerSe
+          decals:
+            51: 2,13
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinCornerSw
+          decals:
+            41: -1,13
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinEndN
+          decals:
+            46: 3,14
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinEndS
+          decals:
+            47: 3,13
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinLineE
+          decals:
+            49: 2,14
+            266: 4,-7
+            267: 4,-8
+            268: 4,-9
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinLineN
+          decals:
+            43: 0,15
+            52: 1,15
+            53: 0,15
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinLineS
+          decals:
+            44: 0,13
+            45: 1,13
+            54: 1,13
+            55: 0,13
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinLineW
+          decals:
+            48: -1,14
+            260: 3,-7
+            261: 3,-8
+            262: 3,-9
+            263: 3,-10
+            264: 3,-11
+    - type: GridAtmosphere
+      version: 2
+      data:
+        tiles:
+          -2,0:
+            0: 61156
+          -2,1:
+            0: 61156
+          -2,2:
+            0: 61152
+          -2,3:
+            1: 4368
+            0: 36044
+          -2,-1:
+            0: 61423
+          -2,4:
+            1: 2
+          -1,1:
+            0: 26470
+          -1,2:
+            0: 65526
+          -1,3:
+            0: 65535
+          -1,-1:
+            0: 65535
+          -1,0:
+            0: 26214
+          0,0:
+            0: 16307
+          0,1:
+            0: 46075
+          0,2:
+            0: 65343
+          0,3:
+            0: 32767
+          -2,-3:
+            1: 275
+            0: 61120
+          -2,-2:
+            0: 59630
+          -2,-4:
+            1: 57344
+          -1,-4:
+            1: 61440
+          -1,-3:
+            0: 13104
+            2: 64
+            3: 16384
+          -1,-2:
+            0: 61747
+            1: 64
+          0,-4:
+            0: 20480
+            1: 32768
+          0,-3:
+            0: 65527
+          0,-2:
+            0: 65535
+          0,-1:
+            0: 65535
+          1,-4:
+            1: 4096
+          1,-3:
+            1: 547
+            0: 4352
+          1,-2:
+            0: 4369
+          1,-1:
+            0: 4883
+          1,0:
+            0: 272
+          1,1:
+            0: 4113
+          1,2:
+            0: 4353
+          1,3:
+            1: 8736
+          1,4:
+            1: 1
+        uniqueMixes:
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          immutable: True
+          moles:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 6666.982
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 0
+          - 6666.982
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        chunkSize: 4
+    - type: OccluderTree
+    - type: Shuttle
+    - type: RadiationGridResistance
+    - type: GravityShake
+      shakeTimes: 10
+    - type: GasTileOverlay
+    - type: SpreaderGrid
+    - type: GridPathfinding
+- proto: ActionToggleLight
+  entities:
+  - uid: 3
+    components:
+    - type: Transform
+      parent: 2
+    - type: InstantAction
+      container: 2
+- proto: AirAlarm
+  entities:
+  - uid: 399
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,3.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 432
+      - 436
+      - 426
+      - 438
+      - 937
+      - 940
+  - uid: 400
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,5.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 430
+      - 431
+      - 434
+      - 437
+      - 402
+      - 404
+      - 410
+      - 944
+      - 985
+      - 947
+      - 983
+      - 932
+  - uid: 936
+    components:
+    - type: Transform
+      pos: 4.5,12.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 422
+      - 421
+      - 424
+      - 425
+      - 426
+      - 438
+      - 430
+      - 431
+      - 630
+      - 624
+      - 614
+      - 606
+      - 423
+      - 420
+      - 623
+      - 605
+      - 627
+      - 612
+  - uid: 986
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-5.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 433
+      - 435
+      - 406
+      - 414
+      - 405
+      - 418
+      - 429
+      - 436
+      - 432
+      - 413
+      - 412
+      - 415
+      - 407
+      - 417
+      - 409
+      - 403
+      - 411
+      - 434
+      - 437
+      - 419
+      - 408
+      - 416
+      - 622
+      - 611
+      - 607
+      - 620
+  - uid: 987
+    components:
+    - type: Transform
+      pos: -2.5,-5.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 618
+      - 621
+      - 433
+      - 435
+  - uid: 988
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-9.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 628
+      - 609
+      - 416
+      - 408
+      - 419
+  - uid: 989
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,2.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 427
+      - 429
+      - 604
+      - 633
+  - uid: 990
+    components:
+    - type: Transform
+      pos: -5.5,8.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 632
+      - 608
+      - 428
+      - 427
+- proto: AirlockEngineeringLocked
+  entities:
+  - uid: 4
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-5.5
+      parent: 1
+  - uid: 5
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-5.5
+      parent: 1
+- proto: AirlockExternalGlassShuttleArrivals
+  entities:
+  - uid: 6
+    components:
+    - type: Transform
+      pos: 2.5,-12.5
+      parent: 1
+  - uid: 7
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-3.5
+      parent: 1
+  - uid: 8
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,-1.5
+      parent: 1
+  - uid: 11
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,-3.5
+      parent: 1
+  - uid: 12
+    components:
+    - type: Transform
+      pos: 0.5,-12.5
+      parent: 1
+  - uid: 13
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-1.5
+      parent: 1
+- proto: AirlockMedical
+  entities:
+  - uid: 15
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,4.5
+      parent: 1
+  - uid: 16
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,8.5
+      parent: 1
+  - uid: 17
+    components:
+    - type: Transform
+      pos: -2.5,8.5
+      parent: 1
+  - uid: 18
+    components:
+    - type: Transform
+      pos: -3.5,6.5
+      parent: 1
+- proto: AirlockMedicalGlassLocked
+  entities:
+  - uid: 19
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 20
+    components:
+    - type: Transform
+      pos: -5.5,0.5
+      parent: 1
+  - uid: 21
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,0.5
+      parent: 1
+- proto: AirlockSecurityLocked
+  entities:
+  - uid: 22
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 23
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 24
+    components:
+    - type: Transform
+      pos: 1.5,9.5
+      parent: 1
+  - uid: 25
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,9.5
+      parent: 1
+- proto: APCBasic
+  entities:
+  - uid: 26
+    components:
+    - type: Transform
+      pos: -5.5,-5.5
+      parent: 1
+  - uid: 27
+    components:
+    - type: Transform
+      pos: 2.5,9.5
+      parent: 1
+  - uid: 28
+    components:
+    - type: Transform
+      pos: -4.5,8.5
+      parent: 1
+- proto: AtmosDeviceFanDirectional
+  entities:
+  - uid: 30
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-3.5
+      parent: 1
+  - uid: 33
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,-1.5
+      parent: 1
+  - uid: 34
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,-3.5
+      parent: 1
+  - uid: 35
+    components:
+    - type: Transform
+      pos: 2.5,-12.5
+      parent: 1
+  - uid: 36
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-1.5
+      parent: 1
+  - uid: 37
+    components:
+    - type: Transform
+      pos: 0.5,-12.5
+      parent: 1
+- proto: AtmosFixBlockerMarker
+  entities:
+  - uid: 38
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-6.5
+      parent: 1
+- proto: AtmosFixNitrogenMarker
+  entities:
+  - uid: 39
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-8.5
+      parent: 1
+- proto: AtmosFixOxygenMarker
+  entities:
+  - uid: 40
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-10.5
+      parent: 1
+- proto: BaseGasCondenser
+  entities:
+  - uid: 560
+    components:
+    - type: Transform
+      pos: -5.5,12.5
+      parent: 1
+- proto: Bed
+  entities:
+  - uid: 41
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 1
+  - uid: 42
+    components:
+    - type: Transform
+      pos: 4.5,1.5
+      parent: 1
+  - uid: 43
+    components:
+    - type: Transform
+      pos: 4.5,7.5
+      parent: 1
+- proto: BedsheetMedical
+  entities:
+  - uid: 44
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,3.5
+      parent: 1
+  - uid: 45
+    components:
+    - type: Transform
+      pos: -6.5,2.5
+      parent: 1
+  - uid: 46
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,3.5
+      parent: 1
+  - uid: 47
+    components:
+    - type: Transform
+      pos: -6.5,5.5
+      parent: 1
+  - uid: 48
+    components:
+    - type: Transform
+      pos: -4.5,5.5
+      parent: 1
+  - uid: 49
+    components:
+    - type: Transform
+      pos: -4.5,2.5
+      parent: 1
+  - uid: 50
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,7.5
+      parent: 1
+- proto: BedsheetOrange
+  entities:
+  - uid: 51
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,7.5
+      parent: 1
+  - uid: 52
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,1.5
+      parent: 1
+  - uid: 53
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,4.5
+      parent: 1
+- proto: BlastDoorOpen
+  entities:
+  - uid: 992
+    components:
+    - type: Transform
+      pos: 5.5,4.5
+      parent: 1
+  - uid: 993
+    components:
+    - type: Transform
+      pos: 5.5,5.5
+      parent: 1
+  - uid: 994
+    components:
+    - type: Transform
+      pos: 5.5,7.5
+      parent: 1
+  - uid: 995
+    components:
+    - type: Transform
+      pos: 5.5,8.5
+      parent: 1
+  - uid: 996
+    components:
+    - type: Transform
+      pos: 5.5,1.5
+      parent: 1
+  - uid: 997
+    components:
+    - type: Transform
+      pos: 5.5,2.5
+      parent: 1
+- proto: BluespaceBeaker
+  entities:
+  - uid: 55
+    components:
+    - type: Transform
+      parent: 54
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 56
+    components:
+    - type: Transform
+      parent: 54
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: BoxFlashbang
+  entities:
+  - uid: 67
+    components:
+    - type: Transform
+      pos: 4.680676,10.896025
+      parent: 1
+- proto: BoxFolderBlack
+  entities:
+  - uid: 68
+    components:
+    - type: Transform
+      pos: 0.7460346,14.873093
+      parent: 1
+- proto: BoxFolderRed
+  entities:
+  - uid: 69
+    components:
+    - type: Transform
+      pos: 0.43353462,14.888718
+      parent: 1
+- proto: BoxHandcuff
+  entities:
+  - uid: 70
+    components:
+    - type: Transform
+      pos: 4.508801,10.59915
+      parent: 1
+- proto: BoxZiptie
+  entities:
+  - uid: 71
+    components:
+    - type: Transform
+      pos: 4.258801,10.833525
+      parent: 1
+- proto: ButtonFrameCaution
+  entities:
+  - uid: 1025
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,7.5
+      parent: 1
+- proto: CableApcExtension
+  entities:
+  - uid: 72
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 73
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 74
+    components:
+    - type: Transform
+      pos: -4.5,8.5
+      parent: 1
+  - uid: 75
+    components:
+    - type: Transform
+      pos: -7.5,9.5
+      parent: 1
+  - uid: 76
+    components:
+    - type: Transform
+      pos: -7.5,10.5
+      parent: 1
+  - uid: 77
+    components:
+    - type: Transform
+      pos: -6.5,14.5
+      parent: 1
+  - uid: 78
+    components:
+    - type: Transform
+      pos: -6.5,15.5
+      parent: 1
+  - uid: 79
+    components:
+    - type: Transform
+      pos: -5.5,15.5
+      parent: 1
+  - uid: 80
+    components:
+    - type: Transform
+      pos: -5.5,16.5
+      parent: 1
+  - uid: 81
+    components:
+    - type: Transform
+      pos: -4.5,16.5
+      parent: 1
+  - uid: 82
+    components:
+    - type: Transform
+      pos: -3.5,16.5
+      parent: 1
+  - uid: 83
+    components:
+    - type: Transform
+      pos: -2.5,16.5
+      parent: 1
+  - uid: 84
+    components:
+    - type: Transform
+      pos: -1.5,16.5
+      parent: 1
+  - uid: 85
+    components:
+    - type: Transform
+      pos: -0.5,16.5
+      parent: 1
+  - uid: 86
+    components:
+    - type: Transform
+      pos: 0.5,16.5
+      parent: 1
+  - uid: 87
+    components:
+    - type: Transform
+      pos: -5.5,-11.5
+      parent: 1
+  - uid: 88
+    components:
+    - type: Transform
+      pos: -4.5,6.5
+      parent: 1
+  - uid: 89
+    components:
+    - type: Transform
+      pos: -2.5,6.5
+      parent: 1
+  - uid: 90
+    components:
+    - type: Transform
+      pos: -5.5,5.5
+      parent: 1
+  - uid: 91
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 92
+    components:
+    - type: Transform
+      pos: -3.5,6.5
+      parent: 1
+  - uid: 93
+    components:
+    - type: Transform
+      pos: -5.5,4.5
+      parent: 1
+  - uid: 94
+    components:
+    - type: Transform
+      pos: -4.5,7.5
+      parent: 1
+  - uid: 95
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 1
+  - uid: 96
+    components:
+    - type: Transform
+      pos: -5.5,6.5
+      parent: 1
+  - uid: 97
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 1
+  - uid: 98
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 1
+  - uid: 99
+    components:
+    - type: Transform
+      pos: -5.5,3.5
+      parent: 1
+  - uid: 100
+    components:
+    - type: Transform
+      pos: -5.5,2.5
+      parent: 1
+  - uid: 101
+    components:
+    - type: Transform
+      pos: -5.5,1.5
+      parent: 1
+  - uid: 102
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 1
+  - uid: 103
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 1
+  - uid: 104
+    components:
+    - type: Transform
+      pos: -1.5,9.5
+      parent: 1
+  - uid: 105
+    components:
+    - type: Transform
+      pos: -1.5,10.5
+      parent: 1
+  - uid: 106
+    components:
+    - type: Transform
+      pos: -1.5,11.5
+      parent: 1
+  - uid: 107
+    components:
+    - type: Transform
+      pos: -1.5,12.5
+      parent: 1
+  - uid: 108
+    components:
+    - type: Transform
+      pos: -1.5,13.5
+      parent: 1
+  - uid: 109
+    components:
+    - type: Transform
+      pos: -2.5,13.5
+      parent: 1
+  - uid: 110
+    components:
+    - type: Transform
+      pos: -3.5,13.5
+      parent: 1
+  - uid: 111
+    components:
+    - type: Transform
+      pos: -4.5,13.5
+      parent: 1
+  - uid: 112
+    components:
+    - type: Transform
+      pos: -5.5,13.5
+      parent: 1
+  - uid: 113
+    components:
+    - type: Transform
+      pos: -6.5,13.5
+      parent: 1
+  - uid: 114
+    components:
+    - type: Transform
+      pos: 2.5,11.5
+      parent: 1
+  - uid: 115
+    components:
+    - type: Transform
+      pos: 1.5,11.5
+      parent: 1
+  - uid: 116
+    components:
+    - type: Transform
+      pos: 0.5,11.5
+      parent: 1
+  - uid: 117
+    components:
+    - type: Transform
+      pos: -0.5,11.5
+      parent: 1
+  - uid: 118
+    components:
+    - type: Transform
+      pos: 2.5,12.5
+      parent: 1
+  - uid: 119
+    components:
+    - type: Transform
+      pos: 2.5,13.5
+      parent: 1
+  - uid: 120
+    components:
+    - type: Transform
+      pos: 3.5,13.5
+      parent: 1
+  - uid: 121
+    components:
+    - type: Transform
+      pos: 4.5,13.5
+      parent: 1
+  - uid: 122
+    components:
+    - type: Transform
+      pos: 1.5,16.5
+      parent: 1
+  - uid: 123
+    components:
+    - type: Transform
+      pos: 4.5,14.5
+      parent: 1
+  - uid: 124
+    components:
+    - type: Transform
+      pos: 2.5,16.5
+      parent: 1
+  - uid: 125
+    components:
+    - type: Transform
+      pos: 3.5,16.5
+      parent: 1
+  - uid: 126
+    components:
+    - type: Transform
+      pos: 3.5,15.5
+      parent: 1
+  - uid: 127
+    components:
+    - type: Transform
+      pos: 4.5,15.5
+      parent: 1
+  - uid: 128
+    components:
+    - type: Transform
+      pos: -4.5,12.5
+      parent: 1
+  - uid: 129
+    components:
+    - type: Transform
+      pos: -4.5,10.5
+      parent: 1
+  - uid: 130
+    components:
+    - type: Transform
+      pos: -4.5,11.5
+      parent: 1
+  - uid: 131
+    components:
+    - type: Transform
+      pos: -5.5,10.5
+      parent: 1
+  - uid: 132
+    components:
+    - type: Transform
+      pos: 2.5,9.5
+      parent: 1
+  - uid: 133
+    components:
+    - type: Transform
+      pos: 2.5,8.5
+      parent: 1
+  - uid: 134
+    components:
+    - type: Transform
+      pos: 1.5,8.5
+      parent: 1
+  - uid: 135
+    components:
+    - type: Transform
+      pos: 1.5,7.5
+      parent: 1
+  - uid: 136
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 1
+  - uid: 137
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 138
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 139
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 140
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 141
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 142
+    components:
+    - type: Transform
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 143
+    components:
+    - type: Transform
+      pos: 4.5,2.5
+      parent: 1
+  - uid: 144
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 145
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 1
+  - uid: 146
+    components:
+    - type: Transform
+      pos: 4.5,5.5
+      parent: 1
+  - uid: 147
+    components:
+    - type: Transform
+      pos: 3.5,8.5
+      parent: 1
+  - uid: 148
+    components:
+    - type: Transform
+      pos: 4.5,8.5
+      parent: 1
+  - uid: 149
+    components:
+    - type: Transform
+      pos: -5.5,-5.5
+      parent: 1
+  - uid: 150
+    components:
+    - type: Transform
+      pos: -5.5,-6.5
+      parent: 1
+  - uid: 151
+    components:
+    - type: Transform
+      pos: -5.5,-7.5
+      parent: 1
+  - uid: 152
+    components:
+    - type: Transform
+      pos: -4.5,-7.5
+      parent: 1
+  - uid: 153
+    components:
+    - type: Transform
+      pos: -3.5,-7.5
+      parent: 1
+  - uid: 154
+    components:
+    - type: Transform
+      pos: -3.5,-6.5
+      parent: 1
+  - uid: 155
+    components:
+    - type: Transform
+      pos: -3.5,-5.5
+      parent: 1
+  - uid: 156
+    components:
+    - type: Transform
+      pos: -3.5,-4.5
+      parent: 1
+  - uid: 157
+    components:
+    - type: Transform
+      pos: -3.5,-3.5
+      parent: 1
+  - uid: 158
+    components:
+    - type: Transform
+      pos: -2.5,-3.5
+      parent: 1
+  - uid: 159
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 1
+  - uid: 160
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 1
+  - uid: 161
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+  - uid: 162
+    components:
+    - type: Transform
+      pos: 1.5,-3.5
+      parent: 1
+  - uid: 163
+    components:
+    - type: Transform
+      pos: 2.5,-3.5
+      parent: 1
+  - uid: 164
+    components:
+    - type: Transform
+      pos: 2.5,-4.5
+      parent: 1
+  - uid: 165
+    components:
+    - type: Transform
+      pos: 2.5,-5.5
+      parent: 1
+  - uid: 166
+    components:
+    - type: Transform
+      pos: 2.5,-6.5
+      parent: 1
+  - uid: 167
+    components:
+    - type: Transform
+      pos: 2.5,-7.5
+      parent: 1
+  - uid: 168
+    components:
+    - type: Transform
+      pos: 2.5,-8.5
+      parent: 1
+  - uid: 169
+    components:
+    - type: Transform
+      pos: 2.5,-9.5
+      parent: 1
+  - uid: 170
+    components:
+    - type: Transform
+      pos: 2.5,-10.5
+      parent: 1
+  - uid: 171
+    components:
+    - type: Transform
+      pos: 2.5,-11.5
+      parent: 1
+  - uid: 172
+    components:
+    - type: Transform
+      pos: 3.5,-11.5
+      parent: 1
+  - uid: 173
+    components:
+    - type: Transform
+      pos: 4.5,-11.5
+      parent: 1
+  - uid: 174
+    components:
+    - type: Transform
+      pos: 4.5,-10.5
+      parent: 1
+  - uid: 175
+    components:
+    - type: Transform
+      pos: 4.5,-9.5
+      parent: 1
+  - uid: 176
+    components:
+    - type: Transform
+      pos: 5.5,-9.5
+      parent: 1
+  - uid: 177
+    components:
+    - type: Transform
+      pos: 5.5,-8.5
+      parent: 1
+  - uid: 178
+    components:
+    - type: Transform
+      pos: 5.5,-7.5
+      parent: 1
+  - uid: 179
+    components:
+    - type: Transform
+      pos: 5.5,-6.5
+      parent: 1
+  - uid: 180
+    components:
+    - type: Transform
+      pos: 5.5,-5.5
+      parent: 1
+  - uid: 181
+    components:
+    - type: Transform
+      pos: -2.5,-7.5
+      parent: 1
+  - uid: 182
+    components:
+    - type: Transform
+      pos: -2.5,-8.5
+      parent: 1
+  - uid: 183
+    components:
+    - type: Transform
+      pos: -2.5,-9.5
+      parent: 1
+  - uid: 184
+    components:
+    - type: Transform
+      pos: -2.5,-10.5
+      parent: 1
+  - uid: 185
+    components:
+    - type: Transform
+      pos: -2.5,-11.5
+      parent: 1
+  - uid: 186
+    components:
+    - type: Transform
+      pos: -3.5,-11.5
+      parent: 1
+  - uid: 187
+    components:
+    - type: Transform
+      pos: -4.5,-11.5
+      parent: 1
+  - uid: 188
+    components:
+    - type: Transform
+      pos: -5.5,-11.5
+      parent: 1
+  - uid: 189
+    components:
+    - type: Transform
+      pos: -6.5,-11.5
+      parent: 1
+  - uid: 190
+    components:
+    - type: Transform
+      pos: -6.5,-10.5
+      parent: 1
+  - uid: 191
+    components:
+    - type: Transform
+      pos: -6.5,-9.5
+      parent: 1
+  - uid: 192
+    components:
+    - type: Transform
+      pos: -5.5,-8.5
+      parent: 1
+  - uid: 193
+    components:
+    - type: Transform
+      pos: -4.5,-3.5
+      parent: 1
+  - uid: 194
+    components:
+    - type: Transform
+      pos: -5.5,-3.5
+      parent: 1
+  - uid: 195
+    components:
+    - type: Transform
+      pos: -5.5,-2.5
+      parent: 1
+  - uid: 196
+    components:
+    - type: Transform
+      pos: -5.5,-1.5
+      parent: 1
+  - uid: 197
+    components:
+    - type: Transform
+      pos: -4.5,-1.5
+      parent: 1
+  - uid: 198
+    components:
+    - type: Transform
+      pos: -3.5,-1.5
+      parent: 1
+  - uid: 199
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 1
+  - uid: 200
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 1
+  - uid: 201
+    components:
+    - type: Transform
+      pos: -0.5,-1.5
+      parent: 1
+  - uid: 202
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 1
+  - uid: 203
+    components:
+    - type: Transform
+      pos: 1.5,-1.5
+      parent: 1
+  - uid: 204
+    components:
+    - type: Transform
+      pos: 2.5,-1.5
+      parent: 1
+  - uid: 205
+    components:
+    - type: Transform
+      pos: 3.5,-1.5
+      parent: 1
+  - uid: 206
+    components:
+    - type: Transform
+      pos: 3.5,-2.5
+      parent: 1
+  - uid: 207
+    components:
+    - type: Transform
+      pos: 3.5,-3.5
+      parent: 1
+  - uid: 208
+    components:
+    - type: Transform
+      pos: -6.5,1.5
+      parent: 1
+  - uid: 209
+    components:
+    - type: Transform
+      pos: -7.5,1.5
+      parent: 1
+  - uid: 210
+    components:
+    - type: Transform
+      pos: -7.5,2.5
+      parent: 1
+  - uid: 211
+    components:
+    - type: Transform
+      pos: -7.5,3.5
+      parent: 1
+  - uid: 212
+    components:
+    - type: Transform
+      pos: -7.5,4.5
+      parent: 1
+  - uid: 213
+    components:
+    - type: Transform
+      pos: -7.5,5.5
+      parent: 1
+  - uid: 214
+    components:
+    - type: Transform
+      pos: -7.5,6.5
+      parent: 1
+  - uid: 215
+    components:
+    - type: Transform
+      pos: -7.5,7.5
+      parent: 1
+  - uid: 216
+    components:
+    - type: Transform
+      pos: -7.5,8.5
+      parent: 1
+  - uid: 217
+    components:
+    - type: Transform
+      pos: -7.5,9.5
+      parent: 1
+  - uid: 218
+    components:
+    - type: Transform
+      pos: -7.5,10.5
+      parent: 1
+  - uid: 219
+    components:
+    - type: Transform
+      pos: -6.5,10.5
+      parent: 1
+  - uid: 220
+    components:
+    - type: Transform
+      pos: -5.5,-9.5
+      parent: 1
+- proto: CableHV
+  entities:
+  - uid: 221
+    components:
+    - type: Transform
+      pos: -5.5,-10.5
+      parent: 1
+  - uid: 222
+    components:
+    - type: Transform
+      pos: -5.5,-8.5
+      parent: 1
+  - uid: 223
+    components:
+    - type: Transform
+      pos: -6.5,-7.5
+      parent: 1
+  - uid: 224
+    components:
+    - type: Transform
+      pos: -4.5,-8.5
+      parent: 1
+  - uid: 225
+    components:
+    - type: Transform
+      pos: -6.5,-8.5
+      parent: 1
+  - uid: 226
+    components:
+    - type: Transform
+      pos: -4.5,-10.5
+      parent: 1
+  - uid: 227
+    components:
+    - type: Transform
+      pos: -2.5,-7.5
+      parent: 1
+  - uid: 228
+    components:
+    - type: Transform
+      pos: -6.5,-6.5
+      parent: 1
+  - uid: 229
+    components:
+    - type: Transform
+      pos: -3.5,-8.5
+      parent: 1
+  - uid: 230
+    components:
+    - type: Transform
+      pos: -2.5,-8.5
+      parent: 1
+  - uid: 231
+    components:
+    - type: Transform
+      pos: -5.5,-9.5
+      parent: 1
+- proto: CableMV
+  entities:
+  - uid: 232
+    components:
+    - type: Transform
+      pos: -5.5,-5.5
+      parent: 1
+  - uid: 233
+    components:
+    - type: Transform
+      pos: -6.5,-6.5
+      parent: 1
+  - uid: 234
+    components:
+    - type: Transform
+      pos: -5.5,-6.5
+      parent: 1
+  - uid: 235
+    components:
+    - type: Transform
+      pos: -5.5,-7.5
+      parent: 1
+  - uid: 236
+    components:
+    - type: Transform
+      pos: -4.5,-7.5
+      parent: 1
+  - uid: 237
+    components:
+    - type: Transform
+      pos: -3.5,-7.5
+      parent: 1
+  - uid: 238
+    components:
+    - type: Transform
+      pos: -3.5,-6.5
+      parent: 1
+  - uid: 239
+    components:
+    - type: Transform
+      pos: -3.5,-5.5
+      parent: 1
+  - uid: 240
+    components:
+    - type: Transform
+      pos: -3.5,-4.5
+      parent: 1
+  - uid: 241
+    components:
+    - type: Transform
+      pos: -3.5,-3.5
+      parent: 1
+  - uid: 242
+    components:
+    - type: Transform
+      pos: -2.5,-3.5
+      parent: 1
+  - uid: 243
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 1
+  - uid: 244
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 1
+  - uid: 245
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+  - uid: 246
+    components:
+    - type: Transform
+      pos: 1.5,-3.5
+      parent: 1
+  - uid: 247
+    components:
+    - type: Transform
+      pos: 2.5,-3.5
+      parent: 1
+  - uid: 248
+    components:
+    - type: Transform
+      pos: 3.5,-3.5
+      parent: 1
+  - uid: 249
+    components:
+    - type: Transform
+      pos: 3.5,-2.5
+      parent: 1
+  - uid: 250
+    components:
+    - type: Transform
+      pos: 3.5,-1.5
+      parent: 1
+  - uid: 251
+    components:
+    - type: Transform
+      pos: 2.5,-1.5
+      parent: 1
+  - uid: 252
+    components:
+    - type: Transform
+      pos: 1.5,-1.5
+      parent: 1
+  - uid: 253
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 1
+  - uid: 254
+    components:
+    - type: Transform
+      pos: -0.5,-1.5
+      parent: 1
+  - uid: 255
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 1
+  - uid: 256
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 1
+  - uid: 257
+    components:
+    - type: Transform
+      pos: -3.5,-1.5
+      parent: 1
+  - uid: 258
+    components:
+    - type: Transform
+      pos: -4.5,-1.5
+      parent: 1
+  - uid: 259
+    components:
+    - type: Transform
+      pos: -5.5,-1.5
+      parent: 1
+  - uid: 260
+    components:
+    - type: Transform
+      pos: -5.5,-2.5
+      parent: 1
+  - uid: 261
+    components:
+    - type: Transform
+      pos: -5.5,-3.5
+      parent: 1
+  - uid: 262
+    components:
+    - type: Transform
+      pos: -4.5,-3.5
+      parent: 1
+  - uid: 263
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 1
+  - uid: 264
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 265
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 266
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 1
+  - uid: 267
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 1
+  - uid: 268
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 269
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 270
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 1
+  - uid: 271
+    components:
+    - type: Transform
+      pos: -2.5,6.5
+      parent: 1
+  - uid: 272
+    components:
+    - type: Transform
+      pos: -3.5,6.5
+      parent: 1
+  - uid: 273
+    components:
+    - type: Transform
+      pos: -4.5,6.5
+      parent: 1
+  - uid: 274
+    components:
+    - type: Transform
+      pos: -4.5,7.5
+      parent: 1
+  - uid: 275
+    components:
+    - type: Transform
+      pos: -4.5,8.5
+      parent: 1
+  - uid: 276
+    components:
+    - type: Transform
+      pos: 1.5,8.5
+      parent: 1
+  - uid: 277
+    components:
+    - type: Transform
+      pos: 1.5,7.5
+      parent: 1
+  - uid: 278
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 1
+  - uid: 279
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 280
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 281
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 282
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 283
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 284
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 285
+    components:
+    - type: Transform
+      pos: 1.5,-0.5
+      parent: 1
+  - uid: 286
+    components:
+    - type: Transform
+      pos: 2.5,8.5
+      parent: 1
+  - uid: 287
+    components:
+    - type: Transform
+      pos: 2.5,9.5
+      parent: 1
+  - uid: 288
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 1
+  - uid: 289
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 1
+  - uid: 290
+    components:
+    - type: Transform
+      pos: -1.5,9.5
+      parent: 1
+  - uid: 291
+    components:
+    - type: Transform
+      pos: -1.5,10.5
+      parent: 1
+  - uid: 292
+    components:
+    - type: Transform
+      pos: -1.5,11.5
+      parent: 1
+  - uid: 293
+    components:
+    - type: Transform
+      pos: -1.5,12.5
+      parent: 1
+  - uid: 294
+    components:
+    - type: Transform
+      pos: -1.5,13.5
+      parent: 1
+  - uid: 295
+    components:
+    - type: Transform
+      pos: -2.5,13.5
+      parent: 1
+  - uid: 296
+    components:
+    - type: Transform
+      pos: -3.5,13.5
+      parent: 1
+  - uid: 297
+    components:
+    - type: Transform
+      pos: -4.5,13.5
+      parent: 1
+  - uid: 298
+    components:
+    - type: Transform
+      pos: -5.5,13.5
+      parent: 1
+  - uid: 299
+    components:
+    - type: Transform
+      pos: -6.5,13.5
+      parent: 1
+  - uid: 300
+    components:
+    - type: Transform
+      pos: -6.5,14.5
+      parent: 1
+  - uid: 301
+    components:
+    - type: Transform
+      pos: -6.5,15.5
+      parent: 1
+  - uid: 302
+    components:
+    - type: Transform
+      pos: -5.5,15.5
+      parent: 1
+  - uid: 303
+    components:
+    - type: Transform
+      pos: -5.5,16.5
+      parent: 1
+  - uid: 304
+    components:
+    - type: Transform
+      pos: -4.5,16.5
+      parent: 1
+  - uid: 305
+    components:
+    - type: Transform
+      pos: -3.5,16.5
+      parent: 1
+  - uid: 306
+    components:
+    - type: Transform
+      pos: -2.5,16.5
+      parent: 1
+  - uid: 307
+    components:
+    - type: Transform
+      pos: -1.5,16.5
+      parent: 1
+  - uid: 308
+    components:
+    - type: Transform
+      pos: -0.5,16.5
+      parent: 1
+  - uid: 309
+    components:
+    - type: Transform
+      pos: 0.5,16.5
+      parent: 1
+  - uid: 310
+    components:
+    - type: Transform
+      pos: 1.5,16.5
+      parent: 1
+  - uid: 311
+    components:
+    - type: Transform
+      pos: 2.5,16.5
+      parent: 1
+  - uid: 312
+    components:
+    - type: Transform
+      pos: 3.5,16.5
+      parent: 1
+  - uid: 313
+    components:
+    - type: Transform
+      pos: 3.5,15.5
+      parent: 1
+  - uid: 314
+    components:
+    - type: Transform
+      pos: 4.5,15.5
+      parent: 1
+  - uid: 315
+    components:
+    - type: Transform
+      pos: 4.5,14.5
+      parent: 1
+  - uid: 316
+    components:
+    - type: Transform
+      pos: 4.5,13.5
+      parent: 1
+  - uid: 317
+    components:
+    - type: Transform
+      pos: 3.5,13.5
+      parent: 1
+  - uid: 318
+    components:
+    - type: Transform
+      pos: 2.5,13.5
+      parent: 1
+  - uid: 319
+    components:
+    - type: Transform
+      pos: 2.5,12.5
+      parent: 1
+  - uid: 320
+    components:
+    - type: Transform
+      pos: 2.5,11.5
+      parent: 1
+  - uid: 321
+    components:
+    - type: Transform
+      pos: 1.5,11.5
+      parent: 1
+  - uid: 322
+    components:
+    - type: Transform
+      pos: 0.5,11.5
+      parent: 1
+  - uid: 323
+    components:
+    - type: Transform
+      pos: -0.5,11.5
+      parent: 1
+  - uid: 324
+    components:
+    - type: Transform
+      pos: 2.5,10.5
+      parent: 1
+  - uid: 325
+    components:
+    - type: Transform
+      pos: 3.5,11.5
+      parent: 1
+  - uid: 326
+    components:
+    - type: Transform
+      pos: 4.5,11.5
+      parent: 1
+  - uid: 327
+    components:
+    - type: Transform
+      pos: 5.5,11.5
+      parent: 1
+  - uid: 328
+    components:
+    - type: Transform
+      pos: 5.5,10.5
+      parent: 1
+  - uid: 329
+    components:
+    - type: Transform
+      pos: 5.5,9.5
+      parent: 1
+  - uid: 330
+    components:
+    - type: Transform
+      pos: 5.5,8.5
+      parent: 1
+  - uid: 331
+    components:
+    - type: Transform
+      pos: 5.5,7.5
+      parent: 1
+  - uid: 332
+    components:
+    - type: Transform
+      pos: 5.5,6.5
+      parent: 1
+  - uid: 333
+    components:
+    - type: Transform
+      pos: 5.5,5.5
+      parent: 1
+  - uid: 334
+    components:
+    - type: Transform
+      pos: 5.5,4.5
+      parent: 1
+  - uid: 335
+    components:
+    - type: Transform
+      pos: 5.5,3.5
+      parent: 1
+  - uid: 336
+    components:
+    - type: Transform
+      pos: 5.5,2.5
+      parent: 1
+  - uid: 337
+    components:
+    - type: Transform
+      pos: 5.5,1.5
+      parent: 1
+  - uid: 338
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 1
+  - uid: 339
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 340
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+  - uid: 341
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+- proto: CableTerminal
+  entities:
+  - uid: 342
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-8.5
+      parent: 1
+- proto: Catwalk
+  entities:
+  - uid: 998
+    components:
+    - type: Transform
+      pos: 5.5,13.5
+      parent: 1
+  - uid: 999
+    components:
+    - type: Transform
+      pos: 5.5,14.5
+      parent: 1
+  - uid: 1000
+    components:
+    - type: Transform
+      pos: 5.5,15.5
+      parent: 1
+  - uid: 1001
+    components:
+    - type: Transform
+      pos: 4.5,16.5
+      parent: 1
+  - uid: 1002
+    components:
+    - type: Transform
+      pos: -7.5,13.5
+      parent: 1
+  - uid: 1003
+    components:
+    - type: Transform
+      pos: -7.5,15.5
+      parent: 1
+  - uid: 1004
+    components:
+    - type: Transform
+      pos: -7.5,14.5
+      parent: 1
+  - uid: 1005
+    components:
+    - type: Transform
+      pos: -6.5,16.5
+      parent: 1
+  - uid: 1006
+    components:
+    - type: Transform
+      pos: -6.5,-12.5
+      parent: 1
+  - uid: 1007
+    components:
+    - type: Transform
+      pos: -5.5,-12.5
+      parent: 1
+  - uid: 1008
+    components:
+    - type: Transform
+      pos: -4.5,-12.5
+      parent: 1
+  - uid: 1009
+    components:
+    - type: Transform
+      pos: -2.5,-12.5
+      parent: 1
+  - uid: 1010
+    components:
+    - type: Transform
+      pos: -1.5,-12.5
+      parent: 1
+  - uid: 1011
+    components:
+    - type: Transform
+      pos: -3.5,-12.5
+      parent: 1
+  - uid: 1012
+    components:
+    - type: Transform
+      pos: -7.5,-11.5
+      parent: 1
+  - uid: 1013
+    components:
+    - type: Transform
+      pos: -7.5,-10.5
+      parent: 1
+  - uid: 1014
+    components:
+    - type: Transform
+      pos: 5.5,-11.5
+      parent: 1
+  - uid: 1015
+    components:
+    - type: Transform
+      pos: 5.5,-10.5
+      parent: 1
+  - uid: 1016
+    components:
+    - type: Transform
+      pos: 4.5,-12.5
+      parent: 1
+- proto: ChairOfficeDark
+  entities:
+  - uid: 343
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,11.5
+      parent: 1
+- proto: ChairPilotSeat
+  entities:
+  - uid: 344
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-9.5
+      parent: 1
+  - uid: 345
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,15.5
+      parent: 1
+  - uid: 346
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 347
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,14.5
+      parent: 1
+  - uid: 348
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,13.5
+      parent: 1
+  - uid: 349
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,14.5
+      parent: 1
+  - uid: 350
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,6.5
+      parent: 1
+  - uid: 351
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,14.5
+      parent: 1
+  - uid: 352
+    components:
+    - type: Transform
+      pos: -4.5,-3.5
+      parent: 1
+  - uid: 353
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,14.5
+      parent: 1
+  - uid: 354
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-1.5
+      parent: 1
+  - uid: 355
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-1.5
+      parent: 1
+  - uid: 356
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-0.5
+      parent: 1
+  - uid: 357
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-4.5
+      parent: 1
+  - uid: 358
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,14.5
+      parent: 1
+  - uid: 359
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,15.5
+      parent: 1
+  - uid: 360
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-8.5
+      parent: 1
+  - uid: 361
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-9.5
+      parent: 1
+  - uid: 362
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 1
+  - uid: 363
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-1.5
+      parent: 1
+  - uid: 364
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-8.5
+      parent: 1
+  - uid: 365
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-1.5
+      parent: 1
+  - uid: 366
+    components:
+    - type: Transform
+      pos: -3.5,-3.5
+      parent: 1
+  - uid: 367
+    components:
+    - type: Transform
+      pos: 2.5,-3.5
+      parent: 1
+  - uid: 368
+    components:
+    - type: Transform
+      pos: 1.5,-3.5
+      parent: 1
+  - uid: 369
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-0.5
+      parent: 1
+  - uid: 370
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 1
+  - uid: 371
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-1.5
+      parent: 1
+  - uid: 372
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-1.5
+      parent: 1
+  - uid: 373
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-4.5
+      parent: 1
+  - uid: 374
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,14.5
+      parent: 1
+- proto: ChemDispenser
+  entities:
+  - uid: 376
+    components:
+    - type: Transform
+      pos: -5.5,9.5
+      parent: 1
+- proto: ChemistryHotplate
+  entities:
+  - uid: 377
+    components:
+    - type: Transform
+      pos: -3.5,12.5
+      parent: 1
+- proto: ChemMaster
+  entities:
+  - uid: 375
+    components:
+    - type: Transform
+      pos: -4.5,9.5
+      parent: 1
+- proto: ComfyChair
+  entities:
+  - uid: 378
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-7.5
+      parent: 1
+  - uid: 379
+    components:
+    - type: Transform
+      pos: 4.5,-5.5
+      parent: 1
+  - uid: 380
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-7.5
+      parent: 1
+  - uid: 381
+    components:
+    - type: Transform
+      pos: 3.5,-5.5
+      parent: 1
+- proto: ComputerAlert
+  entities:
+  - uid: 382
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,14.5
+      parent: 1
+- proto: ComputerComms
+  entities:
+  - uid: 383
+    components:
+    - type: Transform
+      pos: -2.5,15.5
+      parent: 1
+- proto: ComputerId
+  entities:
+  - uid: 384
+    components:
+    - type: Transform
+      pos: -4.5,15.5
+      parent: 1
+- proto: ComputerRadar
+  entities:
+  - uid: 386
+    components:
+    - type: Transform
+      pos: -1.5,15.5
+      parent: 1
+- proto: ComputerShuttle
+  entities:
+  - uid: 387
+    components:
+    - type: Transform
+      pos: -3.5,15.5
+      parent: 1
+- proto: CrateEmergencyExplosive
+  entities:
+  - uid: 388
+    components:
+    - type: Transform
+      pos: 2.5,10.5
+      parent: 1
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.1496
+        moles:
+        - 1.8856695
+        - 7.0937095
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+- proto: CrateEmergencyInternalsLarge
+  entities:
+  - uid: 389
+    components:
+    - type: Transform
+      pos: 0.5,-7.5
+      parent: 1
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.1496
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+  - uid: 390
+    components:
+    - type: Transform
+      pos: 0.5,-6.5
+      parent: 1
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.1496
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+- proto: CrateParticleDecelerators
+  entities:
+  - uid: 1027
+    components:
+    - type: Transform
+      pos: 0.5,-8.5
+      parent: 1
+- proto: DefibrillatorCabinet
+  entities:
+  - uid: 391
+    components:
+    - type: Transform
+      pos: -6.5,4.5
+      parent: 1
+  - uid: 392
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,7.5
+      parent: 1
+- proto: DrinkMugGreen
+  entities:
+  - uid: 393
+    components:
+    - type: Transform
+      pos: 3.7066736,14.779343
+      parent: 1
+  - uid: 394
+    components:
+    - type: Transform
+      pos: 3.3703594,14.794968
+      parent: 1
+- proto: DrinkWaterJug
+  entities:
+  - uid: 57
+    components:
+    - type: Transform
+      parent: 54
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 58
+    components:
+    - type: Transform
+      parent: 54
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 59
+    components:
+    - type: Transform
+      parent: 54
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 60
+    components:
+    - type: Transform
+      parent: 54
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: EmergencyLight
+  entities:
+  - uid: 395
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-7.5
+      parent: 1
+- proto: EmergencyRollerBed
+  entities:
+  - uid: 396
+    components:
+    - type: Transform
+      pos: -1.5180254,6.168866
+      parent: 1
+  - uid: 397
+    components:
+    - type: Transform
+      pos: -1.5803733,2.965352
+      parent: 1
+  - uid: 398
+    components:
+    - type: Transform
+      pos: -1.5492754,2.4657412
+      parent: 1
+  - uid: 948
+    components:
+    - type: Transform
+      pos: -1.5508257,3.7665472
+      parent: 1
+  - uid: 984
+    components:
+    - type: Transform
+      pos: -1.5091591,5.47488
+      parent: 1
+- proto: FaxMachineBase
+  entities:
+  - uid: 401
+    components:
+    - type: Transform
+      pos: -5.5,13.5
+      parent: 1
+    - type: FaxMachine
+      name: NT-Hygieia
+- proto: FirelockEdge
+  entities:
+  - uid: 402
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,2.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 400
+  - uid: 403
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 986
+  - uid: 404
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,5.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 400
+  - uid: 405
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-1.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 986
+  - uid: 406
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-4.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 986
+  - uid: 407
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 986
+  - uid: 408
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-5.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 986
+      - 988
+  - uid: 409
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-4.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 986
+  - uid: 410
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,8.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 400
+  - uid: 411
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-2.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 986
+  - uid: 412
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-1.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 986
+  - uid: 413
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-0.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 986
+  - uid: 414
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-3.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 986
+  - uid: 415
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-2.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 986
+  - uid: 416
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-5.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 986
+      - 988
+  - uid: 417
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-3.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 986
+  - uid: 418
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-0.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 986
+  - uid: 419
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-5.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 986
+      - 988
+  - uid: 420
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,10.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 936
+  - uid: 421
+    components:
+    - type: Transform
+      pos: 1.5,13.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 936
+  - uid: 422
+    components:
+    - type: Transform
+      pos: 2.5,13.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 936
+  - uid: 423
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,11.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 936
+  - uid: 424
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,12.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 936
+  - uid: 425
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,12.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 936
+- proto: FirelockGlass
+  entities:
+  - uid: 426
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,8.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 936
+      - 399
+  - uid: 427
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,4.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 990
+      - 989
+  - uid: 428
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,6.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 990
+  - uid: 429
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,0.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 986
+      - 989
+  - uid: 430
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,9.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 936
+      - 400
+  - uid: 431
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,9.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 936
+      - 400
+  - uid: 432
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,0.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 986
+      - 399
+  - uid: 433
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-5.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 987
+      - 986
+  - uid: 434
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,0.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 986
+      - 400
+  - uid: 435
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-5.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 987
+      - 986
+  - uid: 436
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,0.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 986
+      - 399
+  - uid: 437
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,0.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 986
+      - 400
+  - uid: 438
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,8.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 936
+      - 399
+- proto: FloorDrain
+  entities:
+  - uid: 941
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,10.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: FoodBoxDonut
+  entities:
+  - uid: 439
+    components:
+    - type: Transform
+      pos: 0.4396093,12.674404
+      parent: 1
+  - uid: 440
+    components:
+    - type: Transform
+      pos: 3.5285802,14.419968
+      parent: 1
+- proto: GasMinerNitrogen
+  entities:
+  - uid: 441
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-8.5
+      parent: 1
+- proto: GasMinerOxygen
+  entities:
+  - uid: 442
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-10.5
+      parent: 1
+- proto: GasMixer
+  entities:
+  - uid: 443
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-8.5
+      parent: 1
+    - type: GasMixer
+      inletTwoConcentration: 0.78
+      inletOneConcentration: 0.22
+    - type: AtmosPipeColor
+      color: '#03FCD3FF'
+- proto: GasPassiveVent
+  entities:
+  - uid: 619
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeBend
+  entities:
+  - uid: 444
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 445
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 446
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 447
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 448
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 449
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#03FCD3FF'
+  - uid: 450
+    components:
+    - type: Transform
+      pos: 2.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 625
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeFourway
+  entities:
+  - uid: 451
+    components:
+    - type: Transform
+      pos: -1.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 577
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 579
+    components:
+    - type: Transform
+      pos: 1.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 591
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeStraight
+  entities:
+  - uid: 452
+    components:
+    - type: Transform
+      pos: -4.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 453
+    components:
+    - type: Transform
+      pos: 3.5,-5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 454
+    components:
+    - type: Transform
+      pos: 3.5,-7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 455
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 456
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 457
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 458
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 459
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 460
+    components:
+    - type: Transform
+      pos: -2.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 461
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 462
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 463
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 465
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,13.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 466
+    components:
+    - type: Transform
+      pos: 0.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 467
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 468
+    components:
+    - type: Transform
+      pos: 0.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 469
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 470
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 471
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 472
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 473
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 474
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 475
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 476
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 477
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 478
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 479
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 480
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 481
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 482
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 483
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 484
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 485
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 486
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 487
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 488
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 489
+    components:
+    - type: Transform
+      pos: 1.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 490
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 491
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,14.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 492
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 493
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 494
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 495
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 496
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,13.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 497
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 498
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 499
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 500
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 501
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 502
+    components:
+    - type: Transform
+      pos: -0.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 503
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 504
+    components:
+    - type: Transform
+      pos: 2.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 505
+    components:
+    - type: Transform
+      pos: 2.5,-7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 506
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#03FCD3FF'
+  - uid: 507
+    components:
+    - type: Transform
+      pos: 1.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 508
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 509
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 510
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 511
+    components:
+    - type: Transform
+      pos: -4.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 512
+    components:
+    - type: Transform
+      pos: -2.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 513
+    components:
+    - type: Transform
+      pos: -4.5,-5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 514
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 515
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 516
+    components:
+    - type: Transform
+      pos: 2.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 517
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 518
+    components:
+    - type: Transform
+      pos: 2.5,-5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 519
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 520
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 521
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 522
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 523
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 524
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 525
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 526
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,13.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 527
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 528
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 529
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 530
+    components:
+    - type: Transform
+      pos: 1.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 531
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 532
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,14.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 533
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 534
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 536
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,14.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 537
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 538
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 539
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 540
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 541
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 542
+    components:
+    - type: Transform
+      pos: -2.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 544
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 545
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 546
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 547
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 549
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 550
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 551
+    components:
+    - type: Transform
+      pos: 3.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 552
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 553
+    components:
+    - type: Transform
+      pos: 3.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 554
+    components:
+    - type: Transform
+      pos: 3.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 555
+    components:
+    - type: Transform
+      pos: 3.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 556
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 557
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 558
+    components:
+    - type: Transform
+      pos: -0.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 559
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 561
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 562
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 563
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 564
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 565
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 566
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 567
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 568
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 569
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 570
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 571
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 572
+    components:
+    - type: Transform
+      pos: -2.5,-5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 931
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeTJunction
+  entities:
+  - uid: 464
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 535
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 543
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 548
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 573
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 574
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,14.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 575
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 576
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 578
+    components:
+    - type: Transform
+      pos: 0.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 580
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 581
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 582
+    components:
+    - type: Transform
+      pos: -2.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 583
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 584
+    components:
+    - type: Transform
+      pos: -0.5,13.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 585
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 586
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 587
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 588
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 589
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 590
+    components:
+    - type: Transform
+      pos: 1.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 592
+    components:
+    - type: Transform
+      pos: -2.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 593
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 594
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 595
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 596
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 597
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 598
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 599
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+- proto: GasPort
+  entities:
+  - uid: 939
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,11.5
+      parent: 1
+- proto: GasPressurePump
+  entities:
+  - uid: 600
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 601
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#03FCD3FF'
+  - uid: 602
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#03FCD3FF'
+- proto: GasVentPump
+  entities:
+  - uid: 604
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,2.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 989
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 605
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,13.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 936
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 606
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,10.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 936
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 607
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-0.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 986
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 608
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,7.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 990
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 609
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-8.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 988
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 610
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 611
+    components:
+    - type: Transform
+      pos: 3.5,-0.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 986
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 612
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,10.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 936
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 613
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 614
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,13.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 936
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 615
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-8.5
+      parent: 1
+  - uid: 616
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 617
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-10.5
+      parent: 1
+  - uid: 618
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-7.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 987
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 937
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,3.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 399
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 983
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,6.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 400
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 985
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,3.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 400
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+- proto: GasVentScrubber
+  entities:
+  - uid: 620
+    components:
+    - type: Transform
+      pos: -4.5,-0.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 986
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 621
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-7.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 987
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 622
+    components:
+    - type: Transform
+      pos: 2.5,-0.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 986
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 623
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,14.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 936
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 624
+    components:
+    - type: Transform
+      pos: -4.5,13.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 936
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 626
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 627
+    components:
+    - type: Transform
+      pos: -1.5,15.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 936
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 628
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-8.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 988
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 629
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 630
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,11.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 936
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 631
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 632
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,6.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 990
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 633
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,1.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 989
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 932
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,8.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 400
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 940
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,5.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 399
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 944
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,1.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 400
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 947
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,4.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 400
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 991
+    components:
+    - type: Transform
+      pos: -3.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GeneratorBasic15kW
+  entities:
+  - uid: 634
+    components:
+    - type: Transform
+      pos: -2.5,-7.5
+      parent: 1
+  - uid: 635
+    components:
+    - type: Transform
+      pos: -4.5,-10.5
+      parent: 1
+  - uid: 636
+    components:
+    - type: Transform
+      pos: -5.5,-10.5
+      parent: 1
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 637
+    components:
+    - type: Transform
+      pos: -3.5,-10.5
+      parent: 1
+- proto: Grille
+  entities:
+  - uid: 9
+    components:
+    - type: Transform
+      pos: 5.5,-2.5
+      parent: 1
+  - uid: 10
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-2.5
+      parent: 1
+  - uid: 29
+    components:
+    - type: Transform
+      pos: 1.5,-12.5
+      parent: 1
+  - uid: 638
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,7.5
+      parent: 1
+  - uid: 639
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,5.5
+      parent: 1
+  - uid: 640
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,16.5
+      parent: 1
+  - uid: 641
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,1.5
+      parent: 1
+  - uid: 642
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,5.5
+      parent: 1
+  - uid: 643
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-6.5
+      parent: 1
+  - uid: 644
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-5.5
+      parent: 1
+  - uid: 645
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 646
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 647
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,7.5
+      parent: 1
+  - uid: 648
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,0.5
+      parent: 1
+  - uid: 649
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,2.5
+      parent: 1
+  - uid: 650
+    components:
+    - type: Transform
+      pos: -7.5,3.5
+      parent: 1
+  - uid: 651
+    components:
+    - type: Transform
+      pos: -7.5,2.5
+      parent: 1
+  - uid: 652
+    components:
+    - type: Transform
+      pos: -3.5,-11.5
+      parent: 1
+  - uid: 653
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,15.5
+      parent: 1
+  - uid: 654
+    components:
+    - type: Transform
+      pos: -2.5,16.5
+      parent: 1
+  - uid: 655
+    components:
+    - type: Transform
+      pos: -3.5,16.5
+      parent: 1
+  - uid: 656
+    components:
+    - type: Transform
+      pos: -4.5,16.5
+      parent: 1
+  - uid: 657
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,16.5
+      parent: 1
+  - uid: 658
+    components:
+    - type: Transform
+      pos: 0.5,16.5
+      parent: 1
+  - uid: 659
+    components:
+    - type: Transform
+      pos: -5.5,15.5
+      parent: 1
+  - uid: 660
+    components:
+    - type: Transform
+      pos: -6.5,15.5
+      parent: 1
+  - uid: 661
+    components:
+    - type: Transform
+      pos: -6.5,14.5
+      parent: 1
+  - uid: 662
+    components:
+    - type: Transform
+      pos: -7.5,6.5
+      parent: 1
+  - uid: 663
+    components:
+    - type: Transform
+      pos: -7.5,10.5
+      parent: 1
+  - uid: 664
+    components:
+    - type: Transform
+      pos: -4.5,-11.5
+      parent: 1
+  - uid: 665
+    components:
+    - type: Transform
+      pos: -2.5,-11.5
+      parent: 1
+  - uid: 666
+    components:
+    - type: Transform
+      pos: -7.5,1.5
+      parent: 1
+  - uid: 667
+    components:
+    - type: Transform
+      pos: -1.5,16.5
+      parent: 1
+  - uid: 668
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,16.5
+      parent: 1
+  - uid: 669
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-7.5
+      parent: 1
+  - uid: 670
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,9.5
+      parent: 1
+  - uid: 671
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,1.5
+      parent: 1
+  - uid: 672
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-8.5
+      parent: 1
+  - uid: 673
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,8.5
+      parent: 1
+  - uid: 674
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,4.5
+      parent: 1
+  - uid: 675
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 1
+  - uid: 676
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,7.5
+      parent: 1
+  - uid: 677
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,14.5
+      parent: 1
+  - uid: 678
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,10.5
+      parent: 1
+  - uid: 679
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,11.5
+      parent: 1
+  - uid: 680
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,5.5
+      parent: 1
+  - uid: 681
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,15.5
+      parent: 1
+  - uid: 682
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,16.5
+      parent: 1
+  - uid: 683
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,16.5
+      parent: 1
+  - uid: 684
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,16.5
+      parent: 1
+- proto: Gyroscope
+  entities:
+  - uid: 385
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-7.5
+      parent: 1
+  - uid: 933
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-6.5
+      parent: 1
+- proto: HolopadUnlimitedRange
+  entities:
+  - uid: 1017
+    components:
+    - type: MetaData
+      name: quantum entangling holopad (NT-Hygieia)
+    - type: Transform
+      pos: -1.5,11.5
+      parent: 1
+    - type: Label
+      currentLabel: NT-Hygieia
+    - type: NameModifier
+      baseName: quantum entangling holopad
+- proto: Jug
+  entities:
+  - uid: 61
+    components:
+    - type: Transform
+      parent: 54
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 62
+    components:
+    - type: Transform
+      parent: 54
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 63
+    components:
+    - type: Transform
+      parent: 54
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 64
+    components:
+    - type: Transform
+      parent: 54
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: KitchenReagentGrinder
+  entities:
+  - uid: 685
+    components:
+    - type: Transform
+      pos: -6.5,9.5
+      parent: 1
+- proto: LampGold
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      pos: 0.35053897,15.837923
+      parent: 1
+    - type: HandheldLight
+      toggleActionEntity: 3
+    - type: ContainerContainer
+      containers:
+        cell_slot: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+        actions: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 3
+    - type: Physics
+      canCollide: True
+    - type: ActionsContainer
+- proto: LockerChemistryFilled
+  entities:
+  - uid: 54
+    components:
+    - type: Transform
+      pos: -6.5,10.5
+      parent: 1
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.1496
+        moles:
+        - 1.8856695
+        - 7.0937095
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 61
+          - 57
+          - 62
+          - 63
+          - 55
+          - 56
+          - 65
+          - 58
+          - 59
+          - 64
+          - 66
+          - 60
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+- proto: LockerWallMedicalDoctorFilled
+  entities:
+  - uid: 686
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,4.5
+      parent: 1
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.1496
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+- proto: MachineCentrifuge
+  entities:
+  - uid: 943
+    components:
+    - type: Transform
+      pos: -3.5,10.5
+      parent: 1
+- proto: MachineElectrolysisUnit
+  entities:
+  - uid: 836
+    components:
+    - type: Transform
+      pos: -3.5,9.5
+      parent: 1
+- proto: MedicalBed
+  entities:
+  - uid: 687
+    components:
+    - type: Transform
+      pos: -6.5,3.5
+      parent: 1
+  - uid: 688
+    components:
+    - type: Transform
+      pos: -6.5,7.5
+      parent: 1
+  - uid: 689
+    components:
+    - type: Transform
+      pos: -6.5,2.5
+      parent: 1
+  - uid: 690
+    components:
+    - type: Transform
+      pos: -4.5,5.5
+      parent: 1
+  - uid: 691
+    components:
+    - type: Transform
+      pos: -4.5,2.5
+      parent: 1
+  - uid: 692
+    components:
+    - type: Transform
+      pos: -4.5,3.5
+      parent: 1
+  - uid: 693
+    components:
+    - type: Transform
+      pos: -6.5,5.5
+      parent: 1
+- proto: MedkitAdvancedFilled
+  entities:
+  - uid: 694
+    components:
+    - type: Transform
+      pos: -5.7813635,7.7174473
+      parent: 1
+- proto: MedkitBruteFilled
+  entities:
+  - uid: 695
+    components:
+    - type: Transform
+      pos: -5.295559,7.7018223
+      parent: 1
+- proto: MedkitBurnFilled
+  entities:
+  - uid: 696
+    components:
+    - type: Transform
+      pos: -5.2853947,7.8612895
+      parent: 1
+- proto: MedkitCombatFilled
+  entities:
+  - uid: 697
+    components:
+    - type: Transform
+      pos: -5.7385197,7.8612895
+      parent: 1
+- proto: MedkitO2
+  entities:
+  - uid: 698
+    components:
+    - type: Transform
+      pos: -5.7969885,7.4518223
+      parent: 1
+- proto: MedkitToxin
+  entities:
+  - uid: 699
+    components:
+    - type: Transform
+      pos: -5.2969885,7.4674473
+      parent: 1
+- proto: PaperBin10
+  entities:
+  - uid: 700
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,13.5
+      parent: 1
+- proto: Pen
+  entities:
+  - uid: 701
+    components:
+    - type: Transform
+      pos: 0.678653,14.613018
+      parent: 1
+  - uid: 702
+    components:
+    - type: Transform
+      pos: 0.3812492,14.513718
+      parent: 1
+- proto: PlasmaReinforcedWindowDirectional
+  entities:
+  - uid: 703
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-8.5
+      parent: 1
+  - uid: 704
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-10.5
+      parent: 1
+  - uid: 705
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-6.5
+      parent: 1
+- proto: PlushieLizard
+  entities:
+  - uid: 706
+    components:
+    - type: Transform
+      pos: -4.463278,-9.441589
+      parent: 1
+- proto: PlushieSlime
+  entities:
+  - uid: 707
+    components:
+    - type: Transform
+      pos: 4.4983554,-5.6872573
+      parent: 1
+- proto: PosterContrabandInterdyne
+  entities:
+  - uid: 708
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,4.5
+      parent: 1
+- proto: PosterLegitHelpOthers
+  entities:
+  - uid: 709
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-8.5
+      parent: 1
+- proto: PosterLegitHereForYourSafety
+  entities:
+  - uid: 710
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,0.5
+      parent: 1
+- proto: PosterLegitIonRifle
+  entities:
+  - uid: 711
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,8.5
+      parent: 1
+- proto: PosterLegitJustAWeekAway
+  entities:
+  - uid: 712
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,4.5
+      parent: 1
+- proto: PosterLegitNanotrasenLogo
+  entities:
+  - uid: 713
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,13.5
+      parent: 1
+  - uid: 714
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,13.5
+      parent: 1
+- proto: PosterLegitSafetyMothEpi
+  entities:
+  - uid: 715
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,0.5
+      parent: 1
+- proto: PosterLegitSafetyMothHardhat
+  entities:
+  - uid: 716
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-7.5
+      parent: 1
+- proto: PosterLegitSafetyMothPiping
+  entities:
+  - uid: 717
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-9.5
+      parent: 1
+- proto: PosterLegitSafetyReport
+  entities:
+  - uid: 718
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,0.5
+      parent: 1
+- proto: PowerCellRecharger
+  entities:
+  - uid: 719
+    components:
+    - type: Transform
+      pos: -6.5,1.5
+      parent: 1
+- proto: Poweredlight
+  entities:
+  - uid: 720
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-4.5
+      parent: 1
+  - uid: 721
+    components:
+    - type: Transform
+      pos: -5.5,-6.5
+      parent: 1
+  - uid: 722
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-9.5
+      parent: 1
+  - uid: 723
+    components:
+    - type: Transform
+      pos: -3.5,-0.5
+      parent: 1
+  - uid: 724
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,9.5
+      parent: 1
+  - uid: 725
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,2.5
+      parent: 1
+  - uid: 726
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-4.5
+      parent: 1
+  - uid: 727
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,6.5
+      parent: 1
+  - uid: 728
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-7.5
+      parent: 1
+  - uid: 729
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,10.5
+      parent: 1
+  - uid: 730
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-1.5
+      parent: 1
+  - uid: 731
+    components:
+    - type: Transform
+      pos: 2.5,-0.5
+      parent: 1
+  - uid: 732
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,13.5
+      parent: 1
+  - uid: 733
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,13.5
+      parent: 1
+  - uid: 734
+    components:
+    - type: Transform
+      pos: -5.5,7.5
+      parent: 1
+  - uid: 735
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 736
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 737
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-6.5
+      parent: 1
+  - uid: 738
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-10.5
+      parent: 1
+- proto: PoweredSmallLight
+  entities:
+  - uid: 739
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 740
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,1.5
+      parent: 1
+  - uid: 741
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,7.5
+      parent: 1
+- proto: RandomDrinkBottle
+  entities:
+  - uid: 742
+    components:
+    - type: Transform
+      pos: 3.5,-9.5
+      parent: 1
+- proto: RandomDrinkGlass
+  entities:
+  - uid: 743
+    components:
+    - type: Transform
+      pos: 3.5,-6.5
+      parent: 1
+  - uid: 744
+    components:
+    - type: Transform
+      pos: -4.5,-8.5
+      parent: 1
+- proto: RandomFoodMeal
+  entities:
+  - uid: 745
+    components:
+    - type: Transform
+      pos: -4.5,-9.5
+      parent: 1
+  - uid: 746
+    components:
+    - type: Transform
+      pos: 4.5,-6.5
+      parent: 1
+  - uid: 747
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-6.5
+      parent: 1
+  - uid: 748
+    components:
+    - type: Transform
+      pos: 0.5,15.5
+      parent: 1
+- proto: RandomHumanoidSpawnerERTEngineerEVA
+  entities:
+  - uid: 1024
+    components:
+    - type: Transform
+      pos: -4.5,-7.5
+      parent: 1
+- proto: RandomHumanoidSpawnerERTLeaderEVALecterTime
+  entities:
+  - uid: 1018
+    components:
+    - type: Transform
+      pos: -3.5,14.5
+      parent: 1
+- proto: RandomHumanoidSpawnerERTMedicalEVA
+  entities:
+  - uid: 1023
+    components:
+    - type: Transform
+      pos: -5.5,2.5
+      parent: 1
+- proto: RandomHumanoidSpawnerERTMedicalEVATime
+  entities:
+  - uid: 1022
+    components:
+    - type: Transform
+      pos: -5.5,6.5
+      parent: 1
+- proto: RandomHumanoidSpawnerERTSecurityEVALecter
+  entities:
+  - uid: 1020
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+- proto: RandomHumanoidSpawnerERTSecurityEVALecterTime
+  entities:
+  - uid: 1019
+    components:
+    - type: Transform
+      pos: 1.5,7.5
+      parent: 1
+  - uid: 1021
+    components:
+    - type: Transform
+      pos: 1.5,11.5
+      parent: 1
+- proto: SheetPlasma1
+  entities:
+  - uid: 65
+    components:
+    - type: Transform
+      parent: 54
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 66
+    components:
+    - type: Transform
+      parent: 54
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: ShuttleWindow
+  entities:
+  - uid: 14
+    components:
+    - type: Transform
+      pos: 5.5,-2.5
+      parent: 1
+  - uid: 31
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-2.5
+      parent: 1
+  - uid: 32
+    components:
+    - type: Transform
+      pos: 1.5,-12.5
+      parent: 1
+  - uid: 749
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,4.5
+      parent: 1
+  - uid: 750
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,7.5
+      parent: 1
+  - uid: 751
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 752
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,2.5
+      parent: 1
+  - uid: 753
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-7.5
+      parent: 1
+  - uid: 754
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,5.5
+      parent: 1
+  - uid: 755
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,7.5
+      parent: 1
+  - uid: 756
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,7.5
+      parent: 1
+  - uid: 757
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,9.5
+      parent: 1
+  - uid: 758
+    components:
+    - type: Transform
+      pos: -3.5,1.5
+      parent: 1
+  - uid: 759
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-6.5
+      parent: 1
+  - uid: 760
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,5.5
+      parent: 1
+  - uid: 761
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 762
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,16.5
+      parent: 1
+  - uid: 763
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,0.5
+      parent: 1
+  - uid: 764
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,16.5
+      parent: 1
+  - uid: 765
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-11.5
+      parent: 1
+  - uid: 766
+    components:
+    - type: Transform
+      pos: -7.5,6.5
+      parent: 1
+  - uid: 767
+    components:
+    - type: Transform
+      pos: -7.5,1.5
+      parent: 1
+  - uid: 768
+    components:
+    - type: Transform
+      pos: -7.5,2.5
+      parent: 1
+  - uid: 769
+    components:
+    - type: Transform
+      pos: -7.5,10.5
+      parent: 1
+  - uid: 770
+    components:
+    - type: Transform
+      pos: -6.5,14.5
+      parent: 1
+  - uid: 771
+    components:
+    - type: Transform
+      pos: -5.5,15.5
+      parent: 1
+  - uid: 772
+    components:
+    - type: Transform
+      pos: -1.5,16.5
+      parent: 1
+  - uid: 773
+    components:
+    - type: Transform
+      pos: -3.5,16.5
+      parent: 1
+  - uid: 774
+    components:
+    - type: Transform
+      pos: 0.5,16.5
+      parent: 1
+  - uid: 775
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,14.5
+      parent: 1
+  - uid: 776
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-11.5
+      parent: 1
+  - uid: 777
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-11.5
+      parent: 1
+  - uid: 778
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,16.5
+      parent: 1
+  - uid: 779
+    components:
+    - type: Transform
+      pos: -2.5,16.5
+      parent: 1
+  - uid: 780
+    components:
+    - type: Transform
+      pos: -7.5,3.5
+      parent: 1
+  - uid: 781
+    components:
+    - type: Transform
+      pos: -6.5,15.5
+      parent: 1
+  - uid: 782
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,1.5
+      parent: 1
+  - uid: 783
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,16.5
+      parent: 1
+  - uid: 784
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,15.5
+      parent: 1
+  - uid: 785
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,15.5
+      parent: 1
+  - uid: 786
+    components:
+    - type: Transform
+      pos: 2.5,16.5
+      parent: 1
+  - uid: 787
+    components:
+    - type: Transform
+      pos: 1.5,16.5
+      parent: 1
+  - uid: 788
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,5.5
+      parent: 1
+  - uid: 789
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-8.5
+      parent: 1
+  - uid: 790
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 1
+  - uid: 791
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,10.5
+      parent: 1
+  - uid: 792
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,11.5
+      parent: 1
+  - uid: 793
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-5.5
+      parent: 1
+  - uid: 794
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,8.5
+      parent: 1
+- proto: SignalButtonDirectional
+  entities:
+  - uid: 1026
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,7.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        995:
+        - Pressed: Toggle
+        994:
+        - Pressed: Toggle
+        993:
+        - Pressed: Toggle
+        992:
+        - Pressed: Toggle
+        997:
+        - Pressed: Toggle
+        996:
+        - Pressed: Toggle
+- proto: SignRedOne
+  entities:
+  - uid: 795
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,1.5
+      parent: 1
+- proto: SignRedThree
+  entities:
+  - uid: 796
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,7.5
+      parent: 1
+- proto: SignRedTwo
+  entities:
+  - uid: 797
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,4.5
+      parent: 1
+- proto: SMESAdvanced
+  entities:
+  - uid: 798
+    components:
+    - type: Transform
+      pos: -6.5,-8.5
+      parent: 1
+- proto: StasisBed
+  entities:
+  - uid: 799
+    components:
+    - type: Transform
+      pos: -4.5,1.5
+      parent: 1
+  - uid: 800
+    components:
+    - type: Transform
+      pos: -4.5,7.5
+      parent: 1
+- proto: SubstationBasic
+  entities:
+  - uid: 801
+    components:
+    - type: Transform
+      pos: -6.5,-6.5
+      parent: 1
+- proto: Table
+  entities:
+  - uid: 802
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-9.5
+      parent: 1
+  - uid: 803
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-6.5
+      parent: 1
+  - uid: 804
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-6.5
+      parent: 1
+- proto: TableGlass
+  entities:
+  - uid: 805
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,7.5
+      parent: 1
+  - uid: 806
+    components:
+    - type: Transform
+      pos: -6.5,1.5
+      parent: 1
+- proto: TableReinforced
+  entities:
+  - uid: 807
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,10.5
+      parent: 1
+  - uid: 808
+    components:
+    - type: Transform
+      pos: 0.5,12.5
+      parent: 1
+  - uid: 809
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,10.5
+      parent: 1
+  - uid: 810
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,9.5
+      parent: 1
+  - uid: 811
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,11.5
+      parent: 1
+  - uid: 812
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,9.5
+      parent: 1
+  - uid: 813
+    components:
+    - type: Transform
+      pos: -0.5,12.5
+      parent: 1
+  - uid: 814
+    components:
+    - type: Transform
+      pos: -4.5,-9.5
+      parent: 1
+  - uid: 815
+    components:
+    - type: Transform
+      pos: -4.5,-8.5
+      parent: 1
+  - uid: 816
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,10.5
+      parent: 1
+  - uid: 817
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,12.5
+      parent: 1
+  - uid: 818
+    components:
+    - type: Transform
+      pos: -5.5,13.5
+      parent: 1
+- proto: TableWood
+  entities:
+  - uid: 819
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,13.5
+      parent: 1
+  - uid: 820
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,14.5
+      parent: 1
+  - uid: 821
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,15.5
+      parent: 1
+  - uid: 822
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,14.5
+      parent: 1
+- proto: Thruster
+  entities:
+  - uid: 603
+    components:
+    - type: Transform
+      pos: 4.5,16.5
+      parent: 1
+  - uid: 823
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-12.5
+      parent: 1
+  - uid: 824
+    components:
+    - type: Transform
+      pos: -6.5,16.5
+      parent: 1
+  - uid: 825
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-12.5
+      parent: 1
+  - uid: 826
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-12.5
+      parent: 1
+  - uid: 827
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-11.5
+      parent: 1
+  - uid: 828
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,-12.5
+      parent: 1
+  - uid: 829
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,13.5
+      parent: 1
+  - uid: 830
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-11.5
+      parent: 1
+  - uid: 831
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-12.5
+      parent: 1
+  - uid: 832
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-10.5
+      parent: 1
+  - uid: 833
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,13.5
+      parent: 1
+  - uid: 834
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,14.5
+      parent: 1
+  - uid: 835
+    components:
+    - type: Transform
+      pos: 5.5,15.5
+      parent: 1
+  - uid: 837
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-10.5
+      parent: 1
+  - uid: 838
+    components:
+    - type: Transform
+      pos: -7.5,15.5
+      parent: 1
+  - uid: 839
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,14.5
+      parent: 1
+- proto: VendingMachineChemicals
+  entities:
+  - uid: 840
+    components:
+    - type: Transform
+      pos: -6.5,11.5
+      parent: 1
+- proto: VendingMachineCoffee
+  entities:
+  - uid: 841
+    components:
+    - type: Transform
+      pos: 3.5,-10.5
+      parent: 1
+- proto: VendingMachineSec
+  entities:
+  - uid: 842
+    components:
+    - type: Transform
+      pos: 3.5,12.5
+      parent: 1
+- proto: WallShuttle
+  entities:
+  - uid: 843
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,6.5
+      parent: 1
+  - uid: 844
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,8.5
+      parent: 1
+  - uid: 845
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,9.5
+      parent: 1
+  - uid: 846
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-8.5
+      parent: 1
+  - uid: 847
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,3.5
+      parent: 1
+  - uid: 848
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,0.5
+      parent: 1
+  - uid: 849
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,11.5
+      parent: 1
+  - uid: 850
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-5.5
+      parent: 1
+  - uid: 851
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-5.5
+      parent: 1
+  - uid: 852
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-7.5
+      parent: 1
+  - uid: 853
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-5.5
+      parent: 1
+  - uid: 854
+    components:
+    - type: Transform
+      pos: -0.5,-12.5
+      parent: 1
+  - uid: 855
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,4.5
+      parent: 1
+  - uid: 856
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 857
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-6.5
+      parent: 1
+  - uid: 858
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,-0.5
+      parent: 1
+  - uid: 859
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,8.5
+      parent: 1
+  - uid: 860
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,6.5
+      parent: 1
+  - uid: 861
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,4.5
+      parent: 1
+  - uid: 862
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 863
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,4.5
+      parent: 1
+  - uid: 864
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,8.5
+      parent: 1
+  - uid: 865
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 866
+    components:
+    - type: Transform
+      pos: -0.5,-11.5
+      parent: 1
+  - uid: 867
+    components:
+    - type: Transform
+      pos: -3.5,2.5
+      parent: 1
+  - uid: 868
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,3.5
+      parent: 1
+  - uid: 869
+    components:
+    - type: Transform
+      pos: -0.5,8.5
+      parent: 1
+  - uid: 870
+    components:
+    - type: Transform
+      pos: -6.5,0.5
+      parent: 1
+  - uid: 871
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,6.5
+      parent: 1
+  - uid: 872
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-5.5
+      parent: 1
+  - uid: 873
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,9.5
+      parent: 1
+  - uid: 874
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 875
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-9.5
+      parent: 1
+  - uid: 876
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,1.5
+      parent: 1
+  - uid: 877
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,9.5
+      parent: 1
+  - uid: 878
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-5.5
+      parent: 1
+  - uid: 879
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-9.5
+      parent: 1
+  - uid: 880
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-10.5
+      parent: 1
+  - uid: 881
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,4.5
+      parent: 1
+  - uid: 882
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,7.5
+      parent: 1
+  - uid: 883
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,6.5
+      parent: 1
+  - uid: 884
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,8.5
+      parent: 1
+  - uid: 885
+    components:
+    - type: Transform
+      pos: -7.5,0.5
+      parent: 1
+  - uid: 886
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,7.5
+      parent: 1
+  - uid: 887
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-7.5
+      parent: 1
+  - uid: 888
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,2.5
+      parent: 1
+  - uid: 889
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,12.5
+      parent: 1
+  - uid: 890
+    components:
+    - type: Transform
+      pos: -1.5,-11.5
+      parent: 1
+  - uid: 891
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,0.5
+      parent: 1
+  - uid: 892
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,0.5
+      parent: 1
+  - uid: 893
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 894
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,3.5
+      parent: 1
+  - uid: 895
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,-4.5
+      parent: 1
+  - uid: 896
+    components:
+    - type: Transform
+      pos: -7.5,8.5
+      parent: 1
+  - uid: 897
+    components:
+    - type: Transform
+      pos: -7.5,4.5
+      parent: 1
+  - uid: 898
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-11.5
+      parent: 1
+  - uid: 899
+    components:
+    - type: Transform
+      pos: -7.5,-5.5
+      parent: 1
+  - uid: 900
+    components:
+    - type: Transform
+      pos: -7.5,-6.5
+      parent: 1
+  - uid: 901
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,12.5
+      parent: 1
+  - uid: 902
+    components:
+    - type: Transform
+      pos: -7.5,-8.5
+      parent: 1
+  - uid: 903
+    components:
+    - type: Transform
+      pos: -7.5,-7.5
+      parent: 1
+  - uid: 904
+    components:
+    - type: Transform
+      pos: -6.5,13.5
+      parent: 1
+  - uid: 905
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-10.5
+      parent: 1
+  - uid: 906
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,12.5
+      parent: 1
+  - uid: 907
+    components:
+    - type: Transform
+      pos: 3.5,-12.5
+      parent: 1
+  - uid: 908
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,9.5
+      parent: 1
+  - uid: 909
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,13.5
+      parent: 1
+  - uid: 910
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-11.5
+      parent: 1
+  - uid: 911
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,12.5
+      parent: 1
+  - uid: 912
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-10.5
+      parent: 1
+  - uid: 913
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,0.5
+      parent: 1
+  - uid: 914
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-0.5
+      parent: 1
+  - uid: 915
+    components:
+    - type: Transform
+      pos: 5.5,-4.5
+      parent: 1
+  - uid: 916
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,6.5
+      parent: 1
+- proto: WallShuttleDiagonal
+  entities:
+  - uid: 917
+    components:
+    - type: Transform
+      pos: -0.5,9.5
+      parent: 1
+  - uid: 918
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-9.5
+      parent: 1
+  - uid: 919
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-11.5
+      parent: 1
+  - uid: 920
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-9.5
+      parent: 1
+  - uid: 921
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-11.5
+      parent: 1
+  - uid: 922
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-9.5
+      parent: 1
+  - uid: 923
+    components:
+    - type: Transform
+      pos: 4.5,-9.5
+      parent: 1
+- proto: WallWeaponCapacitorRecharger
+  entities:
+  - uid: 1028
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,1.5
+      parent: 1
+- proto: WardrobePrisonFilled
+  entities:
+  - uid: 924
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 925
+    components:
+    - type: Transform
+      pos: 3.5,7.5
+      parent: 1
+  - uid: 926
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 1
+- proto: WaterCooler
+  entities:
+  - uid: 927
+    components:
+    - type: Transform
+      pos: 2.5,15.5
+      parent: 1
+  - uid: 928
+    components:
+    - type: Transform
+      pos: 4.5,-8.5
+      parent: 1
+- proto: WeaponCapacitorRecharger
+  entities:
+  - uid: 929
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,11.5
+      parent: 1
+  - uid: 930
+    components:
+    - type: Transform
+      pos: -0.5,12.5
+      parent: 1
+- proto: WindoorSecureChemistryLocked
+  entities:
+  - uid: 934
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,11.5
+      parent: 1
+  - uid: 935
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,10.5
+      parent: 1
+- proto: WindoorSecureCommandLocked
+  entities:
+  - uid: 938
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,12.5
+      parent: 1
+  - uid: 942
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,12.5
+      parent: 1
+  - uid: 945
+    components:
+    - type: Transform
+      pos: 2.5,13.5
+      parent: 1
+  - uid: 946
+    components:
+    - type: Transform
+      pos: 1.5,13.5
+      parent: 1
+- proto: WindoorSecureSecurityLocked
+  entities:
+  - uid: 949
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 950
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,8.5
+      parent: 1
+  - uid: 951
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,5.5
+      parent: 1
+- proto: WindowReinforcedDirectional
+  entities:
+  - uid: 952
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,12.5
+      parent: 1
+  - uid: 953
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,12.5
+      parent: 1
+  - uid: 954
+    components:
+    - type: Transform
+      pos: -0.5,13.5
+      parent: 1
+  - uid: 955
+    components:
+    - type: Transform
+      pos: 1.5,-2.5
+      parent: 1
+  - uid: 956
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-2.5
+      parent: 1
+  - uid: 957
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-2.5
+      parent: 1
+  - uid: 958
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,12.5
+      parent: 1
+  - uid: 959
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,12.5
+      parent: 1
+  - uid: 960
+    components:
+    - type: Transform
+      pos: 3.5,13.5
+      parent: 1
+  - uid: 961
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-5.5
+      parent: 1
+  - uid: 962
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,15.5
+      parent: 1
+  - uid: 963
+    components:
+    - type: Transform
+      pos: 0.5,13.5
+      parent: 1
+  - uid: 964
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,13.5
+      parent: 1
+  - uid: 965
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,9.5
+      parent: 1
+  - uid: 966
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-5.5
+      parent: 1
+  - uid: 967
+    components:
+    - type: Transform
+      pos: -0.5,-2.5
+      parent: 1
+  - uid: 968
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-2.5
+      parent: 1
+  - uid: 969
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-2.5
+      parent: 1
+  - uid: 970
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,14.5
+      parent: 1
+  - uid: 971
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-2.5
+      parent: 1
+  - uid: 972
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-2.5
+      parent: 1
+  - uid: 973
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 1
+  - uid: 974
+    components:
+    - type: Transform
+      pos: -4.5,-2.5
+      parent: 1
+  - uid: 975
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-2.5
+      parent: 1
+  - uid: 976
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-2.5
+      parent: 1
+  - uid: 977
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-2.5
+      parent: 1
+  - uid: 978
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 1
+  - uid: 979
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-2.5
+      parent: 1
+  - uid: 980
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-2.5
+      parent: 1
+  - uid: 981
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 1
+  - uid: 982
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-2.5
+      parent: 1
+...

--- a/Resources/Maps/_Harmony/Shuttles/ShuttleEvent/ERTMedSmall.yml
+++ b/Resources/Maps/_Harmony/Shuttles/ShuttleEvent/ERTMedSmall.yml
@@ -1,0 +1,2138 @@
+meta:
+  format: 6
+  postmapinit: false
+tilemap:
+  1: Space
+  9: FloorDarkMono
+  7: FloorShuttleWhite
+  3: FloorSteel
+  10: FloorTechMaint
+  5: FloorWhite
+  6: FloorWhiteMini
+  8: FloorWhiteMono
+  4: Lattice
+  2: Plating
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: NT-Denobula
+    - type: Transform
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        -1,0:
+          ind: -1,0
+          tiles: AQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAABQAAAAABBQAAAAACBQAAAAADAwAAAAADAwAAAAACAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAABQAAAAACBQAAAAAABQAAAAABAwAAAAACAwAAAAADAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAAABQAAAAAABQAAAAACBQAAAAACAwAAAAACAwAAAAABAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAACBgAAAAACBgAAAAADAwAAAAADAwAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAAABgAAAAABBgAAAAACCAAAAAAAAwAAAAADAwAAAAABAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAABgAAAAADBgAAAAAAAwAAAAACAwAAAAADAwAAAAADAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAABBgAAAAACBgAAAAABAwAAAAAAAwAAAAADAwAAAAACAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAAAwAAAAABBwAAAAAACQAAAAACCQAAAAADAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAABAAAAAAAAgAAAAAACQAAAAAAAgAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAAAgAAAAAAAgAAAAAAAgAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAA
+          version: 6
+        0,0:
+          ind: 0,0
+          tiles: AwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAACAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAADAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAABAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAACAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAA
+          version: 6
+        -1,-1:
+          ind: -1,-1
+          tiles: AQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAAAgAAAAAAAgAAAAAAAgAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAAAgAAAAAAAgAAAAAABAAAAAAAAgAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAgAAAAAACgAAAAAACgAAAAAACgAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAACgAAAAAACgAAAAAACgAAAAAACgAAAAAACgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAABQAAAAACBQAAAAAABQAAAAAAAwAAAAACAwAAAAAB
+          version: 6
+        0,-1:
+          ind: 0,-1
+          tiles: AQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAADAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAA
+          version: 6
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: CargoShuttle
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            color: '#FFFFFFFF'
+            id: BoxGreyscale
+          decals:
+            32: -1,6
+            33: -1,5
+            34: -1,4
+        - node:
+            color: '#334E6DC8'
+            id: BrickTileWhiteCornerNe
+          decals:
+            16: -1,6
+        - node:
+            color: '#52B4E996'
+            id: BrickTileWhiteCornerNe
+          decals:
+            4: -3,1
+        - node:
+            color: '#A9D5F4FF'
+            id: BrickTileWhiteCornerNe
+          decals:
+            40: -3,1
+        - node:
+            color: '#334E6DC8'
+            id: BrickTileWhiteCornerNw
+          decals:
+            17: -2,6
+        - node:
+            color: '#334E6DC8'
+            id: BrickTileWhiteCornerSe
+          decals:
+            18: -1,-1
+        - node:
+            color: '#5A96BEFF'
+            id: BrickTileWhiteCornerSe
+          decals:
+            35: -3,-1
+        - node:
+            color: '#A9D5F4FF'
+            id: BrickTileWhiteCornerSe
+          decals:
+            37: -3,-1
+        - node:
+            color: '#334E6DC8'
+            id: BrickTileWhiteCornerSw
+          decals:
+            2: -3,7
+            19: -2,-1
+        - node:
+            color: '#A9D5F4FF'
+            id: BrickTileWhiteCornerSw
+          decals:
+            36: -5,-1
+        - node:
+            color: '#334E6DC8'
+            id: BrickTileWhiteEndE
+          decals:
+            1: -2,7
+        - node:
+            color: '#334E6DC8'
+            id: BrickTileWhiteEndN
+          decals:
+            0: -3,8
+        - node:
+            color: '#334E6DC8'
+            id: BrickTileWhiteInnerNe
+          decals:
+            3: -3,7
+        - node:
+            color: '#A9D5F4FF'
+            id: BrickTileWhiteInnerNe
+          decals:
+            46: -5,1
+        - node:
+            color: '#334E6DC8'
+            id: BrickTileWhiteLineE
+          decals:
+            20: -1,0
+            21: -1,1
+            22: -1,2
+            23: -1,3
+            24: -1,4
+            25: -1,5
+        - node:
+            color: '#52B4E996'
+            id: BrickTileWhiteLineE
+          decals:
+            5: -3,-1
+            6: -3,0
+        - node:
+            color: '#A9D5F4FF'
+            id: BrickTileWhiteLineE
+          decals:
+            42: -3,0
+            44: -5,2
+        - node:
+            color: '#52B4E996'
+            id: BrickTileWhiteLineN
+          decals:
+            7: -4,1
+        - node:
+            color: '#A9D5F4FF'
+            id: BrickTileWhiteLineN
+          decals:
+            38: -4,1
+        - node:
+            color: '#A9D5F4FF'
+            id: BrickTileWhiteLineS
+          decals:
+            39: -4,-1
+        - node:
+            color: '#334E6DC8'
+            id: BrickTileWhiteLineW
+          decals:
+            26: -2,5
+            27: -2,4
+            28: -2,3
+            29: -2,2
+            30: -2,1
+            31: -2,0
+        - node:
+            color: '#52B4E996'
+            id: BrickTileWhiteLineW
+          decals:
+            8: -5,0
+        - node:
+            color: '#A9D5F4FF'
+            id: BrickTileWhiteLineW
+          decals:
+            41: -5,0
+            43: -5,1
+            45: -5,2
+        - node:
+            color: '#A9D5F4FF'
+            id: FullTileOverlayGreyscale
+          decals:
+            47: -4,2
+            48: -3,2
+        - node:
+            color: '#52B4E996'
+            id: MiniTileWhiteBox
+          decals:
+            9: -5,6
+        - node:
+            color: '#52B4E996'
+            id: MiniTileWhiteCornerNe
+          decals:
+            10: -4,5
+        - node:
+            color: '#52B4E996'
+            id: MiniTileWhiteCornerNw
+          decals:
+            11: -5,5
+        - node:
+            color: '#52B4E996'
+            id: MiniTileWhiteCornerSe
+          decals:
+            12: -4,3
+        - node:
+            color: '#52B4E996'
+            id: MiniTileWhiteCornerSw
+          decals:
+            13: -5,3
+        - node:
+            color: '#52B4E996'
+            id: MiniTileWhiteLineE
+          decals:
+            14: -4,4
+        - node:
+            color: '#52B4E996'
+            id: MiniTileWhiteLineW
+          decals:
+            15: -5,4
+    - type: GridAtmosphere
+      version: 2
+      data:
+        tiles:
+          -2,0:
+            0: 34952
+          -2,1:
+            0: 2184
+            1: 16384
+          -2,2:
+            1: 140
+          -2,-1:
+            0: 34816
+            1: 4
+          -1,0:
+            0: 53247
+          -1,1:
+            0: 27871
+          -1,-1:
+            0: 65392
+            1: 2
+          -1,2:
+            0: 2
+            1: 136
+          0,0:
+            0: 4112
+          0,1:
+            1: 4096
+          0,2:
+            1: 1
+          -2,-2:
+            1: 32768
+          -1,-2:
+            1: 32768
+          0,-1:
+            1: 1
+        uniqueMixes:
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          immutable: True
+          moles:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        chunkSize: 4
+    - type: OccluderTree
+    - type: Shuttle
+    - type: GridPathfinding
+    - type: RadiationGridResistance
+    - type: SpreaderGrid
+    - type: GravityShake
+      shakeTimes: 10
+    - type: GasTileOverlay
+- proto: AirCanister
+  entities:
+  - uid: 224
+    components:
+    - type: Transform
+      anchored: True
+      pos: -3.5,-1.5
+      parent: 1
+    - type: Physics
+      bodyType: Static
+- proto: AirlockChemistryLocked
+  entities:
+  - uid: 3
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 1
+- proto: AirlockGlassShuttle
+  entities:
+  - uid: 4
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 5
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,3.5
+      parent: 1
+- proto: APCHyperCapacity
+  entities:
+  - uid: 6
+    components:
+    - type: Transform
+      pos: -0.5,7.5
+      parent: 1
+- proto: AtmosDeviceFanDirectional
+  entities:
+  - uid: 7
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 8
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,1.5
+      parent: 1
+- proto: BedsheetMedical
+  entities:
+  - uid: 11
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,0.5
+      parent: 1
+  - uid: 13
+    components:
+    - type: Transform
+      pos: -4.5,-0.5
+      parent: 1
+  - uid: 131
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-0.5
+      parent: 1
+- proto: BluespaceBeaker
+  entities:
+  - uid: 16
+    components:
+    - type: Transform
+      parent: 15
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 17
+    components:
+    - type: Transform
+      parent: 15
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: BoxBodyBag
+  entities:
+  - uid: 68
+    components:
+    - type: Transform
+      parent: 2
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 116
+    components:
+    - type: Transform
+      parent: 2
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 268
+    components:
+    - type: Transform
+      parent: 2
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: BoxSyringe
+  entities:
+  - uid: 71
+    components:
+    - type: Transform
+      pos: -2.4577973,2.5309758
+      parent: 1
+- proto: CableApcExtension
+  entities:
+  - uid: 28
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 1
+  - uid: 29
+    components:
+    - type: Transform
+      pos: -2.5,7.5
+      parent: 1
+  - uid: 30
+    components:
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 1
+  - uid: 31
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 1
+  - uid: 32
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 1
+  - uid: 33
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 1
+  - uid: 34
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 1
+  - uid: 35
+    components:
+    - type: Transform
+      pos: -0.5,7.5
+      parent: 1
+  - uid: 36
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 1
+  - uid: 37
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 1
+  - uid: 38
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 39
+    components:
+    - type: Transform
+      pos: -0.5,1.5
+      parent: 1
+  - uid: 40
+    components:
+    - type: Transform
+      pos: -3.5,1.5
+      parent: 1
+  - uid: 41
+    components:
+    - type: Transform
+      pos: -4.5,1.5
+      parent: 1
+  - uid: 42
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 1
+  - uid: 43
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 44
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 1
+  - uid: 45
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 1
+  - uid: 46
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 47
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 1
+  - uid: 48
+    components:
+    - type: Transform
+      pos: -2.5,8.5
+      parent: 1
+  - uid: 49
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 1
+  - uid: 50
+    components:
+    - type: Transform
+      pos: -4.5,-3.5
+      parent: 1
+  - uid: 51
+    components:
+    - type: Transform
+      pos: -3.5,8.5
+      parent: 1
+  - uid: 52
+    components:
+    - type: Transform
+      pos: -4.5,8.5
+      parent: 1
+  - uid: 53
+    components:
+    - type: Transform
+      pos: -3.5,-3.5
+      parent: 1
+  - uid: 54
+    components:
+    - type: Transform
+      pos: -0.5,8.5
+      parent: 1
+  - uid: 55
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 1
+  - uid: 56
+    components:
+    - type: Transform
+      pos: -3.5,-1.5
+      parent: 1
+  - uid: 57
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 1
+- proto: CableHV
+  entities:
+  - uid: 257
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 1
+  - uid: 258
+    components:
+    - type: Transform
+      pos: -3.5,-1.5
+      parent: 1
+  - uid: 259
+    components:
+    - type: Transform
+      pos: -4.5,-1.5
+      parent: 1
+  - uid: 261
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 1
+- proto: CableMV
+  entities:
+  - uid: 61
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 1
+  - uid: 62
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 64
+    components:
+    - type: Transform
+      pos: -2.5,7.5
+      parent: 1
+  - uid: 67
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 1
+  - uid: 69
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 70
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 72
+    components:
+    - type: Transform
+      pos: -0.5,7.5
+      parent: 1
+  - uid: 73
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 1
+  - uid: 75
+    components:
+    - type: Transform
+      pos: -1.5,9.5
+      parent: 1
+  - uid: 76
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 1
+  - uid: 77
+    components:
+    - type: Transform
+      pos: -5.5,2.5
+      parent: 1
+  - uid: 78
+    components:
+    - type: Transform
+      pos: -5.5,3.5
+      parent: 1
+  - uid: 79
+    components:
+    - type: Transform
+      pos: -5.5,4.5
+      parent: 1
+  - uid: 80
+    components:
+    - type: Transform
+      pos: -5.5,5.5
+      parent: 1
+  - uid: 81
+    components:
+    - type: Transform
+      pos: -5.5,1.5
+      parent: 1
+  - uid: 82
+    components:
+    - type: Transform
+      pos: -5.5,0.5
+      parent: 1
+  - uid: 83
+    components:
+    - type: Transform
+      pos: -5.5,-0.5
+      parent: 1
+  - uid: 84
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 1
+  - uid: 85
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 1
+  - uid: 138
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 1
+  - uid: 168
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 204
+    components:
+    - type: Transform
+      pos: -3.5,8.5
+      parent: 1
+  - uid: 210
+    components:
+    - type: Transform
+      pos: -3.5,9.5
+      parent: 1
+  - uid: 212
+    components:
+    - type: Transform
+      pos: -2.5,9.5
+      parent: 1
+  - uid: 252
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 1
+  - uid: 253
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 1
+  - uid: 254
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 1
+  - uid: 255
+    components:
+    - type: Transform
+      pos: -3.5,-1.5
+      parent: 1
+  - uid: 256
+    components:
+    - type: Transform
+      pos: -4.5,-1.5
+      parent: 1
+  - uid: 262
+    components:
+    - type: Transform
+      pos: -4.5,5.5
+      parent: 1
+- proto: CableTerminal
+  entities:
+  - uid: 260
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-2.5
+      parent: 1
+- proto: Catwalk
+  entities:
+  - uid: 217
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 1
+  - uid: 221
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 1
+  - uid: 263
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 1
+  - uid: 264
+    components:
+    - type: Transform
+      pos: -0.5,-4.5
+      parent: 1
+  - uid: 267
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+  - uid: 273
+    components:
+    - type: Transform
+      pos: -4.5,-4.5
+      parent: 1
+  - uid: 274
+    components:
+    - type: Transform
+      pos: -5.5,-3.5
+      parent: 1
+  - uid: 275
+    components:
+    - type: Transform
+      pos: -5.5,8.5
+      parent: 1
+  - uid: 276
+    components:
+    - type: Transform
+      pos: -4.5,9.5
+      parent: 1
+  - uid: 277
+    components:
+    - type: Transform
+      pos: -0.5,9.5
+      parent: 1
+  - uid: 278
+    components:
+    - type: Transform
+      pos: 0.5,8.5
+      parent: 1
+- proto: Chair
+  entities:
+  - uid: 12
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,0.5
+      parent: 1
+  - uid: 126
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-0.5
+      parent: 1
+- proto: ChairOfficeLight
+  entities:
+  - uid: 58
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,0.5
+      parent: 1
+  - uid: 86
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,5.5
+      parent: 1
+- proto: ChairPilotSeat
+  entities:
+  - uid: 89
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,7.5
+      parent: 1
+- proto: ChemDispenser
+  entities:
+  - uid: 63
+    components:
+    - type: Transform
+      pos: -4.5,6.5
+      parent: 1
+- proto: ChemMaster
+  entities:
+  - uid: 90
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 1
+- proto: ComputerShuttle
+  entities:
+  - uid: 92
+    components:
+    - type: Transform
+      pos: -2.5,8.5
+      parent: 1
+- proto: DefibrillatorCabinetFilled
+  entities:
+  - uid: 94
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,2.5
+      parent: 1
+  - uid: 186
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 1
+- proto: FloorDrain
+  entities:
+  - uid: 270
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,4.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: GasPassiveVent
+  entities:
+  - uid: 110
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeBend
+  entities:
+  - uid: 59
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 66
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 167
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeStraight
+  entities:
+  - uid: 96
+    components:
+    - type: Transform
+      pos: -0.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 98
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 99
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 100
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 101
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 109
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 231
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 236
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 237
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 239
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 240
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,7.5
+      parent: 1
+  - uid: 241
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 242
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 243
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 244
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 245
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 246
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 247
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 248
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeTJunction
+  entities:
+  - uid: 60
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 102
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 103
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 104
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 238
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 249
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 250
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 251
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPort
+  entities:
+  - uid: 93
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasVentPump
+  entities:
+  - uid: 74
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 106
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 107
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 108
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 235
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasVentScrubber
+  entities:
+  - uid: 9
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 105
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,7.5
+      parent: 1
+  - uid: 112
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 165
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 234
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GeneratorBasic15kW
+  entities:
+  - uid: 87
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 1
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 97
+    components:
+    - type: Transform
+      pos: -0.5,-1.5
+      parent: 1
+- proto: Grille
+  entities:
+  - uid: 111
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,5.5
+      parent: 1
+  - uid: 113
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,9.5
+      parent: 1
+  - uid: 114
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,9.5
+      parent: 1
+  - uid: 115
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,9.5
+      parent: 1
+  - uid: 117
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,8.5
+      parent: 1
+  - uid: 118
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,0.5
+      parent: 1
+  - uid: 119
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,5.5
+      parent: 1
+  - uid: 120
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,8.5
+      parent: 1
+  - uid: 121
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-0.5
+      parent: 1
+  - uid: 122
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,1.5
+      parent: 1
+- proto: Gyroscope
+  entities:
+  - uid: 65
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 1
+- proto: HandLabeler
+  entities:
+  - uid: 18
+    components:
+    - type: Transform
+      parent: 15
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: Jug
+  entities:
+  - uid: 19
+    components:
+    - type: Transform
+      parent: 15
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 20
+    components:
+    - type: Transform
+      parent: 15
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 21
+    components:
+    - type: Transform
+      parent: 15
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 22
+    components:
+    - type: Transform
+      parent: 15
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 23
+    components:
+    - type: Transform
+      parent: 15
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 24
+    components:
+    - type: Transform
+      parent: 15
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 25
+    components:
+    - type: Transform
+      parent: 15
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 26
+    components:
+    - type: Transform
+      parent: 15
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 271
+    components:
+    - type: Transform
+      pos: -4.561964,4.249726
+      parent: 1
+  - uid: 272
+    components:
+    - type: Transform
+      pos: -4.340074,4.50377
+      parent: 1
+- proto: JugCarbon
+  entities:
+  - uid: 91
+    components:
+    - type: Transform
+      pos: -3.808824,4.337925
+      parent: 1
+- proto: LockerChemistryFilled
+  entities:
+  - uid: 15
+    components:
+    - type: Transform
+      pos: -0.3488598,2.492177
+      parent: 1
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.1496
+        moles:
+        - 1.8856695
+        - 7.0937095
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 18
+          - 25
+          - 24
+          - 17
+          - 16
+          - 23
+          - 22
+          - 21
+          - 19
+          - 20
+          - 27
+          - 26
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+- proto: LockerWallMedical
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-0.5
+      parent: 1
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.1462
+        moles:
+        - 1.8744951
+        - 7.051672
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 68
+          - 268
+          - 116
+- proto: LockerWallMedicalFilled
+  entities:
+  - uid: 265
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,0.5
+      parent: 1
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+- proto: MedicalBed
+  entities:
+  - uid: 129
+    components:
+    - type: Transform
+      pos: -4.5,-0.5
+      parent: 1
+  - uid: 166
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 1
+  - uid: 219
+    components:
+    - type: Transform
+      pos: -4.5,0.5
+      parent: 1
+- proto: MedkitAdvancedFilled
+  entities:
+  - uid: 147
+    components:
+    - type: Transform
+      pos: -2.4114592,2.7824645
+      parent: 1
+- proto: MedkitBruteFilled
+  entities:
+  - uid: 134
+    components:
+    - type: Transform
+      pos: -2.8697925,2.7824645
+      parent: 1
+  - uid: 136
+    components:
+    - type: Transform
+      pos: -2.890626,2.6574645
+      parent: 1
+- proto: MedkitBurnFilled
+  entities:
+  - uid: 132
+    components:
+    - type: Transform
+      pos: -3.3802092,2.7928813
+      parent: 1
+  - uid: 141
+    components:
+    - type: Transform
+      pos: -3.4010425,2.6678813
+      parent: 1
+- proto: MedkitCombatFilled
+  entities:
+  - uid: 146
+    components:
+    - type: Transform
+      pos: -3.390626,2.459548
+      parent: 1
+- proto: MedkitFilled
+  entities:
+  - uid: 139
+    components:
+    - type: Transform
+      pos: -2.4265473,2.6663923
+      parent: 1
+- proto: MedkitOxygenFilled
+  entities:
+  - uid: 137
+    components:
+    - type: Transform
+      pos: -2.9010425,2.428298
+      parent: 1
+- proto: MedkitRadiationFilled
+  entities:
+  - uid: 140
+    components:
+    - type: Transform
+      pos: -3.7552092,2.772048
+      parent: 1
+- proto: MedkitToxinFilled
+  entities:
+  - uid: 133
+    components:
+    - type: Transform
+      pos: -3.765626,2.5428813
+      parent: 1
+  - uid: 135
+    components:
+    - type: Transform
+      pos: -3.765626,2.5428813
+      parent: 1
+- proto: PlasmaReinforcedWindowDirectional
+  entities:
+  - uid: 269
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-3.5
+      parent: 1
+- proto: PowerCellRecharger
+  entities:
+  - uid: 151
+    components:
+    - type: Transform
+      pos: -3.5,2.5
+      parent: 1
+- proto: Poweredlight
+  entities:
+  - uid: 95
+    components:
+    - type: Transform
+      pos: -3.5,2.5
+      parent: 1
+  - uid: 127
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,7.5
+      parent: 1
+  - uid: 142
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,2.5
+      parent: 1
+    - type: ApcPowerReceiver
+      powerLoad: 0
+  - uid: 143
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,7.5
+      parent: 1
+    - type: ApcPowerReceiver
+      powerLoad: 0
+  - uid: 145
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-3.5
+      parent: 1
+  - uid: 148
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 218
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,4.5
+      parent: 1
+  - uid: 230
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,3.5
+      parent: 1
+- proto: RandomHumanoidSpawnerERTMedicalEVA
+  entities:
+  - uid: 280
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 1
+- proto: RandomHumanoidSpawnerERTMedicalEVATime
+  entities:
+  - uid: 279
+    components:
+    - type: Transform
+      pos: -2.5,7.5
+      parent: 1
+- proto: RollerBed
+  entities:
+  - uid: 125
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 1
+- proto: SheetPlasma1
+  entities:
+  - uid: 27
+    components:
+    - type: Transform
+      parent: 15
+    - type: Stack
+      count: 2
+    - type: Item
+      size: Small
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: ShuttleWindow
+  entities:
+  - uid: 149
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,0.5
+      parent: 1
+  - uid: 150
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,1.5
+      parent: 1
+  - uid: 152
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,5.5
+      parent: 1
+  - uid: 153
+    components:
+    - type: Transform
+      pos: -3.5,8.5
+      parent: 1
+  - uid: 154
+    components:
+    - type: Transform
+      pos: -3.5,9.5
+      parent: 1
+  - uid: 156
+    components:
+    - type: Transform
+      pos: -2.5,9.5
+      parent: 1
+  - uid: 157
+    components:
+    - type: Transform
+      pos: -1.5,9.5
+      parent: 1
+  - uid: 158
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 1
+  - uid: 159
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,5.5
+      parent: 1
+  - uid: 160
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-0.5
+      parent: 1
+- proto: SinkWide
+  entities:
+  - uid: 161
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,4.5
+      parent: 1
+- proto: SMESBasic
+  entities:
+  - uid: 124
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 1
+- proto: StasisBed
+  entities:
+  - uid: 10
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 1
+  - uid: 14
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 220
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 1
+- proto: SubstationBasic
+  entities:
+  - uid: 155
+    components:
+    - type: Transform
+      pos: -4.5,-1.5
+      parent: 1
+- proto: TableReinforced
+  entities:
+  - uid: 223
+    components:
+    - type: Transform
+      pos: -3.5,2.5
+      parent: 1
+  - uid: 232
+    components:
+    - type: Transform
+      pos: -4.5,3.5
+      parent: 1
+  - uid: 233
+    components:
+    - type: Transform
+      pos: -2.5,2.5
+      parent: 1
+- proto: Thruster
+  entities:
+  - uid: 169
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,8.5
+      parent: 1
+  - uid: 170
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-4.5
+      parent: 1
+  - uid: 171
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-4.5
+      parent: 1
+  - uid: 172
+    components:
+    - type: Transform
+      pos: -0.5,9.5
+      parent: 1
+  - uid: 173
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,8.5
+      parent: 1
+  - uid: 174
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-3.5
+      parent: 1
+  - uid: 175
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-3.5
+      parent: 1
+  - uid: 176
+    components:
+    - type: Transform
+      pos: -4.5,9.5
+      parent: 1
+- proto: VendingMachineWallMedical
+  entities:
+  - uid: 162
+    components:
+    - type: Transform
+      pos: -2.5,3.5
+      parent: 1
+  - uid: 178
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,6.5
+      parent: 1
+- proto: WallShuttle
+  entities:
+  - uid: 123
+    components:
+    - type: Transform
+      pos: -2.5,3.5
+      parent: 1
+  - uid: 144
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 1
+  - uid: 163
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 1
+  - uid: 179
+    components:
+    - type: Transform
+      pos: -5.5,4.5
+      parent: 1
+  - uid: 180
+    components:
+    - type: Transform
+      pos: -5.5,3.5
+      parent: 1
+  - uid: 181
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 182
+    components:
+    - type: Transform
+      pos: -2.5,6.5
+      parent: 1
+  - uid: 183
+    components:
+    - type: Transform
+      pos: -4.5,7.5
+      parent: 1
+  - uid: 184
+    components:
+    - type: Transform
+      pos: -4.5,8.5
+      parent: 1
+  - uid: 185
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 187
+    components:
+    - type: Transform
+      pos: -3.5,7.5
+      parent: 1
+  - uid: 188
+    components:
+    - type: Transform
+      pos: -5.5,7.5
+      parent: 1
+  - uid: 189
+    components:
+    - type: Transform
+      pos: -0.5,7.5
+      parent: 1
+  - uid: 190
+    components:
+    - type: Transform
+      pos: -3.5,6.5
+      parent: 1
+  - uid: 191
+    components:
+    - type: Transform
+      pos: -0.5,8.5
+      parent: 1
+  - uid: 192
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 1
+  - uid: 193
+    components:
+    - type: Transform
+      pos: -5.5,-1.5
+      parent: 1
+  - uid: 194
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 1
+  - uid: 195
+    components:
+    - type: Transform
+      pos: 0.5,7.5
+      parent: 1
+  - uid: 196
+    components:
+    - type: Transform
+      pos: -5.5,6.5
+      parent: 1
+  - uid: 197
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 198
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 1
+  - uid: 199
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 200
+    components:
+    - type: Transform
+      pos: -2.5,-4.5
+      parent: 1
+  - uid: 201
+    components:
+    - type: Transform
+      pos: -5.5,2.5
+      parent: 1
+  - uid: 202
+    components:
+    - type: Transform
+      pos: -3.5,-3.5
+      parent: 1
+  - uid: 203
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 1
+  - uid: 205
+    components:
+    - type: Transform
+      pos: -3.5,-4.5
+      parent: 1
+  - uid: 206
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 1
+  - uid: 207
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 1
+  - uid: 208
+    components:
+    - type: Transform
+      pos: -0.5,-2.5
+      parent: 1
+  - uid: 209
+    components:
+    - type: Transform
+      pos: -4.5,-3.5
+      parent: 1
+  - uid: 211
+    components:
+    - type: Transform
+      pos: -5.5,-2.5
+      parent: 1
+  - uid: 216
+    components:
+    - type: Transform
+      pos: -4.5,-2.5
+      parent: 1
+- proto: WindoorSecureCentralCommandLocked
+  entities:
+  - uid: 213
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,6.5
+      parent: 1
+  - uid: 227
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 1
+- proto: WindoorSecureChemistryLocked
+  entities:
+  - uid: 164
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,3.5
+      parent: 1
+- proto: WindoorSecureMedicalLocked
+  entities:
+  - uid: 128
+    components:
+    - type: Transform
+      pos: -4.5,3.5
+      parent: 1
+  - uid: 214
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,1.5
+      parent: 1
+  - uid: 215
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,3.5
+      parent: 1
+  - uid: 226
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,1.5
+      parent: 1
+- proto: WindowReinforcedDirectional
+  entities:
+  - uid: 88
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 1
+  - uid: 130
+    components:
+    - type: Transform
+      pos: -3.5,-0.5
+      parent: 1
+  - uid: 177
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,2.5
+      parent: 1
+  - uid: 222
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-0.5
+      parent: 1
+  - uid: 225
+    components:
+    - type: Transform
+      pos: -4.5,-0.5
+      parent: 1
+  - uid: 228
+    components:
+    - type: Transform
+      pos: -0.5,-0.5
+      parent: 1
+  - uid: 229
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,0.5
+      parent: 1
+- proto: Wrench
+  entities:
+  - uid: 266
+    components:
+    - type: Transform
+      pos: -1.5173755,-1.4895834
+      parent: 1
+...

--- a/Resources/Maps/_Harmony/Shuttles/ShuttleEvent/ERTSecMedium.yml
+++ b/Resources/Maps/_Harmony/Shuttles/ShuttleEvent/ERTSecMedium.yml
@@ -1,0 +1,4442 @@
+meta:
+  format: 6
+  postmapinit: false
+tilemap:
+  1: Space
+  6: FloorDark
+  7: FloorDarkMono
+  2: FloorSteel
+  5: FloorTechMaint
+  8: FloorWood
+  9: FloorWoodTile
+  4: Lattice
+  3: Plating
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: NT-Salus
+    - type: Transform
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        -1,0:
+          ind: -1,0
+          tiles: AQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAABBQAAAAAAAwAAAAAABgAAAAACBwAAAAACBgAAAAABBgAAAAACAgAAAAADAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAADBQAAAAAABQAAAAAABQAAAAAAAgAAAAAABgAAAAAABgAAAAABBwAAAAABAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAABAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAABgAAAAACBgAAAAAAAgAAAAABAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAADBgAAAAADBgAAAAABBgAAAAACAgAAAAAABgAAAAAABgAAAAAAAgAAAAABAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAABgAAAAADBgAAAAACBgAAAAACAgAAAAADBgAAAAAABgAAAAABBwAAAAACAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAACAgAAAAAABwAAAAAAAgAAAAACAgAAAAADBgAAAAADBgAAAAACAgAAAAABAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAABwAAAAACBgAAAAAABwAAAAAAAgAAAAACBgAAAAACBgAAAAADAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAAABwAAAAADBgAAAAABBwAAAAACAgAAAAADBgAAAAADBgAAAAACBwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAACBwAAAAABBgAAAAABBwAAAAACAgAAAAABBgAAAAAABgAAAAABAgAAAAADAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAADAgAAAAAABwAAAAADAgAAAAADAgAAAAADBwAAAAACBwAAAAACAgAAAAABAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAAAgAAAAABBgAAAAAABgAAAAACBgAAAAACBgAAAAABBgAAAAAACAAAAAADAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAAAgAAAAABBgAAAAADBgAAAAAABgAAAAABBgAAAAACBgAAAAABCAAAAAACAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAAAwAAAAAABgAAAAACBgAAAAACBgAAAAABBgAAAAABBgAAAAAACAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAAAAwAAAAAABwAAAAADBwAAAAAABwAAAAABBwAAAAACCQAAAAABAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAA
+          version: 6
+        -1,-1:
+          ind: -1,-1
+          tiles: AQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAABAAAAAAAAgAAAAABBQAAAAAAAgAAAAABBQAAAAAAAgAAAAACAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAAAgAAAAACAgAAAAACAgAAAAADBwAAAAAABwAAAAAABwAAAAAAAgAAAAADAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAABQAAAAAABAAAAAAAAgAAAAAABwAAAAADBwAAAAACBwAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAACBQAAAAAABQAAAAAAAgAAAAADBwAAAAAABgAAAAACBgAAAAACBwAAAAABAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAABQAAAAAAAwAAAAAABgAAAAACAgAAAAABBgAAAAAABgAAAAABBwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAACBQAAAAAAAwAAAAAABgAAAAADAgAAAAABBgAAAAADBgAAAAADAgAAAAAB
+          version: 6
+        0,-1:
+          ind: 0,-1
+          tiles: AQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAACAgAAAAADBAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAADAgAAAAACAgAAAAADAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAABAgAAAAABAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAACAgAAAAADAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAABAgAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAA
+          version: 6
+        0,0:
+          ind: 0,0
+          tiles: AgAAAAAAAgAAAAADAgAAAAABAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAADAgAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAADAgAAAAADAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAABAgAAAAABAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAADAgAAAAACAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAgAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAABAgAAAAABAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAgAAAAACAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAABAgAAAAABAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAABAgAAAAABAgAAAAABAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAACAAAAAAAAgAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAACAAAAAAAAgAAAAABBAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAACAAAAAACAwAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAA
+          version: 6
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            color: '#FFFFFFFF'
+            id: Bot
+          decals:
+            71: -4,-3
+            78: -7,4
+            79: -7,3
+            81: -5,4
+            82: -5,3
+            91: -3,11
+        - node:
+            color: '#FFFFFFFF'
+            id: BotRight
+          decals:
+            64: 1,-2
+            68: 1,-3
+        - node:
+            color: '#DE3A3A96'
+            id: BrickTileSteelCornerNe
+          decals:
+            73: -5,4
+        - node:
+            color: '#DE3A3A96'
+            id: BrickTileSteelCornerNw
+          decals:
+            74: -7,4
+        - node:
+            color: '#DE3A3A96'
+            id: BrickTileSteelCornerSe
+          decals:
+            76: -5,3
+        - node:
+            color: '#DE3A3A96'
+            id: BrickTileSteelCornerSw
+          decals:
+            75: -7,3
+        - node:
+            color: '#DE3A3A96'
+            id: BrickTileSteelLineN
+          decals:
+            77: -6,4
+        - node:
+            color: '#3AB3DAFF'
+            id: BrickTileWhiteCornerNe
+          decals:
+            42: 1,5
+        - node:
+            color: '#80C71FFF'
+            id: BrickTileWhiteCornerNe
+          decals:
+            46: 1,2
+        - node:
+            color: '#C74EBDFF'
+            id: BrickTileWhiteCornerNe
+          decals:
+            50: 1,-1
+        - node:
+            color: '#DE3A3ACD'
+            id: BrickTileWhiteCornerNe
+          decals:
+            7: -2,8
+            24: -2,12
+        - node:
+            color: '#F9801DE6'
+            id: BrickTileWhiteCornerNe
+          decals:
+            63: 1,8
+        - node:
+            color: '#3AB3DAFF'
+            id: BrickTileWhiteCornerNw
+          decals:
+            41: 0,5
+        - node:
+            color: '#80C71FFF'
+            id: BrickTileWhiteCornerNw
+          decals:
+            45: 0,2
+        - node:
+            color: '#C74EBDFF'
+            id: BrickTileWhiteCornerNw
+          decals:
+            49: 0,-1
+        - node:
+            color: '#DE3A3ACD'
+            id: BrickTileWhiteCornerNw
+          decals:
+            25: -6,12
+        - node:
+            color: '#F53A3A93'
+            id: BrickTileWhiteCornerNw
+          decals:
+            85: -3,8
+        - node:
+            color: '#F9801DE6'
+            id: BrickTileWhiteCornerNw
+          decals:
+            62: 0,8
+        - node:
+            color: '#3AB3DAFF'
+            id: BrickTileWhiteCornerSe
+          decals:
+            40: 1,4
+        - node:
+            color: '#80C71FFF'
+            id: BrickTileWhiteCornerSe
+          decals:
+            47: 1,1
+        - node:
+            color: '#C74EBDFF'
+            id: BrickTileWhiteCornerSe
+          decals:
+            48: 1,-4
+            65: 1,-3
+        - node:
+            color: '#DE3A3A96'
+            id: BrickTileWhiteCornerSe
+          decals:
+            54: -2,-3
+            55: -2,-3
+        - node:
+            color: '#DE3A3ACD'
+            id: BrickTileWhiteCornerSe
+          decals:
+            27: -2,10
+        - node:
+            color: '#F9801DE6'
+            id: BrickTileWhiteCornerSe
+          decals:
+            61: 1,7
+        - node:
+            color: '#3AB3DAFF'
+            id: BrickTileWhiteCornerSw
+          decals:
+            43: 0,4
+        - node:
+            color: '#80C71FFF'
+            id: BrickTileWhiteCornerSw
+          decals:
+            44: 0,1
+        - node:
+            color: '#DE3A3A96'
+            id: BrickTileWhiteCornerSw
+          decals:
+            72: -3,-3
+        - node:
+            color: '#DE3A3ACD'
+            id: BrickTileWhiteCornerSw
+          decals:
+            26: -6,10
+        - node:
+            color: '#F9801DE6'
+            id: BrickTileWhiteCornerSw
+          decals:
+            60: 0,7
+        - node:
+            color: '#DE3A3ACD'
+            id: BrickTileWhiteEndN
+          decals:
+            36: -6,8
+        - node:
+            color: '#C74EBDFF'
+            id: BrickTileWhiteEndS
+          decals:
+            66: 0,-4
+        - node:
+            color: '#DE3A3ACD'
+            id: BrickTileWhiteEndS
+          decals:
+            37: -6,6
+        - node:
+            color: '#C74EBDFF'
+            id: BrickTileWhiteInnerSe
+          decals:
+            67: 0,-3
+        - node:
+            color: '#C74EBDFF'
+            id: BrickTileWhiteLineE
+          decals:
+            51: 1,-2
+        - node:
+            color: '#DE3A3ACD'
+            id: BrickTileWhiteLineE
+          decals:
+            8: -2,-2
+            9: -2,-1
+            10: -2,0
+            11: -2,1
+            12: -2,2
+            13: -2,3
+            14: -2,4
+            15: -2,5
+            16: -2,6
+            17: -2,7
+            28: -2,11
+            38: -6,7
+        - node:
+            color: '#DE3A3ACD'
+            id: BrickTileWhiteLineN
+          decals:
+            33: -5,12
+            34: -4,12
+            35: -3,12
+        - node:
+            color: '#79150096'
+            id: BrickTileWhiteLineS
+          decals:
+            90: -6,3
+        - node:
+            color: '#DE3A3ACD'
+            id: BrickTileWhiteLineS
+          decals:
+            30: -5,10
+            31: -4,10
+            32: -3,10
+        - node:
+            color: '#3AB3DAFF'
+            id: BrickTileWhiteLineW
+          decals:
+            87: -3,4
+        - node:
+            color: '#80C71FFF'
+            id: BrickTileWhiteLineW
+          decals:
+            88: -3,1
+        - node:
+            color: '#C74EBDFF'
+            id: BrickTileWhiteLineW
+          decals:
+            52: 0,-2
+            53: 0,-3
+            89: -3,-2
+        - node:
+            color: '#DE3A3ACD'
+            id: BrickTileWhiteLineW
+          decals:
+            18: -3,5
+            19: -3,6
+            20: -3,3
+            21: -3,2
+            22: -3,0
+            23: -3,-1
+            29: -6,11
+            39: -6,7
+        - node:
+            color: '#F9801DFF'
+            id: BrickTileWhiteLineW
+          decals:
+            86: -3,7
+        - node:
+            angle: 3.141592653589793 rad
+            color: '#FFFFFFFF'
+            id: LoadingArea
+          decals:
+            69: -4,-5
+            70: -2,-5
+        - node:
+            color: '#DE3A3A41'
+            id: MonoOverlay
+          decals:
+            56: -5,13
+            57: -4,13
+            58: -3,13
+            59: -2,13
+        - node:
+            color: '#FFFFFFFF'
+            id: StandClear
+          decals:
+            84: -3,-4
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinBox
+          decals:
+            6: -1,13
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinCornerNe
+          decals:
+            0: 0,12
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinCornerNw
+          decals:
+            5: -1,12
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinCornerSe
+          decals:
+            1: 0,10
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinCornerSw
+          decals:
+            2: -1,10
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinLineE
+          decals:
+            4: 0,11
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinLineW
+          decals:
+            3: -1,11
+    - type: GridAtmosphere
+      version: 2
+      data:
+        tiles:
+          -2,0:
+            0: 57582
+          -2,1:
+            0: 60942
+          -2,2:
+            0: 52302
+            1: 4352
+          -2,3:
+            1: 1
+            0: 140
+          -2,-1:
+            0: 58976
+            1: 4
+          -1,0:
+            0: 26343
+          -1,2:
+            0: 65382
+          -1,3:
+            0: 255
+          -1,1:
+            0: 58990
+          -1,-1:
+            0: 28407
+          0,0:
+            0: 816
+          0,1:
+            0: 12339
+          0,2:
+            0: 4355
+            1: 17408
+          0,3:
+            0: 1
+            1: 4
+          -2,-2:
+            1: 5632
+          -1,-2:
+            0: 29952
+          0,-2:
+            1: 17152
+          0,-1:
+            0: 13105
+        uniqueMixes:
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          immutable: True
+          moles:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        chunkSize: 4
+    - type: OccluderTree
+    - type: Shuttle
+    - type: RadiationGridResistance
+    - type: GravityShake
+      shakeTimes: 10
+    - type: GasTileOverlay
+    - type: SpreaderGrid
+    - type: GridPathfinding
+- proto: ActionToggleInternals
+  entities:
+  - uid: 100
+    components:
+    - type: Transform
+      parent: 266
+    - type: InstantAction
+      container: 266
+- proto: AirAlarm
+  entities:
+  - uid: 271
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,7.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 209
+      - 516
+      - 547
+  - uid: 273
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,1.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 546
+      - 207
+      - 549
+  - uid: 278
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,1.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 549
+  - uid: 279
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-1.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 506
+      - 206
+      - 550
+  - uid: 280
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,4.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 208
+      - 520
+      - 548
+  - uid: 420
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,9.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 541
+      - 540
+      - 421
+      - 210
+      - 214
+      - 551
+      - 545
+      - 552
+      - 553
+      - 140
+      - 495
+      - 185
+      - 523
+      - 530
+      - 212
+      - 538
+      - 211
+      - 131
+      - 132
+  - uid: 559
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-3.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 140
+      - 495
+      - 553
+      - 552
+      - 545
+      - 214
+      - 551
+      - 135
+      - 132
+      - 131
+  - uid: 560
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-1.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 185
+      - 523
+      - 135
+- proto: AirCanister
+  entities:
+  - uid: 339
+    components:
+    - type: Transform
+      anchored: True
+      pos: -5.5,1.5
+      parent: 1
+    - type: Physics
+      bodyType: Static
+- proto: AirlockCentralCommandGlassLocked
+  entities:
+  - uid: 430
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,9.5
+      parent: 1
+- proto: AirlockCentralCommandLocked
+  entities:
+  - uid: 4
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,0.5
+      parent: 1
+  - uid: 431
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,9.5
+      parent: 1
+  - uid: 432
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,9.5
+      parent: 1
+- proto: AirlockGlassShuttle
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      pos: -1.5,-5.5
+      parent: 1
+  - uid: 6
+    components:
+    - type: Transform
+      pos: -3.5,-5.5
+      parent: 1
+- proto: AirSensor
+  entities:
+  - uid: 421
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,11.5
+      parent: 1
+  - uid: 547
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,8.5
+      parent: 1
+  - uid: 548
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 549
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 550
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-1.5
+      parent: 1
+  - uid: 551
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,5.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 559
+  - uid: 552
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,2.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 559
+  - uid: 553
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-3.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 559
+- proto: APCSuperCapacity
+  entities:
+  - uid: 10
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,10.5
+      parent: 1
+  - uid: 51
+    components:
+    - type: Transform
+      pos: -5.5,2.5
+      parent: 1
+- proto: AtmosDeviceFanDirectional
+  entities:
+  - uid: 5
+    components:
+    - type: Transform
+      pos: -1.5,-5.5
+      parent: 1
+  - uid: 12
+    components:
+    - type: Transform
+      pos: -3.5,-5.5
+      parent: 1
+- proto: Bed
+  entities:
+  - uid: 15
+    components:
+    - type: Transform
+      pos: 1.5,-0.5
+      parent: 1
+  - uid: 16
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 17
+    components:
+    - type: Transform
+      pos: 1.5,8.5
+      parent: 1
+  - uid: 18
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 19
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+- proto: BedsheetOrange
+  entities:
+  - uid: 14
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+  - uid: 20
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 21
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-0.5
+      parent: 1
+  - uid: 22
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 23
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,8.5
+      parent: 1
+- proto: BlastDoorOpen
+  entities:
+  - uid: 327
+    components:
+    - type: Transform
+      pos: -6.5,12.5
+      parent: 1
+  - uid: 433
+    components:
+    - type: Transform
+      pos: -6.5,13.5
+      parent: 1
+  - uid: 452
+    components:
+    - type: Transform
+      pos: -5.5,13.5
+      parent: 1
+  - uid: 498
+    components:
+    - type: Transform
+      pos: -5.5,14.5
+      parent: 1
+  - uid: 499
+    components:
+    - type: Transform
+      pos: -4.5,14.5
+      parent: 1
+  - uid: 500
+    components:
+    - type: Transform
+      pos: -3.5,14.5
+      parent: 1
+  - uid: 561
+    components:
+    - type: Transform
+      pos: -2.5,14.5
+      parent: 1
+  - uid: 562
+    components:
+    - type: Transform
+      pos: -0.5,14.5
+      parent: 1
+  - uid: 563
+    components:
+    - type: Transform
+      pos: 0.5,14.5
+      parent: 1
+  - uid: 564
+    components:
+    - type: Transform
+      pos: -1.5,14.5
+      parent: 1
+  - uid: 565
+    components:
+    - type: Transform
+      pos: 0.5,13.5
+      parent: 1
+  - uid: 566
+    components:
+    - type: Transform
+      pos: 1.5,13.5
+      parent: 1
+  - uid: 567
+    components:
+    - type: Transform
+      pos: 1.5,12.5
+      parent: 1
+  - uid: 568
+    components:
+    - type: Transform
+      pos: -7.5,7.5
+      parent: 1
+  - uid: 569
+    components:
+    - type: Transform
+      pos: 2.5,8.5
+      parent: 1
+  - uid: 570
+    components:
+    - type: Transform
+      pos: 2.5,7.5
+      parent: 1
+  - uid: 571
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 572
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 573
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 574
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 575
+    components:
+    - type: Transform
+      pos: 2.5,-0.5
+      parent: 1
+  - uid: 576
+    components:
+    - type: Transform
+      pos: 2.5,-1.5
+      parent: 1
+  - uid: 577
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 1
+- proto: BoxBodyBag
+  entities:
+  - uid: 25
+    components:
+    - type: Transform
+      pos: -4.603752,8.272678
+      parent: 1
+- proto: BoxFlashbang
+  entities:
+  - uid: 26
+    components:
+    - type: Transform
+      pos: -4.2180023,8.766628
+      parent: 1
+- proto: BoxFolderRed
+  entities:
+  - uid: 27
+    components:
+    - type: Transform
+      pos: -0.53362274,11.605877
+      parent: 1
+- proto: BoxHandcuff
+  entities:
+  - uid: 28
+    components:
+    - type: Transform
+      pos: -4.188057,8.482319
+      parent: 1
+- proto: BoxZiptie
+  entities:
+  - uid: 29
+    components:
+    - type: Transform
+      pos: -4.652153,8.616993
+      parent: 1
+- proto: ButtonFrameCaution
+  entities:
+  - uid: 213
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,11.5
+      parent: 1
+- proto: CableApcExtension
+  entities:
+  - uid: 3
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 11
+    components:
+    - type: Transform
+      pos: -2.5,10.5
+      parent: 1
+  - uid: 30
+    components:
+    - type: Transform
+      pos: -2.5,12.5
+      parent: 1
+  - uid: 31
+    components:
+    - type: Transform
+      pos: -4.5,11.5
+      parent: 1
+  - uid: 32
+    components:
+    - type: Transform
+      pos: -5.5,-4.5
+      parent: 1
+  - uid: 33
+    components:
+    - type: Transform
+      pos: -6.5,10.5
+      parent: 1
+  - uid: 35
+    components:
+    - type: Transform
+      pos: -3.5,11.5
+      parent: 1
+  - uid: 36
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 1
+  - uid: 37
+    components:
+    - type: Transform
+      pos: -5.5,11.5
+      parent: 1
+  - uid: 38
+    components:
+    - type: Transform
+      pos: -2.5,14.5
+      parent: 1
+  - uid: 39
+    components:
+    - type: Transform
+      pos: -1.5,14.5
+      parent: 1
+  - uid: 40
+    components:
+    - type: Transform
+      pos: -0.5,14.5
+      parent: 1
+  - uid: 41
+    components:
+    - type: Transform
+      pos: 0.5,14.5
+      parent: 1
+  - uid: 42
+    components:
+    - type: Transform
+      pos: 1.5,13.5
+      parent: 1
+  - uid: 43
+    components:
+    - type: Transform
+      pos: 1.5,12.5
+      parent: 1
+  - uid: 44
+    components:
+    - type: Transform
+      pos: -3.5,14.5
+      parent: 1
+  - uid: 45
+    components:
+    - type: Transform
+      pos: -4.5,14.5
+      parent: 1
+  - uid: 46
+    components:
+    - type: Transform
+      pos: -5.5,14.5
+      parent: 1
+  - uid: 47
+    components:
+    - type: Transform
+      pos: -6.5,13.5
+      parent: 1
+  - uid: 48
+    components:
+    - type: Transform
+      pos: -6.5,12.5
+      parent: 1
+  - uid: 49
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 1
+  - uid: 50
+    components:
+    - type: Transform
+      pos: -0.5,-2.5
+      parent: 1
+  - uid: 52
+    components:
+    - type: Transform
+      pos: -5.5,-2.5
+      parent: 1
+  - uid: 53
+    components:
+    - type: Transform
+      pos: -0.5,11.5
+      parent: 1
+  - uid: 54
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 1
+  - uid: 55
+    components:
+    - type: Transform
+      pos: -5.5,1.5
+      parent: 1
+  - uid: 56
+    components:
+    - type: Transform
+      pos: -5.5,-0.5
+      parent: 1
+  - uid: 58
+    components:
+    - type: Transform
+      pos: -1.5,10.5
+      parent: 1
+  - uid: 59
+    components:
+    - type: Transform
+      pos: -4.5,0.5
+      parent: 1
+  - uid: 60
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 61
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 1
+  - uid: 62
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 1
+  - uid: 63
+    components:
+    - type: Transform
+      pos: -5.5,10.5
+      parent: 1
+  - uid: 64
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 1
+  - uid: 65
+    components:
+    - type: Transform
+      pos: -5.5,0.5
+      parent: 1
+  - uid: 66
+    components:
+    - type: Transform
+      pos: 1.5,-4.5
+      parent: 1
+  - uid: 67
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+  - uid: 68
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 1
+  - uid: 69
+    components:
+    - type: Transform
+      pos: -6.5,-4.5
+      parent: 1
+  - uid: 70
+    components:
+    - type: Transform
+      pos: -5.5,13.5
+      parent: 1
+  - uid: 71
+    components:
+    - type: Transform
+      pos: -0.5,10.5
+      parent: 1
+  - uid: 72
+    components:
+    - type: Transform
+      pos: 0.5,13.5
+      parent: 1
+  - uid: 73
+    components:
+    - type: Transform
+      pos: -5.5,-1.5
+      parent: 1
+  - uid: 74
+    components:
+    - type: Transform
+      pos: -5.5,9.5
+      parent: 1
+  - uid: 75
+    components:
+    - type: Transform
+      pos: -5.5,8.5
+      parent: 1
+  - uid: 76
+    components:
+    - type: Transform
+      pos: -5.5,7.5
+      parent: 1
+  - uid: 77
+    components:
+    - type: Transform
+      pos: -5.5,6.5
+      parent: 1
+  - uid: 78
+    components:
+    - type: Transform
+      pos: -5.5,5.5
+      parent: 1
+  - uid: 79
+    components:
+    - type: Transform
+      pos: -5.5,4.5
+      parent: 1
+  - uid: 80
+    components:
+    - type: Transform
+      pos: -2.5,11.5
+      parent: 1
+  - uid: 81
+    components:
+    - type: Transform
+      pos: -2.5,13.5
+      parent: 1
+  - uid: 82
+    components:
+    - type: Transform
+      pos: -5.5,2.5
+      parent: 1
+  - uid: 86
+    components:
+    - type: Transform
+      pos: -6.5,-2.5
+      parent: 1
+  - uid: 138
+    components:
+    - type: Transform
+      pos: -2.5,-4.5
+      parent: 1
+  - uid: 139
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 1
+  - uid: 197
+    components:
+    - type: Transform
+      pos: -3.5,-4.5
+      parent: 1
+  - uid: 199
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 1
+  - uid: 220
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 1
+  - uid: 296
+    components:
+    - type: Transform
+      pos: -6.5,-3.5
+      parent: 1
+  - uid: 453
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 1
+  - uid: 454
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 455
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 456
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 1
+  - uid: 457
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 1
+  - uid: 458
+    components:
+    - type: Transform
+      pos: -0.5,7.5
+      parent: 1
+  - uid: 459
+    components:
+    - type: Transform
+      pos: 0.5,7.5
+      parent: 1
+  - uid: 460
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 1
+  - uid: 461
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 462
+    components:
+    - type: Transform
+      pos: -0.5,1.5
+      parent: 1
+  - uid: 463
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+- proto: CableHV
+  entities:
+  - uid: 87
+    components:
+    - type: Transform
+      pos: -6.5,-1.5
+      parent: 1
+  - uid: 88
+    components:
+    - type: Transform
+      pos: -6.5,-0.5
+      parent: 1
+  - uid: 89
+    components:
+    - type: Transform
+      pos: -6.5,0.5
+      parent: 1
+  - uid: 90
+    components:
+    - type: Transform
+      pos: -6.5,-2.5
+      parent: 1
+  - uid: 91
+    components:
+    - type: Transform
+      pos: -5.5,-2.5
+      parent: 1
+- proto: CableMV
+  entities:
+  - uid: 34
+    components:
+    - type: Transform
+      pos: -5.5,2.5
+      parent: 1
+  - uid: 83
+    components:
+    - type: Transform
+      pos: -5.5,1.5
+      parent: 1
+  - uid: 84
+    components:
+    - type: Transform
+      pos: -6.5,10.5
+      parent: 1
+  - uid: 92
+    components:
+    - type: Transform
+      pos: -6.5,0.5
+      parent: 1
+  - uid: 95
+    components:
+    - type: Transform
+      pos: -5.5,0.5
+      parent: 1
+  - uid: 96
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 1
+  - uid: 97
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 1
+  - uid: 98
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 99
+    components:
+    - type: Transform
+      pos: -4.5,0.5
+      parent: 1
+  - uid: 436
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 437
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 1
+  - uid: 438
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 1
+  - uid: 439
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 440
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 441
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 1
+  - uid: 442
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 1
+  - uid: 443
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 1
+  - uid: 444
+    components:
+    - type: Transform
+      pos: -1.5,9.5
+      parent: 1
+  - uid: 445
+    components:
+    - type: Transform
+      pos: -1.5,10.5
+      parent: 1
+  - uid: 446
+    components:
+    - type: Transform
+      pos: -1.5,11.5
+      parent: 1
+  - uid: 447
+    components:
+    - type: Transform
+      pos: -2.5,11.5
+      parent: 1
+  - uid: 448
+    components:
+    - type: Transform
+      pos: -3.5,11.5
+      parent: 1
+  - uid: 449
+    components:
+    - type: Transform
+      pos: -4.5,11.5
+      parent: 1
+  - uid: 450
+    components:
+    - type: Transform
+      pos: -5.5,11.5
+      parent: 1
+  - uid: 451
+    components:
+    - type: Transform
+      pos: -5.5,10.5
+      parent: 1
+  - uid: 465
+    components:
+    - type: Transform
+      pos: 2.5,8.5
+      parent: 1
+  - uid: 466
+    components:
+    - type: Transform
+      pos: 2.5,7.5
+      parent: 1
+  - uid: 467
+    components:
+    - type: Transform
+      pos: 2.5,6.5
+      parent: 1
+  - uid: 468
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 469
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 470
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 471
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 472
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 473
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 474
+    components:
+    - type: Transform
+      pos: 2.5,-0.5
+      parent: 1
+  - uid: 475
+    components:
+    - type: Transform
+      pos: 2.5,-1.5
+      parent: 1
+  - uid: 476
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 1
+  - uid: 477
+    components:
+    - type: Transform
+      pos: 2.5,-3.5
+      parent: 1
+  - uid: 478
+    components:
+    - type: Transform
+      pos: 1.5,-3.5
+      parent: 1
+  - uid: 480
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+  - uid: 481
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 1
+  - uid: 482
+    components:
+    - type: Transform
+      pos: -0.5,-2.5
+      parent: 1
+  - uid: 483
+    components:
+    - type: Transform
+      pos: -0.5,-1.5
+      parent: 1
+  - uid: 484
+    components:
+    - type: Transform
+      pos: -0.5,-0.5
+      parent: 1
+  - uid: 485
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 1
+  - uid: 486
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 1
+  - uid: 487
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 488
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 489
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 490
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 491
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 492
+    components:
+    - type: Transform
+      pos: -0.5,8.5
+      parent: 1
+  - uid: 493
+    components:
+    - type: Transform
+      pos: 0.5,8.5
+      parent: 1
+  - uid: 494
+    components:
+    - type: Transform
+      pos: 1.5,8.5
+      parent: 1
+  - uid: 587
+    components:
+    - type: Transform
+      pos: -5.5,8.5
+      parent: 1
+  - uid: 588
+    components:
+    - type: Transform
+      pos: -5.5,9.5
+      parent: 1
+  - uid: 590
+    components:
+    - type: Transform
+      pos: -6.5,12.5
+      parent: 1
+  - uid: 591
+    components:
+    - type: Transform
+      pos: -6.5,13.5
+      parent: 1
+  - uid: 592
+    components:
+    - type: Transform
+      pos: -5.5,13.5
+      parent: 1
+  - uid: 593
+    components:
+    - type: Transform
+      pos: -5.5,14.5
+      parent: 1
+  - uid: 594
+    components:
+    - type: Transform
+      pos: -4.5,14.5
+      parent: 1
+  - uid: 595
+    components:
+    - type: Transform
+      pos: -3.5,14.5
+      parent: 1
+  - uid: 596
+    components:
+    - type: Transform
+      pos: -2.5,14.5
+      parent: 1
+  - uid: 597
+    components:
+    - type: Transform
+      pos: -1.5,14.5
+      parent: 1
+  - uid: 598
+    components:
+    - type: Transform
+      pos: -0.5,14.5
+      parent: 1
+  - uid: 599
+    components:
+    - type: Transform
+      pos: 0.5,14.5
+      parent: 1
+  - uid: 600
+    components:
+    - type: Transform
+      pos: 0.5,13.5
+      parent: 1
+  - uid: 601
+    components:
+    - type: Transform
+      pos: 1.5,13.5
+      parent: 1
+  - uid: 602
+    components:
+    - type: Transform
+      pos: 1.5,12.5
+      parent: 1
+  - uid: 604
+    components:
+    - type: Transform
+      pos: -2.5,12.5
+      parent: 1
+  - uid: 605
+    components:
+    - type: Transform
+      pos: -2.5,13.5
+      parent: 1
+  - uid: 606
+    components:
+    - type: Transform
+      pos: -5.5,7.5
+      parent: 1
+  - uid: 607
+    components:
+    - type: Transform
+      pos: -6.5,7.5
+      parent: 1
+  - uid: 608
+    components:
+    - type: Transform
+      pos: -7.5,7.5
+      parent: 1
+- proto: CableTerminal
+  entities:
+  - uid: 101
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,-2.5
+      parent: 1
+- proto: Catwalk
+  entities:
+  - uid: 24
+    components:
+    - type: Transform
+      pos: -7.5,10.5
+      parent: 1
+  - uid: 94
+    components:
+    - type: Transform
+      pos: -5.5,-5.5
+      parent: 1
+  - uid: 255
+    components:
+    - type: Transform
+      pos: 0.5,-5.5
+      parent: 1
+  - uid: 256
+    components:
+    - type: Transform
+      pos: 2.5,-4.5
+      parent: 1
+  - uid: 259
+    components:
+    - type: Transform
+      pos: -6.5,-5.5
+      parent: 1
+  - uid: 267
+    components:
+    - type: Transform
+      pos: -7.5,-4.5
+      parent: 1
+  - uid: 277
+    components:
+    - type: Transform
+      pos: 1.5,-5.5
+      parent: 1
+  - uid: 579
+    components:
+    - type: Transform
+      pos: -5.5,-1.5
+      parent: 1
+  - uid: 580
+    components:
+    - type: Transform
+      pos: -5.5,-0.5
+      parent: 1
+  - uid: 581
+    components:
+    - type: Transform
+      pos: -5.5,0.5
+      parent: 1
+  - uid: 582
+    components:
+    - type: Transform
+      pos: -7.5,11.5
+      parent: 1
+  - uid: 583
+    components:
+    - type: Transform
+      pos: -7.5,12.5
+      parent: 1
+  - uid: 584
+    components:
+    - type: Transform
+      pos: 2.5,12.5
+      parent: 1
+  - uid: 585
+    components:
+    - type: Transform
+      pos: 2.5,11.5
+      parent: 1
+  - uid: 586
+    components:
+    - type: Transform
+      pos: 2.5,10.5
+      parent: 1
+- proto: Chair
+  entities:
+  - uid: 102
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-1.5
+      parent: 1
+  - uid: 103
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-2.5
+      parent: 1
+- proto: ChairFoldingSpawnFolded
+  entities:
+  - uid: 104
+    components:
+    - type: Transform
+      pos: -5.385409,-1.1814368
+      parent: 1
+  - uid: 105
+    components:
+    - type: Transform
+      pos: -5.6145754,-1.7339035
+      parent: 1
+- proto: ChairPilotSeat
+  entities:
+  - uid: 107
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,10.5
+      parent: 1
+  - uid: 108
+    components:
+    - type: Transform
+      pos: -0.5,12.5
+      parent: 1
+  - uid: 109
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,12.5
+      parent: 1
+  - uid: 110
+    components:
+    - type: Transform
+      pos: 0.5,12.5
+      parent: 1
+  - uid: 111
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,10.5
+      parent: 1
+  - uid: 112
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,7.5
+      parent: 1
+  - uid: 113
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,4.5
+      parent: 1
+  - uid: 114
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,1.5
+      parent: 1
+  - uid: 115
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-1.5
+      parent: 1
+  - uid: 116
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,12.5
+      parent: 1
+- proto: ClothingBeltUtilityEngineering
+  entities:
+  - uid: 205
+    components:
+    - type: Transform
+      pos: -6.453505,7.10141
+      parent: 1
+- proto: ComputerComms
+  entities:
+  - uid: 118
+    components:
+    - type: Transform
+      pos: -3.5,13.5
+      parent: 1
+- proto: ComputerPowerMonitoring
+  entities:
+  - uid: 119
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-0.5
+      parent: 1
+- proto: ComputerShuttle
+  entities:
+  - uid: 120
+    components:
+    - type: Transform
+      pos: -4.5,13.5
+      parent: 1
+- proto: CrateEmergencyExplosive
+  entities:
+  - uid: 121
+    components:
+    - type: Transform
+      pos: -4.5,6.5
+      parent: 1
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+- proto: DoorRemoteSecurity
+  entities:
+  - uid: 122
+    components:
+    - type: Transform
+      pos: 0.06012726,11.746502
+      parent: 1
+- proto: DrinkWaterCup
+  entities:
+  - uid: 123
+    components:
+    - type: Transform
+      pos: -2.0664825,13.623829
+      parent: 1
+  - uid: 124
+    components:
+    - type: Transform
+      pos: -1.9916306,13.504124
+      parent: 1
+- proto: FaxMachineBase
+  entities:
+  - uid: 125
+    components:
+    - type: Transform
+      pos: -2.5,13.5
+      parent: 1
+    - type: FaxMachine
+      name: NT-Salus
+- proto: FirelockEdge
+  entities:
+  - uid: 126
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,7.5
+      parent: 1
+  - uid: 127
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,1.5
+      parent: 1
+  - uid: 128
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,4.5
+      parent: 1
+  - uid: 129
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-1.5
+      parent: 1
+  - uid: 130
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-2.5
+      parent: 1
+- proto: FirelockGlass
+  entities:
+  - uid: 131
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,9.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 559
+      - 420
+  - uid: 132
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,9.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 559
+      - 420
+  - uid: 133
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,9.5
+      parent: 1
+  - uid: 134
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,5.5
+      parent: 1
+  - uid: 135
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,0.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 559
+      - 560
+- proto: FoodBoxDonkpocket
+  entities:
+  - uid: 418
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.76510704,11.452583
+      parent: 1
+- proto: FoodBoxDonut
+  entities:
+  - uid: 136
+    components:
+    - type: Transform
+      pos: 0.61756134,11.793995
+      parent: 1
+  - uid: 137
+    components:
+    - type: Transform
+      pos: 0.29149628,11.503162
+      parent: 1
+- proto: GasPassiveVent
+  entities:
+  - uid: 215
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF22FFFF'
+  - uid: 216
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF22FFFF'
+  - uid: 217
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF22FFFF'
+  - uid: 218
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF22FFFF'
+  - uid: 496
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeBend
+  entities:
+  - uid: 141
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 142
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF22FFFF'
+  - uid: 143
+    components:
+    - type: Transform
+      pos: -2.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF22FFFF'
+  - uid: 497
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 510
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 517
+    components:
+    - type: Transform
+      pos: 2.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 521
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeFourway
+  entities:
+  - uid: 529
+    components:
+    - type: Transform
+      pos: -4.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeStraight
+  entities:
+  - uid: 144
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 145
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 146
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 147
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 148
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 149
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 150
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 151
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 152
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 153
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 154
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 155
+    components:
+    - type: Transform
+      pos: -1.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 156
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 157
+    components:
+    - type: Transform
+      pos: -1.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 158
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 160
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 161
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 162
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 163
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 164
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 165
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 166
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 167
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF22FFFF'
+  - uid: 168
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF22FFFF'
+  - uid: 169
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF22FFFF'
+  - uid: 170
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF22FFFF'
+  - uid: 171
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF22FFFF'
+  - uid: 172
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF22FFFF'
+  - uid: 173
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF22FFFF'
+  - uid: 174
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF22FFFF'
+  - uid: 175
+    components:
+    - type: Transform
+      pos: -2.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF22FFFF'
+  - uid: 176
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF22FFFF'
+  - uid: 177
+    components:
+    - type: Transform
+      pos: -2.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF22FFFF'
+  - uid: 178
+    components:
+    - type: Transform
+      pos: -2.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF22FFFF'
+  - uid: 179
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF22FFFF'
+  - uid: 180
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF22FFFF'
+  - uid: 181
+    components:
+    - type: Transform
+      pos: -2.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF22FFFF'
+  - uid: 182
+    components:
+    - type: Transform
+      pos: -2.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF22FFFF'
+  - uid: 183
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF22FFFF'
+  - uid: 184
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF22FFFF'
+  - uid: 261
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 295
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,0.5
+      parent: 1
+  - uid: 297
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 502
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 503
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 504
+    components:
+    - type: Transform
+      anchored: False
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+    - type: Physics
+      canCollide: True
+      bodyType: Dynamic
+  - uid: 507
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 509
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 511
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 513
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 514
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 515
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 518
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 522
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 524
+    components:
+    - type: Transform
+      pos: -4.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 525
+    components:
+    - type: Transform
+      pos: -4.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 526
+    components:
+    - type: Transform
+      pos: -4.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 527
+    components:
+    - type: Transform
+      pos: -4.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 528
+    components:
+    - type: Transform
+      pos: -4.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 531
+    components:
+    - type: Transform
+      pos: -4.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 532
+    components:
+    - type: Transform
+      pos: -4.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 533
+    components:
+    - type: Transform
+      anchored: False
+      pos: -4.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+    - type: Physics
+      canCollide: True
+      bodyType: Dynamic
+  - uid: 534
+    components:
+    - type: Transform
+      pos: -4.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 535
+    components:
+    - type: Transform
+      pos: -4.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 537
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 542
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 543
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 544
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeTJunction
+  entities:
+  - uid: 186
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 187
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 188
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 189
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 190
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 191
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 192
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 193
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 194
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF22FFFF'
+  - uid: 195
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF22FFFF'
+  - uid: 196
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF22FFFF'
+  - uid: 219
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,0.5
+      parent: 1
+  - uid: 338
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 501
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 505
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 508
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 512
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 519
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 536
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 539
+    components:
+    - type: Transform
+      pos: -4.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPort
+  entities:
+  - uid: 198
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF22FFFF'
+  - uid: 340
+    components:
+    - type: Transform
+      pos: -5.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPressurePump
+  entities:
+  - uid: 200
+    components:
+    - type: MetaData
+      desc: A pump to fill the cell with nitrous oxide.
+      name: nitrous oxide
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF22FFFF'
+  - uid: 201
+    components:
+    - type: MetaData
+      desc: A pump to fill the cell with nitrous oxide.
+      name: nitrous oxide pump
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF22FFFF'
+  - uid: 202
+    components:
+    - type: MetaData
+      desc: A pump to fill the cell with nitrous oxide.
+      name: nitrous oxide pump
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF22FFFF'
+  - uid: 203
+    components:
+    - type: MetaData
+      desc: A pump to fill the cell with nitrous oxide.
+      name: nitrous oxide pump
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF22FFFF'
+- proto: GasValve
+  entities:
+  - uid: 85
+    components:
+    - type: MetaData
+      desc: Releases nitrous oxide into the cell pipe network.
+      name: nitrous oxide valve
+    - type: Transform
+      pos: -2.5,10.5
+      parent: 1
+    - type: GasValve
+      open: False
+    - type: AtmosPipeColor
+      color: '#FF22FFFF'
+- proto: GasVentPump
+  entities:
+  - uid: 140
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-3.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 559
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 185
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-0.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 560
+  - uid: 206
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 207
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 208
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 209
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 210
+    components:
+    - type: Transform
+      pos: -1.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 211
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 212
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 214
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,6.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 559
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasVentScrubber
+  entities:
+  - uid: 495
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-4.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 559
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 506
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 516
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 520
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 523
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-1.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 560
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 530
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 538
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 540
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 541
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 545
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,3.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 559
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 546
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GeneratorBasic15kW
+  entities:
+  - uid: 57
+    components:
+    - type: Transform
+      pos: -6.5,-2.5
+      parent: 1
+  - uid: 464
+    components:
+    - type: Transform
+      pos: -5.5,-2.5
+      parent: 1
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 221
+    components:
+    - type: Transform
+      pos: -6.5,1.5
+      parent: 1
+- proto: Grille
+  entities:
+  - uid: 222
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 223
+    components:
+    - type: Transform
+      pos: -0.5,8.5
+      parent: 1
+  - uid: 224
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 225
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,7.5
+      parent: 1
+  - uid: 226
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 227
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 228
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 1
+  - uid: 229
+    components:
+    - type: Transform
+      pos: -5.5,13.5
+      parent: 1
+  - uid: 230
+    components:
+    - type: Transform
+      pos: 0.5,13.5
+      parent: 1
+  - uid: 232
+    components:
+    - type: Transform
+      pos: -6.5,12.5
+      parent: 1
+  - uid: 233
+    components:
+    - type: Transform
+      pos: -6.5,13.5
+      parent: 1
+  - uid: 234
+    components:
+    - type: Transform
+      pos: -5.5,14.5
+      parent: 1
+  - uid: 235
+    components:
+    - type: Transform
+      pos: -4.5,14.5
+      parent: 1
+  - uid: 236
+    components:
+    - type: Transform
+      pos: -3.5,14.5
+      parent: 1
+  - uid: 237
+    components:
+    - type: Transform
+      pos: -1.5,14.5
+      parent: 1
+  - uid: 238
+    components:
+    - type: Transform
+      pos: -0.5,14.5
+      parent: 1
+  - uid: 239
+    components:
+    - type: Transform
+      pos: 0.5,14.5
+      parent: 1
+  - uid: 240
+    components:
+    - type: Transform
+      pos: 1.5,13.5
+      parent: 1
+  - uid: 241
+    components:
+    - type: Transform
+      pos: 1.5,12.5
+      parent: 1
+  - uid: 242
+    components:
+    - type: Transform
+      pos: 2.5,-0.5
+      parent: 1
+  - uid: 243
+    components:
+    - type: Transform
+      pos: -7.5,7.5
+      parent: 1
+  - uid: 244
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 245
+    components:
+    - type: Transform
+      pos: -0.5,-0.5
+      parent: 1
+  - uid: 246
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 1
+  - uid: 247
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 1
+  - uid: 248
+    components:
+    - type: Transform
+      pos: 2.5,-0.5
+      parent: 1
+  - uid: 249
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-1.5
+      parent: 1
+  - uid: 250
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,14.5
+      parent: 1
+  - uid: 251
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,8.5
+      parent: 1
+- proto: GunSafeLaserCarbine
+  entities:
+  - uid: 257
+    components:
+    - type: Transform
+      anchored: True
+      pos: -4.5,3.5
+      parent: 1
+    - type: Physics
+      bodyType: Static
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+- proto: GunSafeRifleLecter
+  entities:
+  - uid: 159
+    components:
+    - type: Transform
+      pos: -4.5,4.5
+      parent: 1
+- proto: GunSafeShotgunEnforcer
+  entities:
+  - uid: 258
+    components:
+    - type: Transform
+      anchored: True
+      pos: -6.5,4.5
+      parent: 1
+    - type: Physics
+      bodyType: Static
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+- proto: GunSafeSubMachineGunDrozd
+  entities:
+  - uid: 260
+    components:
+    - type: Transform
+      anchored: True
+      pos: -6.5,3.5
+      parent: 1
+    - type: Physics
+      bodyType: Static
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+- proto: Gyroscope
+  entities:
+  - uid: 423
+    components:
+    - type: Transform
+      pos: -4.5,1.5
+      parent: 1
+- proto: HighSecCentralCommandLocked
+  entities:
+  - uid: 429
+    components:
+    - type: Transform
+      pos: -5.5,5.5
+      parent: 1
+- proto: HolopadUnlimitedRange
+  entities:
+  - uid: 106
+    components:
+    - type: MetaData
+      name: quantum entangling holopad (NT-Salus)
+    - type: Transform
+      pos: -2.5,11.5
+      parent: 1
+    - type: Label
+      currentLabel: NT-Salus
+    - type: NameModifier
+      baseName: quantum entangling holopad
+- proto: KitchenMicrowave
+  entities:
+  - uid: 263
+    components:
+    - type: Transform
+      pos: -1.5,13.5
+      parent: 1
+- proto: LockerEvidence
+  entities:
+  - uid: 264
+    components:
+    - type: Transform
+      pos: -4.5,10.5
+      parent: 1
+- proto: MedkitCombatFilled
+  entities:
+  - uid: 288
+    components:
+    - type: Transform
+      pos: -6.5993385,6.403008
+      parent: 1
+- proto: NitrogenTankFilled
+  entities:
+  - uid: 266
+    components:
+    - type: Transform
+      pos: -4.271042,7.9297905
+      parent: 1
+    - type: GasTank
+      toggleActionEntity: 100
+    - type: ActionsContainer
+    - type: ContainerContainer
+      containers:
+        actions: !type:Container
+          ents:
+          - 100
+- proto: NitrousOxideCanister
+  entities:
+  - uid: 268
+    components:
+    - type: Transform
+      anchored: True
+      pos: -5.5,12.5
+      parent: 1
+    - type: Physics
+      bodyType: Static
+- proto: OxygenTankFilled
+  entities:
+  - uid: 117
+    components:
+    - type: Transform
+      pos: -4.583542,7.950624
+      parent: 1
+- proto: PenCentcom
+  entities:
+  - uid: 270
+    components:
+    - type: Transform
+      pos: -0.31487274,11.543377
+      parent: 1
+- proto: PlasmaReinforcedWindowDirectional
+  entities:
+  - uid: 252
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-3.5
+      parent: 1
+- proto: PosterLegitDoNotQuestion
+  entities:
+  - uid: 554
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,6.5
+      parent: 1
+- proto: PosterLegitEnlist
+  entities:
+  - uid: 272
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 1
+- proto: PosterLegitHereForYourSafety
+  entities:
+  - uid: 555
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,3.5
+      parent: 1
+- proto: PosterLegitNanotrasenLogo
+  entities:
+  - uid: 274
+    components:
+    - type: Transform
+      pos: -0.5,-5.5
+      parent: 1
+  - uid: 275
+    components:
+    - type: Transform
+      pos: -4.5,-5.5
+      parent: 1
+  - uid: 276
+    components:
+    - type: Transform
+      pos: 1.5,11.5
+      parent: 1
+- proto: PosterLegitNoERP
+  entities:
+  - uid: 556
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,2.5
+      parent: 1
+  - uid: 557
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,2.5
+      parent: 1
+- proto: PosterLegitThereIsNoGasGiant
+  entities:
+  - uid: 558
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,5.5
+      parent: 1
+- proto: PowerCellRecharger
+  entities:
+  - uid: 281
+    components:
+    - type: Transform
+      pos: -6.5,7.5
+      parent: 1
+- proto: Poweredlight
+  entities:
+  - uid: 254
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,10.5
+      parent: 1
+  - uid: 282
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,4.5
+      parent: 1
+  - uid: 283
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 284
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,3.5
+      parent: 1
+  - uid: 285
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 286
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-0.5
+      parent: 1
+  - uid: 287
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 1
+  - uid: 289
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-4.5
+      parent: 1
+  - uid: 290
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,11.5
+      parent: 1
+  - uid: 291
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,8.5
+      parent: 1
+  - uid: 292
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 293
+    components:
+    - type: Transform
+      pos: 0.5,8.5
+      parent: 1
+  - uid: 294
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,6.5
+      parent: 1
+- proto: RandomHumanoidSpawnerERTLeaderEVALecterTime
+  entities:
+  - uid: 603
+    components:
+    - type: Transform
+      pos: -2.5,12.5
+      parent: 1
+- proto: RandomHumanoidSpawnerERTSecurityEVALecterTime
+  entities:
+  - uid: 589
+    components:
+    - type: Transform
+      pos: -5.5,8.5
+      parent: 1
+  - uid: 609
+    components:
+    - type: Transform
+      pos: -5.5,7.5
+      parent: 1
+  - uid: 610
+    components:
+    - type: Transform
+      pos: -5.5,6.5
+      parent: 1
+- proto: ShotGunCabinetFilled
+  entities:
+  - uid: 93
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,6.5
+      parent: 1
+  - uid: 204
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,8.5
+      parent: 1
+- proto: ShuttleWindow
+  entities:
+  - uid: 298
+    components:
+    - type: Transform
+      pos: -0.5,-0.5
+      parent: 1
+  - uid: 299
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 1
+  - uid: 300
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-1.5
+      parent: 1
+  - uid: 301
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,8.5
+      parent: 1
+  - uid: 302
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 1
+  - uid: 303
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 304
+    components:
+    - type: Transform
+      pos: 2.5,-0.5
+      parent: 1
+  - uid: 305
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 306
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 1
+  - uid: 308
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,7.5
+      parent: 1
+  - uid: 309
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 310
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,7.5
+      parent: 1
+  - uid: 311
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 312
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,13.5
+      parent: 1
+  - uid: 313
+    components:
+    - type: Transform
+      pos: 0.5,13.5
+      parent: 1
+  - uid: 314
+    components:
+    - type: Transform
+      pos: 1.5,13.5
+      parent: 1
+  - uid: 315
+    components:
+    - type: Transform
+      pos: 0.5,14.5
+      parent: 1
+  - uid: 316
+    components:
+    - type: Transform
+      pos: -0.5,14.5
+      parent: 1
+  - uid: 317
+    components:
+    - type: Transform
+      pos: -1.5,14.5
+      parent: 1
+  - uid: 318
+    components:
+    - type: Transform
+      pos: -4.5,14.5
+      parent: 1
+  - uid: 319
+    components:
+    - type: Transform
+      pos: -5.5,14.5
+      parent: 1
+  - uid: 320
+    components:
+    - type: Transform
+      pos: -6.5,13.5
+      parent: 1
+  - uid: 321
+    components:
+    - type: Transform
+      pos: -6.5,12.5
+      parent: 1
+  - uid: 322
+    components:
+    - type: Transform
+      pos: -3.5,14.5
+      parent: 1
+  - uid: 323
+    components:
+    - type: Transform
+      pos: 1.5,12.5
+      parent: 1
+  - uid: 324
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 325
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,8.5
+      parent: 1
+  - uid: 326
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,14.5
+      parent: 1
+- proto: SignalButtonDirectional
+  entities:
+  - uid: 578
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,11.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        327:
+        - Pressed: Toggle
+        433:
+        - Pressed: Toggle
+        452:
+        - Pressed: Toggle
+        498:
+        - Pressed: Toggle
+        500:
+        - Pressed: Toggle
+        499:
+        - Pressed: Toggle
+        561:
+        - Pressed: Toggle
+        564:
+        - Pressed: Toggle
+        563:
+        - Pressed: Toggle
+        562:
+        - Pressed: Toggle
+        565:
+        - Pressed: Toggle
+        566:
+        - Pressed: Toggle
+        567:
+        - Pressed: Toggle
+        568:
+        - Pressed: Toggle
+        577:
+        - Pressed: Toggle
+        576:
+        - Pressed: Toggle
+        575:
+        - Pressed: Toggle
+        574:
+        - Pressed: Toggle
+        573:
+        - Pressed: Toggle
+        572:
+        - Pressed: Toggle
+        571:
+        - Pressed: Toggle
+        570:
+        - Pressed: Toggle
+        569:
+        - Pressed: Toggle
+- proto: SMESAdvanced
+  entities:
+  - uid: 265
+    components:
+    - type: Transform
+      pos: -6.5,-1.5
+      parent: 1
+- proto: SubstationBasic
+  entities:
+  - uid: 328
+    components:
+    - type: Transform
+      pos: -6.5,0.5
+      parent: 1
+- proto: TableReinforced
+  entities:
+  - uid: 329
+    components:
+    - type: Transform
+      pos: -2.5,13.5
+      parent: 1
+  - uid: 330
+    components:
+    - type: Transform
+      pos: -1.5,13.5
+      parent: 1
+  - uid: 331
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,11.5
+      parent: 1
+  - uid: 332
+    components:
+    - type: Transform
+      pos: -6.5,7.5
+      parent: 1
+  - uid: 333
+    components:
+    - type: Transform
+      pos: -3.5,10.5
+      parent: 1
+  - uid: 334
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,11.5
+      parent: 1
+  - uid: 335
+    components:
+    - type: Transform
+      pos: -6.5,6.5
+      parent: 1
+  - uid: 336
+    components:
+    - type: Transform
+      pos: -4.5,8.5
+      parent: 1
+  - uid: 337
+    components:
+    - type: Transform
+      pos: -4.5,7.5
+      parent: 1
+- proto: Thruster
+  entities:
+  - uid: 341
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-5.5
+      parent: 1
+  - uid: 342
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-5.5
+      parent: 1
+  - uid: 343
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-5.5
+      parent: 1
+  - uid: 344
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,11.5
+      parent: 1
+  - uid: 345
+    components:
+    - type: Transform
+      pos: -7.5,12.5
+      parent: 1
+  - uid: 346
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,11.5
+      parent: 1
+  - uid: 347
+    components:
+    - type: Transform
+      pos: 2.5,12.5
+      parent: 1
+  - uid: 348
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,-5.5
+      parent: 1
+  - uid: 349
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,10.5
+      parent: 1
+  - uid: 350
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,10.5
+      parent: 1
+  - uid: 375
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-4.5
+      parent: 1
+  - uid: 376
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-4.5
+      parent: 1
+- proto: VendingMachineSec
+  entities:
+  - uid: 351
+    components:
+    - type: Transform
+      pos: -6.5,8.5
+      parent: 1
+- proto: VendingMachineSustenance
+  entities:
+  - uid: 352
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 1
+- proto: VendingMachineTankDispenserEVA
+  entities:
+  - uid: 13
+    components:
+    - type: Transform
+      pos: -4.5,-0.5
+      parent: 1
+- proto: WallShuttle
+  entities:
+  - uid: 231
+    components:
+    - type: Transform
+      pos: 1.5,-3.5
+      parent: 1
+  - uid: 307
+    components:
+    - type: Transform
+      pos: 2.5,-3.5
+      parent: 1
+  - uid: 353
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,5.5
+      parent: 1
+  - uid: 354
+    components:
+    - type: Transform
+      pos: -3.5,7.5
+      parent: 1
+  - uid: 355
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 356
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 357
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,9.5
+      parent: 1
+  - uid: 358
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,4.5
+      parent: 1
+  - uid: 359
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,3.5
+      parent: 1
+  - uid: 360
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,5.5
+      parent: 1
+  - uid: 361
+    components:
+    - type: Transform
+      pos: -4.5,9.5
+      parent: 1
+  - uid: 362
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,6.5
+      parent: 1
+  - uid: 363
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,3.5
+      parent: 1
+  - uid: 364
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 365
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,9.5
+      parent: 1
+  - uid: 366
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,5.5
+      parent: 1
+  - uid: 367
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 368
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,0.5
+      parent: 1
+  - uid: 369
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,9.5
+      parent: 1
+  - uid: 370
+    components:
+    - type: Transform
+      pos: -7.5,6.5
+      parent: 1
+  - uid: 371
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,8.5
+      parent: 1
+  - uid: 372
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,6.5
+      parent: 1
+  - uid: 373
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,6.5
+      parent: 1
+  - uid: 374
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,6.5
+      parent: 1
+  - uid: 377
+    components:
+    - type: Transform
+      pos: 2.5,9.5
+      parent: 1
+  - uid: 378
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-1.5
+      parent: 1
+  - uid: 379
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,6.5
+      parent: 1
+  - uid: 380
+    components:
+    - type: Transform
+      pos: -5.5,-4.5
+      parent: 1
+  - uid: 381
+    components:
+    - type: Transform
+      pos: 1.5,9.5
+      parent: 1
+  - uid: 382
+    components:
+    - type: Transform
+      pos: -6.5,9.5
+      parent: 1
+  - uid: 383
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,2.5
+      parent: 1
+  - uid: 384
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 385
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,2.5
+      parent: 1
+  - uid: 386
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,2.5
+      parent: 1
+  - uid: 387
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-1.5
+      parent: 1
+  - uid: 388
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,-0.5
+      parent: 1
+  - uid: 389
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,-1.5
+      parent: 1
+  - uid: 390
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,3.5
+      parent: 1
+  - uid: 391
+    components:
+    - type: Transform
+      pos: -6.5,-4.5
+      parent: 1
+  - uid: 392
+    components:
+    - type: Transform
+      pos: 1.5,-4.5
+      parent: 1
+  - uid: 393
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,5.5
+      parent: 1
+  - uid: 394
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,-2.5
+      parent: 1
+  - uid: 395
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,2.5
+      parent: 1
+  - uid: 396
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,2.5
+      parent: 1
+  - uid: 397
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-4.5
+      parent: 1
+  - uid: 398
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-4.5
+      parent: 1
+  - uid: 399
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 400
+    components:
+    - type: Transform
+      pos: -7.5,-3.5
+      parent: 1
+  - uid: 401
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-3.5
+      parent: 1
+  - uid: 402
+    components:
+    - type: Transform
+      pos: -7.5,0.5
+      parent: 1
+  - uid: 403
+    components:
+    - type: Transform
+      pos: -7.5,4.5
+      parent: 1
+  - uid: 404
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-2.5
+      parent: 1
+  - uid: 405
+    components:
+    - type: Transform
+      pos: -7.5,8.5
+      parent: 1
+  - uid: 406
+    components:
+    - type: Transform
+      pos: -7.5,9.5
+      parent: 1
+  - uid: 407
+    components:
+    - type: Transform
+      pos: -6.5,10.5
+      parent: 1
+  - uid: 408
+    components:
+    - type: Transform
+      pos: -6.5,11.5
+      parent: 1
+  - uid: 409
+    components:
+    - type: Transform
+      pos: 1.5,11.5
+      parent: 1
+  - uid: 410
+    components:
+    - type: Transform
+      pos: 1.5,10.5
+      parent: 1
+  - uid: 411
+    components:
+    - type: Transform
+      pos: -4.5,-5.5
+      parent: 1
+  - uid: 412
+    components:
+    - type: Transform
+      pos: -0.5,-5.5
+      parent: 1
+  - uid: 413
+    components:
+    - type: Transform
+      pos: -2.5,-5.5
+      parent: 1
+  - uid: 414
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 1
+  - uid: 415
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-0.5
+      parent: 1
+  - uid: 416
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,1.5
+      parent: 1
+  - uid: 417
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,1.5
+      parent: 1
+  - uid: 479
+    components:
+    - type: Transform
+      pos: -6.5,-3.5
+      parent: 1
+- proto: WallWeaponCapacitorRecharger
+  entities:
+  - uid: 419
+    components:
+    - type: Transform
+      pos: -4.5,9.5
+      parent: 1
+- proto: WardrobePrisonFilled
+  entities:
+  - uid: 422
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 424
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 1
+  - uid: 425
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 426
+    components:
+    - type: Transform
+      pos: 0.5,8.5
+      parent: 1
+- proto: WaterCooler
+  entities:
+  - uid: 427
+    components:
+    - type: Transform
+      pos: -0.5,13.5
+      parent: 1
+- proto: WeaponCapacitorRecharger
+  entities:
+  - uid: 253
+    components:
+    - type: Transform
+      pos: -4.5,7.5
+      parent: 1
+  - uid: 269
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,10.5
+      parent: 1
+- proto: WindoorSecureCentralCommandLocked
+  entities:
+  - uid: 7
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-2.5
+      parent: 1
+  - uid: 8
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,4.5
+      parent: 1
+  - uid: 9
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,7.5
+      parent: 1
+  - uid: 262
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,1.5
+      parent: 1
+  - uid: 428
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-1.5
+      parent: 1
+- proto: WindoorSecureSecurityLocked
+  entities:
+  - uid: 434
+    components:
+    - type: Transform
+      pos: -3.5,-4.5
+      parent: 1
+  - uid: 435
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 1
+...

--- a/Resources/Maps/_Harmony/Shuttles/ShuttleEvent/ERTSecSmall.yml
+++ b/Resources/Maps/_Harmony/Shuttles/ShuttleEvent/ERTSecSmall.yml
@@ -1,0 +1,1892 @@
+meta:
+  format: 6
+  postmapinit: false
+tilemap:
+  1: Space
+  9: FloorDarkMono
+  7: FloorShuttleWhite
+  3: FloorSteel
+  6: FloorSteelMini
+  8: FloorSteelMono
+  10: FloorTechMaint
+  5: FloorWood
+  4: Lattice
+  2: Plating
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: NT-Penance
+    - type: Transform
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        -1,0:
+          ind: -1,0
+          tiles: AQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAABQAAAAACBQAAAAAABQAAAAAAAwAAAAAAAwAAAAABAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAABQAAAAABBQAAAAABBQAAAAABAwAAAAABAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAACAgAAAAAAAgAAAAAABQAAAAACAwAAAAACAwAAAAADAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAABgAAAAACBgAAAAABAgAAAAAAAwAAAAACAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAABBgAAAAAABgAAAAACCAAAAAABAwAAAAACAwAAAAABAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAABgAAAAAABgAAAAAAAgAAAAAAAwAAAAADAwAAAAACAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAADBgAAAAAAAwAAAAACAwAAAAABAwAAAAABAwAAAAADAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAAAwAAAAAABwAAAAACCQAAAAACCQAAAAAAAwAAAAADAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAABAAAAAAAAgAAAAAACQAAAAACAgAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAAAgAAAAAAAgAAAAAAAgAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAA
+          version: 6
+        0,0:
+          ind: 0,0
+          tiles: AwAAAAADAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAADAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAACAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAADAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAACAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAACAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAACAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAA
+          version: 6
+        -1,-1:
+          ind: -1,-1
+          tiles: AQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAABAAAAAAAAgAAAAAABAAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAAAgAAAAAACgAAAAAABAAAAAAACgAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAgAAAAAACgAAAAAAAgAAAAAACgAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAACgAAAAAACgAAAAAAAgAAAAAACgAAAAAACgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAABQAAAAADBQAAAAACBQAAAAABAwAAAAADAwAAAAAC
+          version: 6
+        0,-1:
+          ind: 0,-1
+          tiles: AQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAA
+          version: 6
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: CargoShuttle
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            color: '#DE3A3A96'
+            id: BrickTileWhiteCornerNe
+          decals:
+            11: -1,6
+        - node:
+            color: '#DE3A3A96'
+            id: BrickTileWhiteCornerNw
+          decals:
+            10: -2,6
+        - node:
+            color: '#DE3A3A96'
+            id: BrickTileWhiteCornerSe
+          decals:
+            9: -1,-1
+        - node:
+            color: '#334E6DC8'
+            id: BrickTileWhiteCornerSw
+          decals:
+            14: -3,7
+        - node:
+            color: '#DE3A3A96'
+            id: BrickTileWhiteCornerSw
+          decals:
+            26: -2,-1
+        - node:
+            color: '#334E6DC8'
+            id: BrickTileWhiteEndE
+          decals:
+            13: -2,7
+        - node:
+            color: '#334E6DC8'
+            id: BrickTileWhiteEndN
+          decals:
+            12: -3,8
+        - node:
+            color: '#334E6DC8'
+            id: BrickTileWhiteInnerNe
+          decals:
+            15: -3,7
+        - node:
+            color: '#DE3A3A96'
+            id: BrickTileWhiteLineE
+          decals:
+            3: -1,5
+            4: -1,4
+            5: -1,3
+            6: -1,2
+            7: -1,1
+            8: -1,0
+            38: -3,4
+        - node:
+            color: '#DE3A3A96'
+            id: BrickTileWhiteLineW
+          decals:
+            0: -2,3
+            1: -2,4
+            2: -2,5
+            23: -2,2
+            24: -2,1
+            25: -2,0
+        - node:
+            color: '#79150096'
+            id: MiniTileWhiteBox
+          decals:
+            16: -5,6
+        - node:
+            color: '#79150096'
+            id: MiniTileWhiteCornerNe
+          decals:
+            17: -4,5
+        - node:
+            color: '#79150096'
+            id: MiniTileWhiteCornerNw
+          decals:
+            18: -5,5
+        - node:
+            color: '#79150096'
+            id: MiniTileWhiteCornerSe
+          decals:
+            19: -4,3
+        - node:
+            color: '#79150096'
+            id: MiniTileWhiteCornerSw
+          decals:
+            20: -5,3
+        - node:
+            color: '#79150096'
+            id: MiniTileWhiteLineE
+          decals:
+            21: -4,4
+        - node:
+            color: '#79150096'
+            id: MiniTileWhiteLineW
+          decals:
+            22: -5,4
+        - node:
+            angle: 1.5707963267948966 rad
+            color: '#9A0000FF'
+            id: StandClear
+          decals:
+            37: -3,4
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinCornerNw
+          decals:
+            33: -5,1
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinCornerSe
+          decals:
+            30: -3,-1
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinCornerSw
+          decals:
+            35: -5,-1
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinLineE
+          decals:
+            27: -3,2
+            28: -3,1
+            29: -3,0
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinLineN
+          decals:
+            36: -4,1
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinLineS
+          decals:
+            31: -4,-1
+            32: -5,-1
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinLineW
+          decals:
+            34: -5,0
+    - type: GridAtmosphere
+      version: 2
+      data:
+        tiles:
+          -2,0:
+            0: 32904
+          -2,1:
+            0: 2184
+            1: 16384
+          -2,2:
+            1: 140
+          -2,-1:
+            0: 34816
+            1: 4
+          -1,0:
+            0: 57087
+          -1,1:
+            0: 27871
+          -1,-1:
+            0: 65392
+            1: 2
+          -1,2:
+            0: 2
+            1: 136
+          0,0:
+            0: 4112
+          0,1:
+            1: 4096
+          0,2:
+            1: 1
+          -2,-2:
+            1: 32768
+          -1,-2:
+            1: 53248
+          0,-1:
+            1: 1
+        uniqueMixes:
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          immutable: True
+          moles:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        chunkSize: 4
+    - type: OccluderTree
+    - type: Shuttle
+    - type: GridPathfinding
+    - type: RadiationGridResistance
+    - type: SpreaderGrid
+    - type: GravityShake
+      shakeTimes: 10
+    - type: GasTileOverlay
+- proto: AirAlarm
+  entities:
+  - uid: 103
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,6.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 224
+      - 105
+      - 236
+- proto: AirCanister
+  entities:
+  - uid: 106
+    components:
+    - type: Transform
+      anchored: True
+      pos: -0.5,-1.5
+      parent: 1
+    - type: Physics
+      bodyType: Static
+- proto: AirlockGlassShuttle
+  entities:
+  - uid: 3
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 4
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,3.5
+      parent: 1
+- proto: AirSensor
+  entities:
+  - uid: 236
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,4.5
+      parent: 1
+- proto: APCHyperCapacity
+  entities:
+  - uid: 6
+    components:
+    - type: Transform
+      pos: -0.5,7.5
+      parent: 1
+- proto: AtmosDeviceFanTiny
+  entities:
+  - uid: 7
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 8
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+- proto: Bed
+  entities:
+  - uid: 9
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 1
+  - uid: 10
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 1
+- proto: BedsheetOrange
+  entities:
+  - uid: 11
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 1
+  - uid: 12
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,3.5
+      parent: 1
+- proto: BoxHandcuff
+  entities:
+  - uid: 13
+    components:
+    - type: Transform
+      pos: -0.6099169,5.7288613
+      parent: 1
+- proto: BoxZiptie
+  entities:
+  - uid: 14
+    components:
+    - type: Transform
+      pos: -0.36498022,5.419317
+      parent: 1
+- proto: CableApcExtension
+  entities:
+  - uid: 15
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 1
+  - uid: 16
+    components:
+    - type: Transform
+      pos: -2.5,7.5
+      parent: 1
+  - uid: 17
+    components:
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 1
+  - uid: 18
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 1
+  - uid: 19
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 1
+  - uid: 20
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 1
+  - uid: 21
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 1
+  - uid: 22
+    components:
+    - type: Transform
+      pos: -0.5,7.5
+      parent: 1
+  - uid: 23
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 1
+  - uid: 24
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 1
+  - uid: 25
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 26
+    components:
+    - type: Transform
+      pos: -0.5,1.5
+      parent: 1
+  - uid: 27
+    components:
+    - type: Transform
+      pos: -3.5,1.5
+      parent: 1
+  - uid: 28
+    components:
+    - type: Transform
+      pos: -4.5,1.5
+      parent: 1
+  - uid: 29
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 1
+  - uid: 30
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 31
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 1
+  - uid: 32
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 1
+  - uid: 33
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 34
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 1
+  - uid: 35
+    components:
+    - type: Transform
+      pos: -2.5,8.5
+      parent: 1
+  - uid: 36
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 1
+  - uid: 37
+    components:
+    - type: Transform
+      pos: -4.5,-3.5
+      parent: 1
+  - uid: 38
+    components:
+    - type: Transform
+      pos: -3.5,8.5
+      parent: 1
+  - uid: 39
+    components:
+    - type: Transform
+      pos: -4.5,8.5
+      parent: 1
+  - uid: 40
+    components:
+    - type: Transform
+      pos: -3.5,-3.5
+      parent: 1
+  - uid: 41
+    components:
+    - type: Transform
+      pos: -0.5,8.5
+      parent: 1
+  - uid: 42
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 1
+  - uid: 43
+    components:
+    - type: Transform
+      pos: -3.5,-1.5
+      parent: 1
+  - uid: 44
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 1
+  - uid: 184
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 1
+- proto: CableHV
+  entities:
+  - uid: 46
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 1
+  - uid: 78
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 1
+  - uid: 107
+    components:
+    - type: Transform
+      pos: -3.5,-1.5
+      parent: 1
+  - uid: 145
+    components:
+    - type: Transform
+      pos: -4.5,-1.5
+      parent: 1
+- proto: CableMV
+  entities:
+  - uid: 48
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 1
+  - uid: 50
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 1
+  - uid: 51
+    components:
+    - type: Transform
+      pos: -2.5,7.5
+      parent: 1
+  - uid: 52
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 1
+  - uid: 54
+    components:
+    - type: Transform
+      pos: -3.5,1.5
+      parent: 1
+  - uid: 55
+    components:
+    - type: Transform
+      pos: -2.5,3.5
+      parent: 1
+  - uid: 56
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 57
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 1
+  - uid: 58
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 1
+  - uid: 59
+    components:
+    - type: Transform
+      pos: -0.5,7.5
+      parent: 1
+  - uid: 60
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 1
+  - uid: 61
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 62
+    components:
+    - type: Transform
+      pos: -3.5,2.5
+      parent: 1
+  - uid: 63
+    components:
+    - type: Transform
+      pos: -4.5,2.5
+      parent: 1
+  - uid: 64
+    components:
+    - type: Transform
+      pos: -5.5,2.5
+      parent: 1
+  - uid: 65
+    components:
+    - type: Transform
+      pos: -5.5,3.5
+      parent: 1
+  - uid: 66
+    components:
+    - type: Transform
+      pos: -5.5,4.5
+      parent: 1
+  - uid: 67
+    components:
+    - type: Transform
+      pos: -5.5,5.5
+      parent: 1
+  - uid: 68
+    components:
+    - type: Transform
+      pos: -5.5,1.5
+      parent: 1
+  - uid: 69
+    components:
+    - type: Transform
+      pos: -5.5,0.5
+      parent: 1
+  - uid: 70
+    components:
+    - type: Transform
+      pos: -5.5,-0.5
+      parent: 1
+  - uid: 71
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 1
+  - uid: 72
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 1
+  - uid: 98
+    components:
+    - type: Transform
+      pos: -3.5,-1.5
+      parent: 1
+  - uid: 122
+    components:
+    - type: Transform
+      pos: -4.5,-1.5
+      parent: 1
+  - uid: 200
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 1
+  - uid: 229
+    components:
+    - type: Transform
+      pos: -1.5,9.5
+      parent: 1
+  - uid: 230
+    components:
+    - type: Transform
+      pos: -2.5,9.5
+      parent: 1
+  - uid: 231
+    components:
+    - type: Transform
+      pos: -3.5,9.5
+      parent: 1
+  - uid: 232
+    components:
+    - type: Transform
+      pos: -3.5,8.5
+      parent: 1
+  - uid: 244
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 1
+  - uid: 245
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 1
+- proto: CableTerminal
+  entities:
+  - uid: 49
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-2.5
+      parent: 1
+- proto: Catwalk
+  entities:
+  - uid: 144
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 1
+  - uid: 248
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 1
+  - uid: 249
+    components:
+    - type: Transform
+      pos: -5.5,-3.5
+      parent: 1
+  - uid: 250
+    components:
+    - type: Transform
+      pos: -4.5,-4.5
+      parent: 1
+  - uid: 251
+    components:
+    - type: Transform
+      pos: -0.5,-4.5
+      parent: 1
+  - uid: 252
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+  - uid: 253
+    components:
+    - type: Transform
+      pos: -5.5,8.5
+      parent: 1
+  - uid: 254
+    components:
+    - type: Transform
+      pos: -4.5,9.5
+      parent: 1
+  - uid: 255
+    components:
+    - type: Transform
+      pos: -0.5,9.5
+      parent: 1
+  - uid: 256
+    components:
+    - type: Transform
+      pos: 0.5,8.5
+      parent: 1
+- proto: ChairPilotSeat
+  entities:
+  - uid: 73
+    components:
+    - type: Transform
+      pos: -3.5,1.5
+      parent: 1
+  - uid: 74
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-0.5
+      parent: 1
+  - uid: 75
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-0.5
+      parent: 1
+  - uid: 76
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,7.5
+      parent: 1
+  - uid: 77
+    components:
+    - type: Transform
+      pos: -4.5,1.5
+      parent: 1
+- proto: CheckerBoard
+  entities:
+  - uid: 234
+    components:
+    - type: Transform
+      pos: -3.5398066,0.55463433
+      parent: 1
+- proto: ChessBoard
+  entities:
+  - uid: 233
+    components:
+    - type: Transform
+      pos: -4.4785376,6.5732794
+      parent: 1
+- proto: ClosetWallOrange
+  entities:
+  - uid: 87
+    components:
+    - type: Transform
+      pos: -3.5,6.5
+      parent: 1
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+        - 1.8856695
+        - 7.0937095
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 239
+          - 196
+          - 238
+          - 237
+          - 197
+          - 228
+          - 198
+- proto: ClothingShoesColorOrange
+  entities:
+  - uid: 196
+    components:
+    - type: Transform
+      parent: 87
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 237
+    components:
+    - type: Transform
+      parent: 87
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: ClothingUniformJumpskirtPrisoner
+  entities:
+  - uid: 197
+    components:
+    - type: Transform
+      parent: 87
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 198
+    components:
+    - type: Transform
+      parent: 87
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 238
+    components:
+    - type: Transform
+      parent: 87
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: ClothingUniformJumpsuitPrisoner
+  entities:
+  - uid: 228
+    components:
+    - type: Transform
+      parent: 87
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 239
+    components:
+    - type: Transform
+      parent: 87
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: ComputerShuttle
+  entities:
+  - uid: 79
+    components:
+    - type: Transform
+      pos: -2.5,8.5
+      parent: 1
+- proto: DrinkWaterCup
+  entities:
+  - uid: 80
+    components:
+    - type: Transform
+      pos: -1.5754411,-0.5304184
+      parent: 1
+  - uid: 81
+    components:
+    - type: Transform
+      pos: -1.7284467,-0.28190517
+      parent: 1
+- proto: FoodBoxDonut
+  entities:
+  - uid: 82
+    components:
+    - type: Transform
+      pos: -4.593342,0.7761526
+      parent: 1
+  - uid: 83
+    components:
+    - type: Transform
+      pos: -4.399971,0.55689216
+      parent: 1
+- proto: FoodSnackMREBrownie
+  entities:
+  - uid: 84
+    components:
+    - type: Transform
+      pos: -1.3459318,-0.26278877
+      parent: 1
+- proto: FoodSnackNutribrick
+  entities:
+  - uid: 85
+    components:
+    - type: Transform
+      pos: -1.5563142,-0.7406988
+      parent: 1
+  - uid: 86
+    components:
+    - type: Transform
+      pos: -1.3076818,-0.5495348
+      parent: 1
+- proto: GasPassiveVent
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF22FFFF'
+  - uid: 53
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeBend
+  entities:
+  - uid: 88
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#CC5555FF'
+  - uid: 92
+    components:
+    - type: Transform
+      pos: -0.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 226
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeStraight
+  entities:
+  - uid: 91
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF22FFFF'
+  - uid: 93
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 94
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 95
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 96
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 97
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF22FFFF'
+  - uid: 101
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 208
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 209
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 210
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 211
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 214
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 215
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 216
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 217
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 218
+    components:
+    - type: Transform
+      pos: -2.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 221
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 222
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 227
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeTJunction
+  entities:
+  - uid: 89
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 205
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 212
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 213
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 223
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPort
+  entities:
+  - uid: 99
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#CC5555FF'
+  - uid: 100
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPressurePump
+  entities:
+  - uid: 102
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,5.5
+      parent: 1
+    - type: GasPressurePump
+      targetPressure: 115.325
+    - type: AtmosPipeColor
+      color: '#FF22FFFF'
+- proto: GasVentPump
+  entities:
+  - uid: 45
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 104
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 105
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 220
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasVentScrubber
+  entities:
+  - uid: 219
+    components:
+    - type: Transform
+      pos: -2.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 224
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 225
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GeneratorBasic15kW
+  entities:
+  - uid: 47
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 1
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 206
+    components:
+    - type: Transform
+      pos: -3.5,-1.5
+      parent: 1
+- proto: Grille
+  entities:
+  - uid: 108
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,5.5
+      parent: 1
+  - uid: 109
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,3.5
+      parent: 1
+  - uid: 110
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,9.5
+      parent: 1
+  - uid: 111
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,9.5
+      parent: 1
+  - uid: 112
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,2.5
+      parent: 1
+  - uid: 113
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,9.5
+      parent: 1
+  - uid: 114
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,3.5
+      parent: 1
+  - uid: 115
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,8.5
+      parent: 1
+  - uid: 116
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,2.5
+      parent: 1
+  - uid: 117
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,0.5
+      parent: 1
+  - uid: 118
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,5.5
+      parent: 1
+  - uid: 119
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,8.5
+      parent: 1
+  - uid: 120
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-0.5
+      parent: 1
+  - uid: 121
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,1.5
+      parent: 1
+- proto: Gyroscope
+  entities:
+  - uid: 160
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 1
+- proto: NitrousOxideCanister
+  entities:
+  - uid: 123
+    components:
+    - type: Transform
+      anchored: True
+      pos: -0.5,6.5
+      parent: 1
+    - type: Physics
+      bodyType: Static
+- proto: PlasmaReinforcedWindowDirectional
+  entities:
+  - uid: 246
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-3.5
+      parent: 1
+- proto: PottedPlant28
+  entities:
+  - uid: 124
+    components:
+    - type: Transform
+      pos: -2.2257135,2.0694113
+      parent: 1
+- proto: Poweredlight
+  entities:
+  - uid: 125
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,2.5
+      parent: 1
+    - type: ApcPowerReceiver
+      powerLoad: 0
+  - uid: 126
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,7.5
+      parent: 1
+    - type: ApcPowerReceiver
+      powerLoad: 0
+  - uid: 127
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,4.5
+      parent: 1
+  - uid: 128
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,7.5
+      parent: 1
+  - uid: 129
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-3.5
+      parent: 1
+- proto: RandomHumanoidSpawnerERTSecurityEVALecterTime
+  entities:
+  - uid: 207
+    components:
+    - type: Transform
+      pos: -2.5,7.5
+      parent: 1
+  - uid: 258
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+- proto: ShuttleWindow
+  entities:
+  - uid: 130
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,0.5
+      parent: 1
+  - uid: 131
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,1.5
+      parent: 1
+  - uid: 132
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,3.5
+      parent: 1
+  - uid: 133
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,5.5
+      parent: 1
+  - uid: 134
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,2.5
+      parent: 1
+  - uid: 135
+    components:
+    - type: Transform
+      pos: -3.5,8.5
+      parent: 1
+  - uid: 136
+    components:
+    - type: Transform
+      pos: -3.5,9.5
+      parent: 1
+  - uid: 137
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,3.5
+      parent: 1
+  - uid: 138
+    components:
+    - type: Transform
+      pos: -2.5,9.5
+      parent: 1
+  - uid: 139
+    components:
+    - type: Transform
+      pos: -1.5,9.5
+      parent: 1
+  - uid: 140
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 1
+  - uid: 141
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,2.5
+      parent: 1
+  - uid: 142
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,5.5
+      parent: 1
+  - uid: 143
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-0.5
+      parent: 1
+- proto: SMESAdvanced
+  entities:
+  - uid: 183
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 1
+- proto: SpeedLoaderMagnum
+  entities:
+  - uid: 195
+    components:
+    - type: Transform
+      pos: -0.46974462,4.838149
+      parent: 1
+- proto: SubstationBasic
+  entities:
+  - uid: 185
+    components:
+    - type: Transform
+      pos: -4.5,-1.5
+      parent: 1
+- proto: TableReinforced
+  entities:
+  - uid: 146
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-0.5
+      parent: 1
+  - uid: 147
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 148
+    components:
+    - type: Transform
+      pos: -4.5,6.5
+      parent: 1
+  - uid: 149
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 1
+  - uid: 150
+    components:
+    - type: Transform
+      pos: -4.5,0.5
+      parent: 1
+  - uid: 151
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 1
+- proto: Thruster
+  entities:
+  - uid: 152
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,8.5
+      parent: 1
+  - uid: 153
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-4.5
+      parent: 1
+  - uid: 154
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-4.5
+      parent: 1
+  - uid: 155
+    components:
+    - type: Transform
+      pos: -0.5,9.5
+      parent: 1
+  - uid: 156
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,8.5
+      parent: 1
+  - uid: 157
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-3.5
+      parent: 1
+  - uid: 158
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-3.5
+      parent: 1
+  - uid: 159
+    components:
+    - type: Transform
+      pos: -4.5,9.5
+      parent: 1
+- proto: VendingMachineSec
+  entities:
+  - uid: 90
+    components:
+    - type: Transform
+      pos: -0.5,-0.5
+      parent: 1
+- proto: WallShuttle
+  entities:
+  - uid: 161
+    components:
+    - type: Transform
+      pos: -5.5,4.5
+      parent: 1
+  - uid: 162
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 163
+    components:
+    - type: Transform
+      pos: -2.5,6.5
+      parent: 1
+  - uid: 164
+    components:
+    - type: Transform
+      pos: -4.5,7.5
+      parent: 1
+  - uid: 165
+    components:
+    - type: Transform
+      pos: -4.5,8.5
+      parent: 1
+  - uid: 166
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 167
+    components:
+    - type: Transform
+      pos: -3.5,7.5
+      parent: 1
+  - uid: 168
+    components:
+    - type: Transform
+      pos: -5.5,7.5
+      parent: 1
+  - uid: 169
+    components:
+    - type: Transform
+      pos: -0.5,7.5
+      parent: 1
+  - uid: 170
+    components:
+    - type: Transform
+      pos: -3.5,6.5
+      parent: 1
+  - uid: 171
+    components:
+    - type: Transform
+      pos: -0.5,8.5
+      parent: 1
+  - uid: 172
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 1
+  - uid: 173
+    components:
+    - type: Transform
+      pos: -5.5,-1.5
+      parent: 1
+  - uid: 174
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 1
+  - uid: 175
+    components:
+    - type: Transform
+      pos: 0.5,7.5
+      parent: 1
+  - uid: 176
+    components:
+    - type: Transform
+      pos: -5.5,6.5
+      parent: 1
+  - uid: 177
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 178
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 1
+  - uid: 179
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 180
+    components:
+    - type: Transform
+      pos: -2.5,-4.5
+      parent: 1
+  - uid: 181
+    components:
+    - type: Transform
+      pos: -5.5,2.5
+      parent: 1
+  - uid: 186
+    components:
+    - type: Transform
+      pos: -3.5,-4.5
+      parent: 1
+  - uid: 187
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 1
+  - uid: 188
+    components:
+    - type: Transform
+      pos: -0.5,-2.5
+      parent: 1
+  - uid: 189
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 1
+  - uid: 190
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 1
+  - uid: 191
+    components:
+    - type: Transform
+      pos: -3.5,-3.5
+      parent: 1
+  - uid: 192
+    components:
+    - type: Transform
+      pos: -4.5,-2.5
+      parent: 1
+  - uid: 193
+    components:
+    - type: Transform
+      pos: -5.5,-2.5
+      parent: 1
+  - uid: 194
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 1
+  - uid: 247
+    components:
+    - type: Transform
+      pos: -4.5,-3.5
+      parent: 1
+- proto: WallShuttleDiagonal
+  entities:
+  - uid: 182
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,2.5
+      parent: 1
+- proto: WaterCooler
+  entities:
+  - uid: 257
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 1
+- proto: WeaponRevolverDeckard
+  entities:
+  - uid: 199
+    components:
+    - type: Transform
+      pos: -0.49057794,4.5673156
+      parent: 1
+- proto: WindoorSecureCentralCommandLocked
+  entities:
+  - uid: 5
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,4.5
+      parent: 1
+  - uid: 240
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,1.5
+      parent: 1
+  - uid: 241
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 1
+  - uid: 242
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,6.5
+      parent: 1
+  - uid: 243
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,3.5
+      parent: 1
+- proto: WindowReinforcedDirectional
+  entities:
+  - uid: 201
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 1
+  - uid: 202
+    components:
+    - type: Transform
+      pos: -4.5,-0.5
+      parent: 1
+  - uid: 203
+    components:
+    - type: Transform
+      pos: -3.5,-0.5
+      parent: 1
+  - uid: 204
+    components:
+    - type: Transform
+      pos: -0.5,-0.5
+      parent: 1
+- proto: Wrench
+  entities:
+  - uid: 235
+    components:
+    - type: Transform
+      pos: -1.4053601,-1.4865723
+      parent: 1
+...

--- a/Resources/Prototypes/_Harmony/GameRules/ert_shuttles.yml
+++ b/Resources/Prototypes/_Harmony/GameRules/ert_shuttles.yml
@@ -1,0 +1,91 @@
+# Harmony ERT Shuttles
+
+# General
+
+- type: entity
+  id: ERTMedSecLarge
+  parent: BaseUnknownShuttleRule
+  components:
+  - type: StationEvent
+    startAnnouncement: station-event-ert-generic-shuttle-incoming #!!
+    weight: 0 #  Admin only.
+  - type: LoadMapRule
+    preloadedGrid: ShuttleERTMedSecLarge
+
+# Security
+
+- type: entity
+  id: ERTSecMedium
+  parent: BaseUnknownShuttleRule
+  components:
+  - type: StationEvent
+    startAnnouncement: station-event-ert-sec-shuttle-incoming #!!
+    weight: 0 #  Admin only.
+  - type: LoadMapRule
+    preloadedGrid: ShuttleERTSecMedium
+
+- type: entity
+  id: ERTSecSmall
+  parent: BaseUnknownShuttleRule
+  components:
+  - type: StationEvent
+    startAnnouncement: station-event-ert-sec-shuttle-incoming #!!
+    weight: 0 #  Admin only.
+  - type: LoadMapRule
+    preloadedGrid: ShuttleERTSecSmall
+
+# Medical
+
+- type: entity
+  id: ERTMedMedium
+  parent: BaseUnknownShuttleRule
+  components:
+  - type: StationEvent
+    startAnnouncement: station-event-ert-sec-shuttle-incoming #!!
+    weight: 0 #  Admin only.
+  - type: LoadMapRule
+    preloadedGrid: ShuttleERTMedMedium
+
+- type: entity
+  id: ERTMedSmall
+  parent: BaseUnknownShuttleRule
+  components:
+  - type: StationEvent
+    startAnnouncement: station-event-ert-med-shuttle-incoming #!!
+    weight: 0 #  Admin only.
+  - type: LoadMapRule
+    preloadedGrid: ShuttleERTMedSmall
+
+# Engineering
+
+- type: entity
+  id: ERTEngiJaniMedium
+  parent: BaseUnknownShuttleRule
+  components:
+  - type: StationEvent
+    startAnnouncement: station-event-ert-engi-shuttle-incoming #!!
+    weight: 0 #  Admin only.
+  - type: LoadMapRule
+    preloadedGrid: ShuttleERTEngiJaniMedium
+
+- type: entity
+  id: ERTEngiSmall
+  parent: BaseUnknownShuttleRule
+  components:
+  - type: StationEvent
+    startAnnouncement: station-event-ert-engi-shuttle-incoming #!!
+    weight: 0 #  Admin only.
+  - type: LoadMapRule
+    preloadedGrid: ShuttleERTEngiSmall
+
+# Janitorial
+
+- type: entity
+  id: ERTJaniSmall
+  parent: BaseUnknownShuttleRule
+  components:
+  - type: StationEvent
+    startAnnouncement: null # Just a janitor.
+    weight: 0 #  Admin only.
+  - type: LoadMapRule
+    preloadedGrid: ShuttleERTJaniSmall

--- a/Resources/Prototypes/_Harmony/GameRules/unknown_shuttles.yml
+++ b/Resources/Prototypes/_Harmony/GameRules/unknown_shuttles.yml
@@ -1,3 +1,5 @@
+# Harmony Friendly Shuttles
+
 - type: entity
   id: UnknownShuttleChemLab
   parent: BaseUnknownShuttleRule
@@ -6,6 +8,8 @@
     startAnnouncement: station-event-unknown-shuttle-incoming #!!
   - type: LoadMapRule
     preloadedGrid: ShuttleChemLab
+
+# Harmony Hostile Shuttles
 
 - type: entity
   id: UnknownShuttleSyndicateReinforcement

--- a/Resources/Prototypes/_Harmony/Shuttles/shuttle_incoming_event.yml
+++ b/Resources/Prototypes/_Harmony/Shuttles/shuttle_incoming_event.yml
@@ -1,9 +1,55 @@
+# Harmony Friendly Shuttles+
+
 - type: preloadedGrid
   id: ShuttleChemLab
   path: /Maps/_Harmony/Shuttles/ShuttleEvent/chemlab.yml
   copies: 1
 
+# Harmony Hostile Shuttles
+
 - type: preloadedGrid
   id: ShuttleSyndicateReinforcement
   path: /Maps/_Harmony/Shuttles/ShuttleEvent/syndicatereinforcement.yml
+  copies: 1
+
+# Harmony ERT Shuttles
+
+- type: preloadedGrid
+  id: ShuttleERTMedSecLarge
+  path: /Maps/_Harmony/Shuttles/ShuttleEvent/ERTMedSecLarge.yml
+  copies: 1
+
+- type: preloadedGrid
+  id: ShuttleERTSecMedium
+  path: /Maps/_Harmony/Shuttles/ShuttleEvent/ERTSecMedium.yml
+  copies: 1
+
+- type: preloadedGrid
+  id: ShuttleERTSecSmall
+  path: /Maps/_Harmony/Shuttles/ShuttleEvent/ERTSecSmall.yml
+  copies: 1
+
+- type: preloadedGrid
+  id: ShuttleERTMedMedium
+  path: /Maps/_Harmony/Shuttles/ShuttleEvent/ERTMedMedium.yml
+  copies: 1
+
+- type: preloadedGrid
+  id: ShuttleERTMedSmall
+  path: /Maps/_Harmony/Shuttles/ShuttleEvent/ERTMedSmall.yml
+  copies: 1
+
+- type: preloadedGrid
+  id: ShuttleERTEngiJaniMedium
+  path: /Maps/_Harmony/Shuttles/ShuttleEvent/ERTEngiJaniMedium.yml
+  copies: 1
+
+- type: preloadedGrid
+  id: ShuttleERTEngiSmall
+  path: /Maps/_Harmony/Shuttles/ShuttleEvent/ERTEngiSmall.yml
+  copies: 1
+
+- type: preloadedGrid
+  id: ShuttleERTJaniSmall
+  path: /Maps/_Harmony/Shuttles/ShuttleEvent/ERTJaniSmall.yml
   copies: 1


### PR DESCRIPTION
## About the PR
Adds a series of new GameRules to be used by admins via addgamerule. Does not add to add to the space traffic control scheduler. Each comes with a relevant Central Command station announcement.

## Why / Balance
Popular admin request. Exponentially streamlines calling ERT so that it is no longer a chore. Sometimes it takes so long to setup ERT that the threat may be either gone, out of control, or evac may have arrived. It's now as simple as a short console command!

## Technical details

- Map files in `/Resources/Maps/_Harmony/Shuttles/ShuttleEvent/`
- New GameRule prototypes in `/Resources/Prototypes/_Harmony/GameRules/ert_shuttles.yml`
- New announcements in `/Resources/Locale/en-US/_Harmony/station-events/events/ert-shuttles.ftl`
- Added preloaderGrids to `/Resources/Prototypes/_Harmony/Shuttles/shuttle_incoming_event.yml`
- Added labels in `/Resources/Prototypes/_Harmony/GameRules/unknown_shuttles.yml`

Requires time locked ERT prototypes from https://github.com/ss14-harmony/space-station-14/pull/159.
Uses modified shuttles from https://github.com/ss14-harmony/space-station-14/pull/47, credit to TsjipTsjip, luckyshotpictures, and IProduceWidgets.

## Media
![image](https://github.com/user-attachments/assets/b82f495a-018d-4d01-9df9-165ca79176d9)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->