### PR TITLE
Captain spawns with their sword

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -29,6 +29,7 @@
       entity_storage: !type:NestedSelector
         tableId: LockerFillQuarterMaster
 
+# Harmony Change: Removes the Captain's sheath from the locker since it is now part of their loadout.
 # No laser table
 - type: entityTable
   id: LockerFillCaptainNoLaser
@@ -37,7 +38,7 @@
     - id: CaptainIDCard
     - id: CigarGoldCase
       prob: 0.25
-    - id: ClothingBeltSheathFilled
+#    - id: ClothingBeltSheathFilled
     - id: ClothingHeadsetAltCommand
     - id: ClothingOuterArmorCaptainCarapace
     - id: CommsComputerCircuitboard

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -38,7 +38,7 @@
     - id: CaptainIDCard
     - id: CigarGoldCase
       prob: 0.25
-#    - id: ClothingBeltSheathFilled
+#    - id: ClothingBeltSheathFilled # Harmony Change
     - id: ClothingHeadsetAltCommand
     - id: ClothingOuterArmorCaptainCarapace
     - id: CommsComputerCircuitboard

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -37,7 +37,7 @@
   equipment:
     shoes: ClothingShoesBootsLaceup
     eyes: ClothingEyesGlassesSunglasses
-    belt: ClothingBeltSheathFilled
+    belt: ClothingBeltSheathFilled # Harmony Change
     gloves: ClothingHandsGlovesCaptain
     id: CaptainPDA
     ears: ClothingHeadsetAltCommand

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -31,11 +31,13 @@
     components:
       - type: CommandStaff
 
+# Harmony Change: Captain now spawns with a sabre. This will be used later for loadouts involving different swords.
 - type: startingGear
   id: CaptainGear
   equipment:
     shoes: ClothingShoesBootsLaceup
     eyes: ClothingEyesGlassesSunglasses
+    belt: ClothingBeltSheathFilled
     gloves: ClothingHandsGlovesCaptain
     id: CaptainPDA
     ears: ClothingHeadsetAltCommand


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This PR makes the Captain spawn with a sabre already on their belt. 

## Why / Balance
Captain being able to choose their sword is a cool idea that me and some other folks have interest in and this sets part of the groundwork for that happening. BoskiYourk on the Harmony discord has called dibs on doing the first alternate sword for the Captain and already has the belt loadout option programmed, so I haven't changed that part myself, but I removing it from the locker ahead of time helps that.

There's no thief objective for the Captain's sword, and I don't think it would cause any major problems on the rare chance that a bureaucratic error adds a billion now sabre wielding Captains.

## Technical details
The presence of ClothingBeltSheathFilled in the Captain's locker has been commented out
ClothingBeltSheathFilled has been added to the Captain's starting gear

## Media
![image](https://github.com/user-attachments/assets/c2d862b6-5d5e-47f7-a958-d3a7990f598c)
Here is a Captain with their sheath and sword in the spawn menu

![image](https://github.com/user-attachments/assets/ae72ed1a-9659-4380-a687-bbf82323070b)
The sword no longer appears in the locker

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- add: Added sabre sheath to the Captain's loadout
- remove: Removed sabre sheath from the Captain's lockers
