### PR TITLE
Removes explosive payload chain explosions

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/payload.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/payload.yml
@@ -34,21 +34,22 @@
     intensitySlope: 3
     totalIntensity: 120 # about a ~4 tile radius
   - type: ExplodeOnTrigger
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTypeTrigger
-        damageType: Heat
-        damage: 25
-      behaviors:
-      - !type:ExplodeBehavior
-    - trigger:
-        !type:DamageTrigger
-        damage: 50
-      behaviors:
-      - !type:DoActsBehavior
-        acts: [ "Destruction" ]
-
+# Begin Harmony change - Removes explosive payloads chain exploding
+# - type: Destructible
+#   thresholds:
+#   - trigger:
+#       !type:DamageTypeTrigger
+#       damageType: Heat
+#       damage: 25
+#     behaviors:
+#     - !type:ExplodeBehavior
+#   - trigger:
+#       !type:DamageTrigger
+#       damage: 50
+#     behaviors:
+#     - !type:DoActsBehavior
+#       acts: [ "Destruction" ]
+# End of Harmony change
 - type: entity
   name: chemical payload
   parent: BasePayload


### PR DESCRIPTION
## About the PR
Bit of a mald PR, but since this isn't being adressed on upstream, I feel like it atleast should be put up for discussion here.

This PR removes the ability for explosive payloads to chain detonate, which reduces their purpose to being put inside modular grenades.

## Why / Balance
Backpack bombs aren't a major resource or time sink, because explosive payloads are a tier 1 technology, they can be made roundstart with the vault resources, and a single one is enough to kill or crit anything apart from the elite suit within a 4-5 tile radius. Payload stacking is too effective of a weapon for crew and effectively removes warops as a viable strategy for nukies.

It has no counterplay, is borderline unreactable when combined with signal triggers. The only reason we haven't seen them used ALL THE TIME to end nukie rounds is because it's a relatively unknown strategy, despite the Liltenhead video.

## Technical details
Removed destructible component from explosive payload in Prototypes/Entities/Objects/Devices/payload.yml

## Media

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.


## Breaking changes

**Changelog**
:cl:
- remove: Removed explosive payloads being able to chain detonate