### PR TITLE
Adds energy shield to traitor uplink

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -145,6 +145,7 @@
 #     tags:
 #     - NukeOpsUplink
 #End harmony change
+
 - type: listing
   id: UplinkSniperBundle
   name: uplink-sniper-bundle-name


### PR DESCRIPTION
## About the PR
Removes the whitelist from the energy shield which means now traitors can buy it, price stays the same at 8 TC

## Why / Balance
Tots now have a very expensive buy in when they want that extra protection against laser weapons without buying the elite web vest and sacrificing all your pierce resistance. I think bumping the price any higher makes it useless so i just left it at 8.

## Technical details
Commented out the eshield whitelist condition in uplink_catalog.yml

## Media

![Zrzut ekranu 2025-05-05 041604](https://github.com/user-attachments/assets/6e0ba0d0-0280-4238-a048-a915603448ff)

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- add: Added energy shield to traitor uplink
