### PR TITLE
Popups are now based on identity

### DIFF
--- a/Content.Server/_Harmony/GameTicking/Rules/BloodBrotherRuleSystem.cs
+++ b/Content.Server/_Harmony/GameTicking/Rules/BloodBrotherRuleSystem.cs
@@ -15,6 +15,7 @@ using Content.Server.Stunnable;
 using Content.Shared._Harmony.BloodBrothers.Components;
 using Content.Shared.Database;
 using Content.Shared.Humanoid;
+using Content.Shared.IdentityManagement;
 using Content.Shared.Mindshield.Components;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.NPC.Systems;
@@ -30,6 +31,7 @@ namespace Content.Server._Harmony.GameTicking.Rules;
 public sealed class BloodBrotherRuleSystem : GameRuleSystem<BloodBrotherRuleComponent>
 {
     [Dependency] private readonly IAdminLogManager _adminLogManager = default!;
+    [Dependency] private readonly IEntityManager _entityManager = default!;
     [Dependency] private readonly IPlayerManager _playerManager = default!;
     [Dependency] private readonly IServerPreferencesManager _preferencesManager = default!;
     [Dependency] private readonly AntagSelectionSystem _antagSystem = default!;
@@ -95,7 +97,13 @@ public sealed class BloodBrotherRuleSystem : GameRuleSystem<BloodBrotherRuleComp
 
         if (!CanConvert(entity, args.Target, out var failureMessage))
         {
-            _popupSystem.PopupEntity(Loc.GetString(failureMessage, ("converter", entity), ("converted", args.Target)), args.Target, entity, PopupType.MediumCaution);
+            _popupSystem.PopupEntity(
+                Loc.GetString(failureMessage,
+                    ("converter", Identity.Entity(entity, _entityManager)),
+                    ("converted", Identity.Entity(args.Target, _entityManager))),
+                args.Target,
+                entity,
+                PopupType.MediumCaution);
             return;
         }
 
@@ -147,7 +155,10 @@ public sealed class BloodBrotherRuleSystem : GameRuleSystem<BloodBrotherRuleComp
             entity.Comp.BriefingSound);
 
         _popupSystem.PopupEntity(
-            Loc.GetString(entity.Comp.ConvertPopupText, ("converter", entity), ("converted", args.Target)),
+            Loc.GetString(
+                entity.Comp.ConvertPopupText,
+                ("converter", Identity.Entity(entity, _entityManager)),
+                ("converted", Identity.Entity(args.Target, _entityManager))),
             args.Target,
             PopupType.LargeCaution);
 
@@ -166,11 +177,23 @@ public sealed class BloodBrotherRuleSystem : GameRuleSystem<BloodBrotherRuleComp
     {
         if (!CanConvert(entity, args.Target, out var failureMessage))
         {
-            _popupSystem.PopupEntity(Loc.GetString(failureMessage, ("converter", entity), ("converted", args.Target)), args.Target, entity, PopupType.MediumCaution);
+            _popupSystem.PopupEntity(
+                Loc.GetString(failureMessage,
+                    ("converter", Identity.Entity(entity, _entityManager)),
+                    ("converted", Identity.Entity(args.Target, _entityManager))),
+                args.Target,
+                entity,
+                PopupType.MediumCaution);
             return;
         }
 
-        _popupSystem.PopupEntity(Loc.GetString("blood-brother-convert-convertible", ("converter", entity), ("converted", args.Target)), args.Target, entity, PopupType.Medium);
+        _popupSystem.PopupEntity(
+            Loc.GetString("blood-brother-convert-convertible",
+                ("converter", Identity.Entity(entity, _entityManager)),
+                ("converted", Identity.Entity(args.Target, _entityManager))),
+            args.Target,
+            entity,
+            PopupType.Medium);
     }
 
     private bool CanConvert(


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
Blood brother popups now show the person's identity instead of their entity name

The code in this PR is available under the MIT license

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
