### PR TITLE
Move Check prefence above mindshield

### DIFF
--- a/Content.Server/_Harmony/GameTicking/Rules/BloodBrotherRuleSystem.cs
+++ b/Content.Server/_Harmony/GameTicking/Rules/BloodBrotherRuleSystem.cs
@@ -1,4 +1,3 @@
-﻿using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Content.Server._Harmony.GameTicking.Rules.Components;
 using Content.Server._Harmony.Roles;


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
Makes bloodbrothers check for prefence above mindshield
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Mindshield shouldnt prevent it telling you if its elgibile
## Technical details
<!-- Summary of code changes for easier review. -->
Content.Server/_Harmony/GameTicking/Rules/BloodBrotherRuleSystem.cs - moved it down
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
<img width="496" alt="image" src="https://github.com/user-attachments/assets/0481700f-d5af-44f6-9bde-c9ee0a43079c" />

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
no cl no fun
