### PR TITLE
Makes Fultons Indestructable

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/fulton.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/fulton.yml
@@ -65,17 +65,18 @@
     drawdepth: SmallObjects
     sprite: Objects/Tools/fulton.rsi
     state: extraction_pack
-  - type: Damageable
-    damageContainer: Inorganic
-  - type: Destructible
-    thresholds:
-      - trigger:
-          !type:DamageTrigger
-          damage: 100
-        behaviors:
-          - !type:DoActsBehavior
-            acts: [ "Destruction" ]
-
+ #Start of Harmony Change - Removes Destructable status of Fultons.
+#  - type: Damageable
+#    damageContainer: Inorganic
+#  - type: Destructible
+#    thresholds:
+#      - trigger:
+#          !type:DamageTrigger
+#          damage: 100
+#        behaviors:
+#          - !type:DoActsBehavior
+#            acts: [ "Destruction" ]
+#End of Harmony Change - Removes Destructable status of Fultons.
 - type: entity
   id: Fulton1
   parent: Fulton


### PR DESCRIPTION
## About the PR
Comments out code that destroys fultons when the container they're in takes a certain amount of damage.

## Why / Balance
Losing your fultons suck. Especially when its the only bit of salvage kit that gets destroyed by damage. They're annoying to replace unless you buy a whole new salvage vendor restock, or hope that science has the recipe and is willing to print you some. This means that salvagers aren't unjustly punished by losing valuable equipment when met with one of their most common fates (stepping on a landmine or getting hit by "totally random" meteors). Losing your haul for that debris/wreck/etc and potentially being round removed is often punishment enough for being careless and missing a landmine.

## Technical details
Comments out a block of code in Resources/Prototypes/Entites/Objects/Tools/Fulton.yml to remove damage triggers.

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Fultons no longer vanish from containers when the container is damaged.
