### PR TITLE
Adds more/heightens time requirements for nukies

### DIFF
--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -20,7 +20,7 @@
     time: 18000 # 5h
   - !type:RoleTimeRequirement
     role: JobChemist
-    time: 10800 # 3h
+    time: 28800 # Harmony change : 3h -> 8h
   guides: [ NuclearOperatives ]
 
 - type: antag
@@ -35,6 +35,11 @@
   - !type:DepartmentTimeRequirement
     department: Security
     time: 18000 # 5h
+    # Start harmony change
+  - !type:DepartmentTimeRequirement
+     department: Command
+     time: 7200 # 2h
+     # End harmony change
   # should be changed to nukie playtime when thats tracked (wyci)
   guides: [ NuclearOperatives ]
 


### PR DESCRIPTION
## About the PR
Changes nukie medic playtime requirement from 3 hours to 8 hours of chemistry.
Adds 2 hour command playtime requirement to nukie commander.

## Why / Balance
While I think that harmony benefits from having reduced role timers in general, I think nukies are the exception in this case.

Currently you only need one and a half of chemistry shift's worth of playtime to play nukie agent. This is extremely low as the agent basically dictates the flow of the entire shift depending on how long they take to make chems, what chems they make and how experienced they are at treating. As much as I think forcing people to play chemist sucks, it's a necessary evil because you NEED to be good (If not atleast somewhat knowledgeable) at chemistry to do good as agent, and the entire round will suffer if you aren't.

The commander playtime requirements might be controversial, but I think a role that, at heart, requires you to literally command others and know (atleast on a basic level) the gameplay loop and responsibilities of command members should probably require command playtime.

I have seen too many rounds where nukies take 50+ minutes to get onto the station because of inexperience, this obviously won't fix the issue completely but it should do something to alleviate it.

## Technical details
modifies Roles/Antags/nukeops.yml in upstream namespace, adds harmony comments

## Media

## Requirements
- [X] I have tested all added content and changes.
- [ ] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- tweak: Nukie playtime requirements are higher