### PR TITLE
Made generator scrap able to be fultoned

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Materials/scrap.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/scrap.yml
@@ -60,7 +60,7 @@
         shape:
           !type:PhysShapeAabb
           bounds: "-0.40,-0.40,0.40,0.40"
-        density: 100
+        density: 200
         mask:
           - MachineMask
         layer:

--- a/Resources/Prototypes/Entities/Objects/Materials/scrap.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/scrap.yml
@@ -27,7 +27,7 @@
     - Recyclable
 
 - type: entity
-  parent: BaseStructure
+  parent: BaseStructureDynamic # Harmony change - Changed BaseStructure to BaseStructureDynamic
   id: BaseScrapLarge
   abstract: true
   name: scrap
@@ -60,7 +60,7 @@
         shape:
           !type:PhysShapeAabb
           bounds: "-0.40,-0.40,0.40,0.40"
-        density: 200
+        density: 100
         mask:
           - MachineMask
         layer:


### PR DESCRIPTION
## About the PR
This PR makes the broken-down generators that can naturally spawn on wrecks and the VGroid fultonable.

## Why / Balance
Currently there's no good way to loot generator scrap without having to manually drag them back to the reycycler one by one, which is extremely inefficient, especially without a shuttle (and even then, they take up a lot of space). This should give salvagers that run VGroid more ways to get rarer materials like uranium and plasma consistently.

## Technical details
Changed parent of BaseScrapLarge to BaseStructureDynamic from BaseStructure

## Media

![fulton](https://github.com/user-attachments/assets/8f374578-2f33-4660-bf05-20e60a592ff4)

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- tweak: Generator scrap can now be fultoned
