### PR TITLE
Nitrogen Tanks in Fire Safety Closets

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
@@ -81,6 +81,8 @@
       children:
       - id: EmergencyOxygenTankFilled
       - id: OxygenTankFilled
+      - id: EmergencyNitrogenTankFilled
+      - id: NitrogenTankFilled
     - id: CrowbarRed
     - !type:GroupSelector
       children:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fire safety closets now have a chance to contain emergency nitrogen tanks or nitrogen tanks instead of oxygen and emergency oxygen

## Why / Balance
Considering we have two species that is entirely dependent on nitrogen for air now, balancing the distribution of nitrogen tanks and oxygen tanks is important. This change will equalize their distribution to a 50/50 and make finding nitrogen easier for slimes and voxes.

## Technical details
Added NitrogenTankFilled and EmergencyNitrogenTankFilled to the loot table of fire safety closets in Resources/Prototypes/Catalog/Fills/Lockers/misc.yml

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
No breaking changes

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
-add: Nitrogen Tanks can now be found in fire safety closets.

