### PR TITLE
Removes Stun Damage from Throwing Stars

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/throwing_stars.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/throwing_stars.yml
@@ -37,10 +37,12 @@
       types:
         Slash: 8
         Piercing: 10
-  - type: StaminaDamageOnCollide
-    damage: 45
-  - type: StaminaDamageOnEmbed
-    damage: 10
+# Start of Harmony Change: Removes Stamina damage from the Throwing Star
+#  - type: StaminaDamageOnCollide
+#    damage: 45
+#  - type: StaminaDamageOnEmbed
+#    damage: 10
+# End of Harmony Change
 
 - type: entity
   parent: ThrowingStar


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
- Removes stun damage from throwing stars
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Throwing stars dealing stun damage is too powerful. Unlike other stun-dealing ranged weapons, you can still land hits when the person is stamina critted. Ninja's also don't need two stuns.
## Technical details
<!-- Summary of code changes for easier review. -->
Resources/Prototypes/Entities/Objects/Weapons/Throwable/throwing_stars.yml -- Removes stamina damage from throwing stars
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
N/A
## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:

- tweak: Removes stun damage from throwing stars

