### PR TITLE
Added interdyne defib as a separate purchase for nukies

### DIFF
--- a/Resources/Locale/en-US/_Harmony/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/_Harmony/store/uplink-catalog.ftl
@@ -15,3 +15,6 @@ uplink-cluster-weh-desc = Scatters 10 lizard plushies in a circle after a short 
 
 uplink-hyposhell-name = Box of hyposhells
 uplink-hyposhell-desc = A box containing four hyposhells, shotgun shells that can hold 7u of any chemical.
+
+uplink-defib-name = Interdyne Defibrillator
+uplink-defib-desc = A compact defibrillator. It can be used to revive your fellow comrades, or as an effective melee weapon! You should probably throw away your acidifier if you expect to use this.

--- a/Resources/Prototypes/_Harmony/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Harmony/Catalog/uplink_catalog.yml
@@ -11,6 +11,27 @@
   - UplinkExplosives
 # Ammo
 # Chemicals
+- type: listing
+  id: UplinkDefib
+  name: uplink-defib-name
+  description: uplink-defib-desc
+  productEntity: DefibrillatorSyndicate
+  discountCategory: rareDiscounts
+  discountDownTo:
+    Telecrystal: 8
+  cost:
+    Telecrystal: 10
+  categories:
+  - UplinkChemicals
+  conditions:
+  - !type:StoreWhitelistCondition
+    whitelist:
+      tags:
+      - NukeOpsUplink
+  - !type:BuyerWhitelistCondition
+    blacklist:
+      components:
+      - SurplusBundle
 # Deception
 - type: listing
   id: UplinkSmugglerSatchel


### PR DESCRIPTION
## About the PR
Nuclear operatives can now purchase the interdyne defib separately for **10 TC** without having to buy the interdyne bundle.

## Why / Balance
The interdyne medical bundle is rarely purchased (apart from Warops) due to how expensive of a buy-in it is, and how space-consuming the items inside are. Allowing the interdyne defib to be purchased separately would make it less punishing for teams trying to forgo using acidifiers, while still keeping some risk factor due to the price and crew being able to loot them after they die.

## Technical details
added interdyne defib to nukeop uplink listing

## Media
![obraz](https://github.com/user-attachments/assets/9b23a7fb-38ba-4c63-8270-f1de86812053)


## Requirements
- [X] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**

:cl:
- add: Added the Interdyne defibrillator as a separate purchase for nukies, costing 10 TC
