### PR TITLE
Blink V2

### DIFF
--- a/Content.Server/_Harmony/RandomTeleport/RandomTeleportSystem.cs
+++ b/Content.Server/_Harmony/RandomTeleport/RandomTeleportSystem.cs
@@ -1,0 +1,49 @@
+﻿using System.Numerics;
+using Content.Shared._Harmony.RandomTeleport;
+using Content.Shared.Administration.Logs;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Map;
+using Robust.Shared.Random;
+
+namespace Content.Server._Harmony.RandomTeleport;
+
+public sealed class RandomTeleportSystem : EntitySystem
+{
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly EntityLookupSystem _lookup = default!;
+    [Dependency] private readonly SharedTransformSystem _xform = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<RandomTeleportEvent>(OnRandomTeleport);
+    }
+
+    private void OnRandomTeleport(RandomTeleportEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        var xform = Transform(args.Performer);
+        var mapPos = _xform.GetWorldPosition(xform);
+        var radius = args.Radius;
+        var gridBounds = new Box2(mapPos - new Vector2(radius, radius), mapPos + new Vector2(radius, radius));
+
+        var randomX = _random.NextFloat(gridBounds.Left, gridBounds.Right);
+        var randomY = _random.NextFloat(gridBounds.Bottom, gridBounds.Top);
+
+        var pos = new Vector2(randomX, randomY);
+
+        _xform.SetWorldPosition(args.Performer, pos);
+
+
+        MapCoordinates coords = _xform.GetMapCoordinates(args.Performer);
+
+        Spawn(args.Effect, coords);
+
+        _audio.PlayPvs(args.SoundSpecifier, args.Performer);
+
+        args.Handled = true;
+    }
+}

--- a/Content.Server/_Harmony/RandomTeleport/RandomTeleportSystem.cs
+++ b/Content.Server/_Harmony/RandomTeleport/RandomTeleportSystem.cs
@@ -33,7 +33,6 @@ public sealed class RandomTeleportSystem : EntitySystem
         var pos = new Vector2(randomX, randomY);
 
         _xform.SetWorldPosition(args.Performer, pos);
-
         MapCoordinates coords = _xform.GetMapCoordinates(args.Performer);
 
         Spawn(args.Effect, coords);

--- a/Content.Server/_Harmony/RandomTeleport/RandomTeleportSystem.cs
+++ b/Content.Server/_Harmony/RandomTeleport/RandomTeleportSystem.cs
@@ -37,7 +37,6 @@ public sealed class RandomTeleportSystem : EntitySystem
 
         _xform.SetWorldPosition(args.Performer, pos);
 
-
         MapCoordinates coords = _xform.GetMapCoordinates(args.Performer);
 
         Spawn(args.Effect, coords);

--- a/Content.Server/_Harmony/RandomTeleport/RandomTeleportSystem.cs
+++ b/Content.Server/_Harmony/RandomTeleport/RandomTeleportSystem.cs
@@ -1,6 +1,5 @@
 ﻿using System.Numerics;
 using Content.Shared._Harmony.RandomTeleport;
-using Content.Shared.Administration.Logs;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Map;
 using Robust.Shared.Random;
