### PR TITLE
Buffs .30 caseless damage

### DIFF
--- a/Resources/Prototypes/_Harmony/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/light_rifle.yml
+++ b/Resources/Prototypes/_Harmony/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/light_rifle.yml
@@ -7,4 +7,4 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 26
+        Piercing: 35


### PR DESCRIPTION
## About the PR
Buffs .30 caseless damage from 26 to 35. (The ammo type used in the Bandit DMR) 

## Why / Balance
When the scope separated UI bug is adressed upstream I will also be making another PR to add a scope to the DMR and slightly nerfing the damage back down to compensate for having a scope.

Currently:
1. it has a slower TTK than the C-20 (which costs 2 less TC)
2. is more punishing to use due to the lower mag size (15) and low firerate (firerate is the same as a Python)
3. the ammo for it can only be bought in the uplink, impossible to make with a lathe

The base damage should be slightly higher, considering a deckard can outdamage this thing with the same firerate. You invest a ton of TC in exchange for a worse deal then the C-20 or a python right now.


After the buff, it takes 4 shots to crit unarmored and 5 shots with an armor vest. This change will emphasize the gun as the epitome of the Hristov by having the highest single bullet damage among the higher-tier syndicate weapons.

## Technical details

one number change in harmony namespace

## Media

## Requirements
- [X] I have tested all added content and changes.
- [ ] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- tweak: Buffed the Bandit DMR. Now does 35 damage.