### PR TITLE
Part 2: Player projectiles no longer pass through crates

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/base_structurecrates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/base_structurecrates.yml
@@ -93,7 +93,7 @@
     node: crategenericsteel
     containers:
       - entity_storage
-  - type: RequireProjectileTarget
+# - type: RequireProjectileTarget # Harmony change
 
 - type: entity
   parent: CrateGeneric


### PR DESCRIPTION
## About the PR
Part 2 of https://github.com/ss14-harmony/ss14-harmony/pull/799

Crates no longer have the "RequireProjectileTarget" component, which means they behave exactly the same as closets. They no longer let bullets pass through.

## Why / Balance
This may have some unintended consequences in PvP gunfights, but in my opinion the positives far outweigh the negatives. 

Crates no longer being able to be shot through means that you cannot cheese AI with crates while still being able to damage them, which removed all nuance and skill from PvE. 

## Technical details
commented out RequireProjectileTarget from BaseCrateWeldable prototype in base_structurecrates.yml, added harmony comment

## Media

https://github.com/user-attachments/assets/eb603444-ed02-4a7e-8ebf-f2bcaab2faee


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

(Is this even player facing? Maybe don't include these)
**Changelog**
:cl:
- tweak: Player-fired projectiles are no longer able to pass through crates.