### PR TITLE
Removes flagship wreck

### DIFF
--- a/Resources/Maps/Ruins/empty_flagship.yml
+++ b/Resources/Maps/Ruins/empty_flagship.yml
@@ -12151,15 +12151,13 @@ entities:
     - type: Transform
       pos: 28.5,-4.5
       parent: 1
-# Begin harmony change
-#- proto: WeaponSubMachineGunWt550
-# entities:
-# - uid: 1699
-#   components:
-#   - type: Transform
-#     pos: 112.5164,-0.47590828
-#     parent: 1
-# End harmony change
+- proto: WeaponSubMachineGunWt550
+  entities:
+  - uid: 1699
+    components:
+    - type: Transform
+      pos: 112.5164,-0.47590828
+      parent: 1
 - proto: WeaponTurretHostile
   entities:
   - uid: 992

--- a/Resources/Prototypes/Entities/Stations/base.yml
+++ b/Resources/Prototypes/Entities/Stations/base.yml
@@ -73,7 +73,7 @@
           - /Maps/Ruins/biodome_satellite.yml
           - /Maps/Ruins/derelict.yml
           - /Maps/Ruins/djstation.yml
-          - /Maps/Ruins/empty_flagship.yml
+#         - /Maps/Ruins/empty_flagship.yml # Harmony change - removes flagship wreck
           - /Maps/Ruins/hydro_outpost.yml
           - /Maps/Ruins/old_ai_sat.yml
           - /Maps/Ruins/ruined_prison_ship.yml


### PR DESCRIPTION
## About the PR
Removes flagship wreck from wreck spawns

## Why / Balance
It's horribly themed, has death rooms everywhere, has gamer loot, and the WT550 that spawns on it is especially problematic because it's supposed to be a unique weapon to the HoS.

Also wizden isn't tackling this wreck it seems so it's probably best to remove it

## Technical details
1 line commented out in wreck list, added harmony comment

## Media

## Requirements
- [X] I have tested all added content and changes.
- [ ] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- remove: Removed flagship wreck
