### PR TITLE
Incendiary ammo nerf

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -148,7 +148,7 @@
     radius: 2.0
     energy: 7.0
   - type: IgniteOnCollide
-    fireStacks: 0.25
+    fireStacks: 0.125 # Harmony: 0.25 -> 0.125, 50% reduction
 
 - type: entity
   id: BaseBulletAP


### PR DESCRIPTION
## About the PR

This PR changes a single value and halves fire stacks done by incendiary ammo.

## Why / Balance
Incendiary ammo is easy to obtain and ashes any moths or diona with half a magazine if they don't get put out fast enough. There's currently no armor that counters direct heat damage easily apart from the elite suit so it should still be a viable option to use, but should make playing security diona and moth actually enjoyable.
Incendiaries are problematic towards tot/security balance aswell (Because encountering either one is a complete death sentence due to already mentioned lack of protection) so this should alleviate that balance a little.

## Technical details
changed one value in an yml file, added harmony comment

## Media

https://github.com/user-attachments/assets/ca7e9643-5479-478b-a092-c4cde1dec022



## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes


**Changelog**
:cl:
- tweak: Nerfed incendiary ammo