### PR TITLE
Adds More Fultons To The Salvage Vendor

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/salvage.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/salvage.yml
@@ -14,7 +14,7 @@
     Floodlight: 2
     SeismicCharge: 2
     FultonBeacon: 1
-    Fulton: 2
+    Fulton: 4
 # End of Harmony change.
   contrabandInventory:
     PlushieCarp: 1


### PR DESCRIPTION
## About the PR
This PR adds 2 more stacks of fultons to the salv vendor, to bring it up to 4 stacks of 10.

## Why / Balance
As it stands, Fultons are the only item in the salvage vendor that isn't appropriate to the scale of salvagers that most maps in the Harmony map-pool run for (3-4). This creates issues with having to manually split fultons, and if anyone dies, it results in there not being equipment for replacement salvagers who get promoted or late join. Fultons are very, very rarely printed by science in my experience. This encourages Salvage to use fultons more, and punishes them less for having a full team. It also protects against loss of equipment, as fultons are destroyed by explosions (Which Salvage are prone to getting hit by, thanks to space debris, meteors, gibtonite, and landmines).

There are 4 PKAs, 4 pickaxes, 4 ore bags, and 4 grappling hooks. This PR means that there are 4 sets of full fultons for 4 salvagers to match the pattern set by other equipment.

## Technical details
Adjusts the "fulton" value in Resources/Prototypes/Catalog/VendingMachines/Inventories/salvage.yml

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**

:cl:
- tweak: Adds two more stacks of Fultons to the vendor, bringing it up to four!

