### PR TITLE
Grant Command and Security firelock access

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
@@ -106,7 +106,7 @@
     - type: StaticPrice
       price: 150
     - type: AccessReader
-      access: [ [ "Engineering" ] , [ "Security" ], [ "Command" ] ]
+      access: [ [ "Engineering" ] , [ "Security" ], [ "Command" ] ] #Harmony added Security and Command
     - type: PryUnpowered
       pryModifier: 0.5
     - type: PointLight

--- a/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
@@ -106,7 +106,7 @@
     - type: StaticPrice
       price: 150
     - type: AccessReader
-      access: [ [ "Engineering" ] ]
+      access: [ [ "Engineering" ] , [ "Security" ], [ "Command" ] ]
     - type: PryUnpowered
       pryModifier: 0.5
     - type: PointLight


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Grants IDs with the Security or Command access tag to open and close firelocks at will, even when in 'lockdown'.

## Why / Balance
This was limited to Engineering only. Command should have access to such a basic system on the station. 
This will also severly increase the mobility and effectiveness of Security during Nukie or Dragon incursions.

## Technical details
Change under `\Resources\Prototypes\Entities\Structures\Doors\Firelocks` Line 109

## Media
This shows the access of the card 
![grafik](https://github.com/user-attachments/assets/28eb2601-beda-495b-9411-cf5e11bed1d3)

And this shows that it works
![grafik](https://github.com/user-attachments/assets/ba079c60-51ad-4632-a826-0b8d276bf246)

Works the same with only command

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Granted ID cards with the Command or Security access tag to open and close firelocks.
