### PR TITLE
Made syndicate listening post spawn earlier and removed time requirements

### DIFF
--- a/Resources/Prototypes/_DeltaV/GameRules/events.yml
+++ b/Resources/Prototypes/_DeltaV/GameRules/events.yml
@@ -36,7 +36,7 @@
       components:
       - type: RandomMetadata
         nameSegments:
-        - names_death_commando
+        - NamesDeathCommando
       - type: AutoImplant
         implants:
         - DeathAcidifierImplant

--- a/Resources/Prototypes/_DeltaV/GameRules/events.yml
+++ b/Resources/Prototypes/_DeltaV/GameRules/events.yml
@@ -9,7 +9,7 @@
   parent: BaseGameRule
   components:
   - type: StationEvent
-    earliestStart: 20 # Harmony change: Make listening post spawn earlier. 60 -> 20
+    earliestStart: 20
     weight: 2
     minimumPlayers: 40
     maxOccurrences: 1

--- a/Resources/Prototypes/_DeltaV/GameRules/events.yml
+++ b/Resources/Prototypes/_DeltaV/GameRules/events.yml
@@ -9,7 +9,7 @@
   parent: BaseGameRule
   components:
   - type: StationEvent
-    earliestStart: 60
+    earliestStart: 20 # Harmony change: Make listening post spawn earlier. 60 -> 20
     weight: 2
     minimumPlayers: 40
     maxOccurrences: 1

--- a/Resources/Prototypes/_DeltaV/Roles/Antags/listening_post.yml
+++ b/Resources/Prototypes/_DeltaV/Roles/Antags/listening_post.yml
@@ -4,10 +4,4 @@
   antagonist: true
   objective: roles-antag-listening-post-objective
   # keep these in sync with the spawner
-  requirements: # Worth considering these numbers for the goal of making sure someone willing to MRP takes this.
-  - !type:DepartmentTimeRequirement
-    department: Security
-    time: 18000 # 5 hours
-  - !type:DepartmentTimeRequirement
-    department: Command
-    time: 18000 # 5 hours
+

--- a/Resources/Prototypes/_DeltaV/Roles/MindRoles/mind_roles.yml
+++ b/Resources/Prototypes/_DeltaV/Roles/MindRoles/mind_roles.yml
@@ -7,4 +7,5 @@
   - type: MindRole
     antagPrototype: ListeningPost
     exclusiveAntag: true
+    roleType: TeamAntagonist
   - type: ListeningPostRole


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
Changes when the listening post is able to spawn from 60 to 20 minutes.

## Why / Balance
With the current implementation of the listening post, it usually does not impact the round whatsoever due to how late into the round it spawns. This PR should make them more impactful over the course of the round if they spawn.

## Technical details
changed listening post event EarliestStart component value from 60 to 20

## Media

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- tweak: The Syndicate Listening Post can now spawn 20 minutes into the round instead of 60.
