### PR TITLE
Drozd now has full accuracy when unwielded, can no longer be wielded

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -134,6 +134,11 @@
           map: ["enum.GunVisualLayers.Mag"]
     - type: Clothing
       sprite: Objects/Weapons/Guns/SMGs/drozd.rsi
+#    - type: Wieldable
+#      unwieldOnUse: false
+#    - type: GunWieldBonus
+#      minAngle: -19
+#      maxAngle: -16
     - type: Gun
       minAngle: 2 # Harmony change: drozd one-handed accuracy is it's full accuracy
       maxAngle: 16 # Harmony change: drozd one-handed accuracy is it's full accuracy


### PR DESCRIPTION
## About the PR
Title. Drozd is now at its maximum accuracy when not wielded, and you can no longer wield it. It has also has had the delay between bursts increased from .25s to .5s, decreasing its DPS by 33%.
I was considering doing the same for the c-20r, but I'm not sure if it needs it.
This might be a bad idea but I want to see how it goes.

(Might want to wait for the drozd update upstream to be merged because of merge conflicts and stuff.)

## Why / Balance
For awhile the drozd has just kinda been the worst weapon in the armory. Sure it has the benefit of being smaller, but that doesn't really compare to the accuracy of the lecter and the burst DPS of the kammerer. Especially after the drozd was made a burst-fire only weapon, it is just entirely outclassed due to how hard it often is to use burst-fire.
I think this will give it a new use as a more versatile and portable weapon at the cost of poorer accuracy and less DPS.
Lecter DPS is 85 for comparison
Drozd DPS is now 64 if you hit all your shots, which is much harder to do as a result of the worse accuracy.
Perhaps shields will finally be useable for security during actual combat?

## Media
Shooting targets with less accuracy at a distance and more accuracy up close, pressing Z at the end to show it cannot be wielded.

https://github.com/user-attachments/assets/4e2cf474-c056-4d64-9943-f062264a9d41

![image](https://github.com/user-attachments/assets/92a6c4cd-b678-4801-bb15-3d8ea238e395)


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: The drozd now has full accuracy one-handed and has slightly more delay between bursts.