### PR TITLE
Increase minimum playercount for nukies

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -114,7 +114,8 @@
   id: Nukeops
   components:
   - type: GameRule
-    minPlayers: 20
+#    minPlayers: 20 # Commented out on Harmony
+    minPlayers: 35 # Updated minimum required players for Harmony
   - type: LoadMapRule
     mapPath: /Maps/Nonstations/nukieplanet.yml
   - type: AntagSelection


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
This PR increases the minimum required players for the NukeOps gamemode to 35 from its previous 20!

## Why / Balance
Nobody enjoys low-population nukie steamrolls. Its unrewarding for the people nuking and it feels hopelessly unfun for the crew being stomped.

## Technical details
<!-- Summary of code changes for easier review. -->
**Upstream files**
Resources/Prototypes/GameRules/roundstart.yml -- Increase minimum playercount 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
![image](https://github.com/user-attachments/assets/32817ecd-8406-4aa0-b0cc-532be842d86b)

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [  ] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- tweak: Increased minimum players required for NukeOps
-->