@@ -10,9 +9,7 @@ namespace Content.Server._Harmony.RandomTeleport;
 public sealed class RandomTeleportSystem : EntitySystem
 {
     [Dependency] private readonly IRobustRandom _random = default!;
-    [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
-    [Dependency] private readonly EntityLookupSystem _lookup = default!;
     [Dependency] private readonly SharedTransformSystem _xform = default!;
 
     public override void Initialize()

--- a/Content.Shared/_Harmony/RandomTeleport/RandomTeleportEvents.cs
+++ b/Content.Shared/_Harmony/RandomTeleport/RandomTeleportEvents.cs
@@ -6,7 +6,7 @@ namespace Content.Shared._Harmony.RandomTeleport;
 public sealed partial class RandomTeleportEvent : InstantActionEvent
 {
     [DataField]
-    public float Radius = 7;
+    public float Radius = 4;
 
     [DataField]
     public string Effect = "Smoke";

--- a/Content.Shared/_Harmony/RandomTeleport/RandomTeleportEvents.cs
+++ b/Content.Shared/_Harmony/RandomTeleport/RandomTeleportEvents.cs
@@ -3,14 +3,26 @@ using Robust.Shared.Audio;
 
 namespace Content.Shared._Harmony.RandomTeleport;
 
+/// <summary>
+/// Teleports the user randomly on use
+/// </summary>
 public sealed partial class RandomTeleportEvent : InstantActionEvent
 {
+    /// <summary>
+    /// Distance you travel
+    /// </summary>
     [DataField]
     public float Radius = 4;
 
+    /// <summary>
+    /// Effect spawned at teleportation site
+    /// </summary>
     [DataField]
     public string Effect = "Smoke";
 
+    /// <summary>
+    /// Audio played at teleportation site
+    /// </summary>
     [DataField]
     public SoundSpecifier SoundSpecifier =  new SoundPathSpecifier("/Audio/Magic/blink.ogg");
 }

--- a/Content.Shared/_Harmony/RandomTeleport/RandomTeleportEvents.cs
+++ b/Content.Shared/_Harmony/RandomTeleport/RandomTeleportEvents.cs
@@ -18,7 +18,7 @@ public sealed partial class RandomTeleportEvent : InstantActionEvent
     /// Effect spawned at teleportation site
     /// </summary>
     [DataField]
-    public string Effect = "Smoke";
+    public EntProtoId Effect = "Smoke";
 
     /// <summary>
     /// Audio played at teleportation site

--- a/Content.Shared/_Harmony/RandomTeleport/RandomTeleportEvents.cs
+++ b/Content.Shared/_Harmony/RandomTeleport/RandomTeleportEvents.cs
@@ -1,5 +1,6 @@
 ﻿using Content.Shared.Actions;
 using Robust.Shared.Audio;
+using Robust.Shared.Prototypes;
 
 namespace Content.Shared._Harmony.RandomTeleport;
 

--- a/Content.Shared/_Harmony/RandomTeleport/RandomTeleportEvents.cs
+++ b/Content.Shared/_Harmony/RandomTeleport/RandomTeleportEvents.cs
@@ -1,0 +1,16 @@
+﻿using Content.Shared.Actions;
+using Robust.Shared.Audio;
+
+namespace Content.Shared._Harmony.RandomTeleport;
+
+public sealed partial class RandomTeleportEvent : InstantActionEvent
+{
+    [DataField]
+    public float Radius = 7;
+
+    [DataField]
+    public string Effect = "Smoke";
+
+    [DataField]
+    public SoundSpecifier SoundSpecifier =  new SoundPathSpecifier("/Audio/Magic/blink.ogg");
+}

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/airlocks.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/airlocks.yml
@@ -125,6 +125,10 @@
     department: Security
   - type: Wires
     layoutId: AirlockSecurity
+  # Harmony Start
+  - type: WiresPanelSecurity
+    securityLevel: medSecurity
+  # Harmony End
 
 - type: entity
   parent: Airlock
@@ -302,6 +306,10 @@
     department: Security
   - type: Wires
     layoutId: AirlockSecurity
+  # Harmony Start
+  - type: WiresPanelSecurity
+    securityLevel: medSecurity
+  # Harmony End
 
 - type: entity
   parent: AirlockSecurityGlass # see standard

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/airlocks.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/airlocks.yml
@@ -125,10 +125,6 @@
     department: Security
   - type: Wires
     layoutId: AirlockSecurity
-  # Harmony Start
-  - type: WiresPanelSecurity
-    securityLevel: medSecurity
-  # Harmony End
 
 - type: entity
   parent: Airlock
@@ -306,10 +302,6 @@
     department: Security
   - type: Wires
     layoutId: AirlockSecurity
-  # Harmony Start
-  - type: WiresPanelSecurity
-    securityLevel: medSecurity
-  # Harmony End
 
 - type: entity
   parent: AirlockSecurityGlass # see standard

--- a/Resources/Prototypes/Magic/teleport_spells.yml
+++ b/Resources/Prototypes/Magic/teleport_spells.yml
@@ -2,23 +2,27 @@
   parent: BaseAction
   id: ActionBlink
   name: Blink
-  description: Teleport to the clicked location.
+  description: Randomly teleports you # Harmony Change
   components:
   - type: Action
-    useDelay: 10
+    useDelay: 1 # Harmony Change 10 -> 1
     itemIconStyle: BigAction
     sound: !type:SoundPathSpecifier
       path: /Audio/Magic/blink.ogg
     icon:
       sprite: Objects/Magic/magicactions.rsi
       state: blink
-  - type: TargetAction
-    range: 16 # default examine-range.
+  # Harmony Start
+  #- type: TargetAction
+    #range: 16 # default examine-range.
     # ^ should probably add better validation that the clicked location is on the users screen somewhere,
-    repeat: false
-    checkCanAccess: false
-  - type: WorldTargetAction
-    event: !type:TeleportSpellEvent
+    #repeat: false
+    #checkCanAccess: false
+  #- type: WorldTargetAction
+    #event: !type:TeleportSpellEvent
+  - type: InstantAction
+    event: !type:RandomTeleportEvent # Harmony Change - changes blink from controlled teleport to uncontrolled teleport
+  # Harmony End
 
 # TODO: Second level upgrade sometime that allows swapping with all objects
 - type: entity

--- a/Resources/Prototypes/Magic/teleport_spells.yml
+++ b/Resources/Prototypes/Magic/teleport_spells.yml
@@ -2,7 +2,7 @@
   parent: BaseAction
   id: ActionBlink
   name: Blink
-  description: Randomly teleports you # Harmony Change
+  description: Randomly teleports you. # Harmony Change
   components:
   - type: Action
     useDelay: 1 # Harmony Change 10 -> 1


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
Changes blink to be a random teleport instead of a certified ninja teleport knock-off
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Right now jaunt and blink are the exact same thing basically and this makes them a bit diffrent (also this is a lot more "fair" for 1WC)
## Technical details
<!-- Summary of code changes for easier review. -->
Adds random teleport system, a pretty simple system for randomly picking a coordinate then bringing you to do it as well as playing the sound and effect
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

https://github.com/user-attachments/assets/b9412ea2-5c50-4d83-b2d6-6ab9689c32e7


## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Blink now randomly teleports you instead of a guranteed teleport