### PR TITLE
Moves portable recharger to Tier 2 research

### DIFF
--- a/Resources/Locale/en-US/_Harmony/research/technologies.ftl
+++ b/Resources/Locale/en-US/_Harmony/research/technologies.ftl
@@ -1,0 +1,1 @@
+research-technology-portable-recharging = Portable Recharging

--- a/Resources/Prototypes/Research/arsenal.yml
+++ b/Resources/Prototypes/Research/arsenal.yml
@@ -204,10 +204,10 @@
     state: icon
   discipline: Arsenal
   tier: 3
-  cost: 15000
+  cost: 12500 # Harmony - 15000 -> 12500
   recipeUnlocks:
   - WeaponAdvancedLaser
-  - PortableRecharger
+# - PortableRecharger # Harmony
 
 - type: technology
   id: ThermalWeaponry

--- a/Resources/Prototypes/_Harmony/Research/arsenal.yml
+++ b/Resources/Prototypes/_Harmony/Research/arsenal.yml
@@ -1,0 +1,13 @@
+- type: technology
+  id: PortableRecharging
+  name: research-technology-portable-recharging
+  icon:
+    sprite: Objects/Power/portable_recharger.rsi
+    state: charging
+  discipline: Arsenal
+  tier: 2
+  cost: 10000
+  recipeUnlocks:
+  - PortableRecharger
+  technologyPrerequisites:
+  - AdvancedPowercells


### PR DESCRIPTION
## About the PR
This PR adjusts the price of the Portable Microfusion research from 15000 to 12500 RP, moves the Portable Recharger from Portable Microfusion into a new research, Portable Recharging, a tier 2 tech which costs 10000 RP and requires advanced powercells to unlock.

## Why / Balance
![obraz](https://github.com/user-attachments/assets/90c14b71-57b3-4b0f-a3d3-7342870cd802)

Nobody EVER uses the portable recharger (Even during warops, the only time tier 3 security is selected) due to the heavy recipe and research cost, and no real advantage over an advanced recharger, especially when compared to something like the advanced laser pistol which is miles better than the portable recharger and is unlocked by the same research. Considering how we are leaning into energy weapons as the main security weapon, this should make them slightly more bearable to use and more accessible.

## Technical details
added research tech name in technologies.ftl in harmony namespace
adjusted and commented out values in arsenal.yml in upstream namespace, added harmony comments
added new technology in arsenal.yml in harmony namespace

## Media

![Zrzut ekranu 2025-06-23 060942](https://github.com/user-attachments/assets/af6120fa-552e-4cf6-bf74-706b44b99660)

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- add: Added Portable Recharging technology. Unlocks the Portable Recharger
- tweak: Moved the Portable Recharger into a separate tech unlock.
- tweak: Adjusted the price of the Portable Microfusion research.