### PR TITLE
Unnerfs Jetpack acceleration (Reverts #669)

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
@@ -53,7 +53,6 @@
       temperature: 293.15
   - type: Jetpack
     moleUsage: 0.00085
-    acceleration: 0.5 # Harmony
   - type: Appearance
   - type: GenericVisualizer
     visuals:


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
Reverts https://github.com/ss14-harmony/ss14-harmony/pull/669.

## Why / Balance
After constant discussion concerning the matter (a continuation and collation found [here](https://discord.com/channels/1139716325627932682/1392060511188815943)), it seems clear the change ended up not being the best for the health of the game.

While it attempted to dissuade antagonists from fighting in space, it instead made using jetpacks for Salvaging feel awful, and dissauded Security from chasing antagonists into space.

It has also made the issue of space-facing turrets mapped on some wrecks, ruins, and creatable by players even more deadly to deal with, making it a near-guaranteed RR for all but the most robust players.

## Technical details
Deletes the line added in PR 669, returning it to the upstream state.

## Media

https://github.com/user-attachments/assets/17b50243-1431-4f6f-bd8a-085d5ac33892

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Reverts Jetpack Acceleration nerf.
