### PR TITLE
Add the Tattered Bag of Holding

### DIFF
--- a/Resources/Prototypes/_Harmony/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/_Harmony/Entities/Clothing/Back/backpacks.yml
@@ -1,0 +1,33 @@
+- type: entity
+  parent: ClothingBackpackHolding
+  id: ClothingBackpackHoldingTattered
+  name: tattered bag of holding
+  description: A damaged backpack that opens into a localized pocket of bluespace. The damage seems to be affecting its space warping properties in strange ways.
+  components:
+  - type: MultiHandedItem
+  - type: Sprite
+    sprite: Clothing/Back/Backpacks/holding.rsi
+    state: holding
+    layers:
+    - state: holding
+    - state: holding-unlit
+      shader: unshaded
+  - type: Clothing
+    slots:
+      #This removes the ability to wear that comes from the parent
+  - type: Item
+    size: Ginormous
+  - type: Storage
+    maxItemSize: Huge
+    grid:
+    - 0,0,2,7
+    - 3,0,10,2
+    - 3,4,7,7
+    - 4,3,8,3
+    - 8,5,15,7
+    - 9,3,15,4
+    - 11,0,11,1
+    - 12,0,15,2
+    quickInsert: true
+    areaInsert: true
+  - type: Dumpable


### PR DESCRIPTION
## About the PR
This PR adds a new item, the Tattered Bag of Holding. It is meant to fill the niche between roundstart bags and the bag of holding.

I wanted this item to follow the following design:
It's only findable as rare salvage loot
It has a storage of 16x8 (a normal bag of holding is 20x10) and it has three squares of storage missing, making it more difficult to store a lot of large items.
It requires two hands to hold, which will make it slightly harder to use without the next feature
It has the areaInsert and quickInsert similar to the botany bag or trash bag

## Why / Balance
This item is meant as a little treasure for salvage to find, but at the same time it is meant to be fairly unwieldy and worse than the actual bag of holding.

## Technical details
This adds the new item and puts it in the salvage loot pools.

## Media
Coming soon™

## Requirements
Coming soon™
- [ ] I have tested all added content and changes.
- [ ] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
N/A

**Changelog**
:cl:
- add: Added the Tattered Bag of Holding, a new mid tier storage item for salvage to find that is a little better than starting gear.
