### PR TITLE
Adds cycle verb to revolvers

### DIFF
--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Revolver.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Revolver.cs
@@ -223,6 +223,21 @@ public partial class SharedGunSystem
             // Category = VerbCategory.G,
             Act = () => SpinRevolver(uid, component, args.User)
         });
+
+        // Harmony start - adds new cycle verb
+        args.Verbs.Add(new AlternativeVerb()
+        {
+            Text = Loc.GetString("gun-revolver-cycle"),
+            // Category = VerbCategory.G,
+            Act = () =>
+            {
+                Cycle(component);
+                Popup(Loc.GetString("gun-revolver-cycled"), uid, args.User);
+                UpdateAmmoCount(uid, prediction: false);
+                Dirty(uid, component);
+            }
+        });
+        // Harmony End
     }
 
     private bool AnyRevolverCartridges(RevolverAmmoProviderComponent component)

--- a/Resources/Locale/en-US/_Harmony/weapons/ranged/gun.ftl
+++ b/Resources/Locale/en-US/_Harmony/weapons/ranged/gun.ftl
@@ -1,0 +1,2 @@
+﻿gun-revolver-cycle = Cycle
+gun-revolver-cycled = Cycled

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/airlocks.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/airlocks.yml
@@ -125,6 +125,10 @@
     department: Security
   - type: Wires
     layoutId: AirlockSecurity
+  # Harmony Start
+  - type: WiresPanelSecurity
+    securityLevel: medSecurity
+  # Harmony End
 
 - type: entity
   parent: Airlock
@@ -302,6 +306,10 @@
     department: Security
   - type: Wires
     layoutId: AirlockSecurity
+  # Harmony Start
+  - type: WiresPanelSecurity
+    securityLevel: medSecurity
+  # Harmony End
 
 - type: entity
   parent: AirlockSecurityGlass # see standard

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/airlocks.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/airlocks.yml
@@ -125,10 +125,6 @@
     department: Security
   - type: Wires
     layoutId: AirlockSecurity
-  # Harmony Start
-  - type: WiresPanelSecurity
-    securityLevel: medSecurity
-  # Harmony End
 
 - type: entity
   parent: Airlock
@@ -306,10 +302,6 @@
     department: Security
   - type: Wires
     layoutId: AirlockSecurity
-  # Harmony Start
-  - type: WiresPanelSecurity
-    securityLevel: medSecurity
-  # Harmony End
 
 - type: entity
   parent: AirlockSecurityGlass # see standard


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
Adds simple cycle verb to revolvers
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It didnt have this and it should so
## Technical details
<!-- Summary of code changes for easier review. -->
Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Revolver.cs - adds simple verb that cycles on use
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
https://github.com/user-attachments/assets/92316878-9675-426d-987d-8b1c97753ed1

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Revolvers can now be cycled in the right-click menu