### PR TITLE
Removes handheld GPS from Salvage Locker/Vendor, adds AstroNav cartridge to Salvage Vendor

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
@@ -13,7 +13,7 @@
     children:
     - id: ClothingBeltUtilityFilled
     - id: SurvivalKnife
-    - id: HandheldGPSBasic
+#   - id: HandheldGPSBasic # Harmony change: Removed GPS from salvage locker
     - id: RadioHandheld
     - id: SeismicCharge # Harmony change
     - id: AppraisalTool

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/salvage.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/salvage.yml
@@ -6,7 +6,10 @@
     OreBag: 4
     Flare: 4
     FlashlightLantern: 2
-    HandheldGPSBasic: 2
+# Harmony change - Removed GPS, added astronav cartridge
+#   HandheldGPSBasic: 2
+    AstroNavCartridge: 1
+# End of harmony change
     RadioHandheld: 2
     WeaponGrapplingGun: 4
     WeaponProtoKineticAccelerator: 4


### PR DESCRIPTION
## About the PR
This PR removes the handheld GPS from the salvage locker and the salvage vendor, and adds the AstroNav cartridge to the salvage vendor. (1 per restock)

## Why / Balance
Quality of Life. AstroNav is installed by default on the salvage PDA, and does what a GPS does but without taking any storage space. They are effectively useless to salvagers, and the only reason they may be used is for transfers to salvage who may not have a salvage PDA, which is why the AstroNav cartridge is now in the salvage vendor.

## Technical details
removed gps from salvage locker filled prototype in fills/lockers/cargo.yml
removed gps from salvage vendor, added astronav to salvage vendor in vendingmachines/inventories/salvage.yml

## Media
![obraz](https://github.com/user-attachments/assets/a8af7dd9-1155-4b23-bae2-5282656e273c)


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- add: Added AstroNav cartridge to Salvage Vendor
- remove: Removed handheld GPS from Salvage lockers and Salvage Vendor