### PR TITLE
Do not cancel round start due to too few players for Wizard

### DIFF
--- a/Resources/Prototypes/GameRules/subgamemodes.yml
+++ b/Resources/Prototypes/GameRules/subgamemodes.yml
@@ -40,6 +40,7 @@
   # Start harmony specific change
   - type: GameRule
     minPlayers: 25
+    cancelPresetOnTooFewPlayers: false
   # End harmony specific change
   - type: AntagSelection
     agentName: wizard-round-end-name


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
Fixes Wizard sometimes causing rounds with 5-24 players to fail to start.

This is essentially the same as #793, except it's for Wizard instead of Blood Brothers. This causes round start failure more rarely just because Wizard is rarer than Blood Brothers. However, since Wizard has a higher minimum player count than Blood Brothers, it can cause round start failure for larger rounds.

I would probably have just included this in #793, but because it affects Wizard I assumed it would affect upstream. I was wrong, upstream has no minimum player count for Wizard as a subgamemode; the minimum was added rather than just changed for Harmony.

## Why / Balance
The round not starting is annoying. The round starting and Wizard just not actually happening is much better.

## Technical details
Sets `cancelPresetOnTooFewPlayers` to `false` for the Wizard subgamemode game rule. This prevents Wizard from cancelling the selected preset, and thus round start, when it is selected as a subgamemode and there are fewer than 25 players ready.

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: Wizard will no longer sometimes cause rounds with 5-24 players to fail to start
