### PR TITLE
Remove whitelist chameleon tag from vox-specific masks

### DIFF
--- a/Resources/Prototypes/_Harmony/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/_Harmony/Entities/Clothing/Masks/masks.yml
@@ -8,6 +8,8 @@
     sprite: _Harmony/Clothing/Mask/voxcorpsepaint.rsi
   - type: Clothing
     sprite: _Harmony/Clothing/Mask/voxcorpsepaint.rsi
+  - type: Tag
+    tags: []
   - type: BreathMask
   - type: IdentityBlocker
   - type: HideLayerClothing
@@ -24,6 +26,8 @@
     sprite: _Harmony/Clothing/Mask/specvoxmask.rsi
   - type: Clothing
     sprite: _Harmony/Clothing/Mask/specvoxmask.rsi
+  - type: Tag
+    tags: []
   - type: BreathMask
   - type: IdentityBlocker
   - type: HideLayerClothing
@@ -41,8 +45,7 @@
   - type: Clothing
     sprite: _Harmony/Clothing/Mask/NTenforcer.rsi
   - type: Tag
-    tags:
-    - WhitelistChameleon
+    tags: []
   - type: HideLayerClothing
     slots:
     - Snout


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Removes WhitelistChameleon tag from vox-specific masks.

## Why / Balance
Bug fix. It was a way to wear chameleon mask without any mask showing up in game for non-vox users.

## Technical details
Adds Tag component with empty array of tags to overwrite inherited tags (WhitelistChameleon, and HamsterWearable in case of enfocer mask)

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
