### PR TITLE
updates hyperzine description

### DIFF
--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -403,6 +403,7 @@ uplink-nocturine-chemistry-bottle-desc = A chemical that puts your target straig
 uplink-stimpack-name = Hyperzine Injector
 ## Harmony - changed hyperzine injector description
 uplink-stimpack-desc = The legendary chemical produced by Donk Co. for the Syndicate. Injecting yourself with this will increase your run speed and let you recover from stuns faster for 60 seconds.
+
 uplink-stimkit-name = Hyperzine Injector Kit
 ## Harmony - changed hyperzine microinjector description
 uplink-stimkit-desc = A medkit containing 6 hyperzine microinjectors, which each inject you with enough hyperzine to last for 30 seconds.


### PR DESCRIPTION
## About the PR
hyperzine metabolization was changed from 1 -> 0.5 in a harmony PR so upstream descriptions do not reflect actual values represented in game

## Why / Balance
bugfix

## Technical details
just modifies uplink-catalog.ftl in upstream namespace and adds harmony comments (god i hate .ftl comments)

## Media
<img width="749" height="94" alt="1" src="https://github.com/user-attachments/assets/c190b769-9c6a-4bec-a007-d093b1978fd6" />
<img width="742" height="114" alt="2" src="https://github.com/user-attachments/assets/6fd1283d-c6f6-427e-9112-9ce4a7ace89a" />

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- fix: Fixed incorrect hyperzine uplink descriptions