### PR TITLE
Tweaks uplink item prices + misc traitor item changes

### DIFF
--- a/Resources/Prototypes/Actions/types.yml
+++ b/Resources/Prototypes/Actions/types.yml
@@ -340,7 +340,7 @@
   name: Toggle Paramedic Siren
   description: Toggles the paramedic siren on and off.
   components:
-  - type: InstantAction
+  - type: InstantAction 
     icon:
       sprite: Clothing/OuterClothing/Hardsuits/paramed.rsi
       state: icon-siren

--- a/Resources/Prototypes/Actions/types.yml
+++ b/Resources/Prototypes/Actions/types.yml
@@ -140,7 +140,7 @@
   description: Randomly teleports you within a large distance.
   components:
   - type: LimitedCharges
-    maxCharges: 2
+    maxCharges: 3 # Harmony: 2 -> 3
   - type: InstantAction
     checkCanInteract: false
     useDelay: 5
@@ -340,7 +340,7 @@
   name: Toggle Paramedic Siren
   description: Toggles the paramedic siren on and off.
   components:
-  - type: InstantAction 
+  - type: InstantAction
     icon:
       sprite: Clothing/OuterClothing/Hardsuits/paramed.rsi
       state: icon-siren

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -280,10 +280,12 @@
   id: UplinkSingularityGrenade
   name: uplink-singularity-grenade-name
   description: uplink-singularity-grenade-desc
-  productEntity: SingularityGrenade
-  discountCategory: usualDiscounts
-  discountDownTo:
-    Telecrystal: 1
+  productEntity:
+# Begin harmony change - removed discount
+# discountCategory: usualDiscounts
+# discountDownTo:
+#   Telecrystal: 1
+# End harmony change
   cost:
     Telecrystal: 2
   categories:
@@ -294,9 +296,11 @@
   name: uplink-whitehole-grenade-name
   description: uplink-whitehole-grenade-desc
   productEntity: WhiteholeGrenade
-  discountCategory: usualDiscounts
-  discountDownTo:
-    Telecrystal: 1
+# Begin harmony change : Removed discount
+# discountCategory: usualDiscounts
+# discountDownTo:
+#   Telecrystal: 1
+# End harmony change
   cost:
     Telecrystal: 2
   categories:
@@ -816,9 +820,11 @@
   name: uplink-ultrabright-lantern-name
   description: uplink-ultrabright-lantern-desc
   productEntity: LanternFlash
-  discountCategory: usualDiscounts
-  discountDownTo:
-    Telecrystal: 1
+# Begin harmony change- Removed discount
+# discountCategory: usualDiscounts
+# discountDownTo:
+#   Telecrystal: 1
+# End harmony change
   cost:
     Telecrystal: 2
   categories:
@@ -855,9 +861,9 @@
   productEntity: ClothingBackpackDuffelSyndicateDecoyKitFilled
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 3
+    Telecrystal: 2 # Harmony: 4 -> 2
   cost:
-    Telecrystal: 6
+    Telecrystal: 4 # Harmony: 6 -> 4
   categories:
   - UplinkDeception
 
@@ -1021,7 +1027,7 @@
   discountDownTo:
     Telecrystal: 4
   cost:
-    Telecrystal: 8
+    Telecrystal: 7 # Harmony: 8 -> 7
   categories:
   - UplinkDisruption
   conditions:
@@ -1161,11 +1167,11 @@
   description: uplink-reinforcement-radio-traitor-desc
   productEntity: ReinforcementRadioSyndicate
   icon: { sprite: Objects/Devices/communication.rsi, state: old-radio-urist }
-  discountCategory: usualDiscounts
+  discountCategory: rareDiscounts # Harmony: usualDiscounts -> rareDiscounts
   discountDownTo:
     Telecrystal: 7
   cost:
-    Telecrystal: 14
+    Telecrystal: 12 # Harmony - 14 -> 12
   categories:
   - UplinkAllies
   conditions:
@@ -1181,7 +1187,7 @@
   productEntity: ReinforcementRadioSyndicateNukeops
   icon: { sprite: Objects/Devices/communication.rsi, state: old-radio-nukeop }
   cost:
-    Telecrystal: 30
+    Telecrystal: 25 # Harmony: 30 -> 25
   categories:
   - UplinkAllies
   conditions:

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -280,7 +280,7 @@
   id: UplinkSingularityGrenade
   name: uplink-singularity-grenade-name
   description: uplink-singularity-grenade-desc
-  productEntity:
+  productEntity: SingularityGrenade
 # Begin harmony change - removed discount
 # discountCategory: usualDiscounts
 # discountDownTo:

--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -619,7 +619,7 @@
   - type: Storage
     maxItemSize: Huge
     grid:
-    - 0,0,3,3
+    - 0,0,4,3 # Harmony: 0,0,3,3 -> 0,0,4,3
     whitelist:
       components:
         - Gun


### PR DESCRIPTION
## About the PR
Modifies a bunch of numbers in the traitor uplink and removes some discounts, namely:

1. Increased scram implanter charges from 2 to 3
2. Removed discount from singularity grenade
3. Removed discount from whitehole grenade
4. Decreased decoy kit from 6 to 4 TC
5. Decreased powersink from 8 to 7 TC
6. Decreased nukie reinforcement price from 30 to 25 TC
7. Increased syndicate holster size from 3x3 to 4x3
8. Decreased traitor reinforcement price from 14 to 12 and changed to rare discount
9. Removed flash lantern discount

## Why / Balance
Gonna discuss these point by point:

1. Nobody uses this and half the time it kills you, I think it deserves a buff for such a steep price.
2. This discount is utterly useless since nobody buys this anyway, so it's just discount bloat.
3. This discount is utterly useless since nobody buys this anyway, so it's just discount bloat.
4. This is obviously a meme kit, but I think fake grenades are actually pretty healthy for encouraging unique ideas and distractions, so why not make it more attractive to buy?
5. This one might be controversial, but power sink is pretty easy to locate outside of situations where engineering and security doesn't care. Still a better distraction than a bomb in my opinion so I didn't bump the price too low.
6. Completely useless outside of warops, mainly just compensating for https://github.com/ss14-harmony/ss14-harmony/pull/540 removing the blood-reds from their starting loadout.
7. You can actually carry long arms like the C-20 and Bulldog and the ammo for them inside this now, making it a sidegrade to the toolbelt instead of a meme item.
8. Pretty much nobody buys reinforcements so this should spice up ghost role variety more often. Also makes the discount rarer because it seemed odd to me that such an expensive item is on the usual discounts list, the only other item that's this expensive that also does this is the Hristov.
9. This discount is utterly useless since nobody buys this anyway, so it's just discount bloat.

## Technical details
All in upstream:
changed value in types.yml
changed values and commented out some discounts in uplink_catalog.yml
changed syndie holster belt size in belts.yml

## Media
not adding media because if i have to make any changes then i have to re-do the whole list

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**

:cl:
- tweak: Adjusted uplink item price values
