### PR TITLE
Updates Ingame Blue Alert Text To Allign With Harmony SoP

### DIFF
--- a/Resources/Locale/en-US/alert-levels/alert-levels.ftl
+++ b/Resources/Locale/en-US/alert-levels/alert-levels.ftl
@@ -11,7 +11,7 @@ alert-level-blue = Blue
 # Start Harmony Change - Align description with SOP
 # alert-level-blue-announcement = There is a confirmed threat to the station. Security should perform random checks. Crewmembers are advised to be vigilant and report suspicious activity to security.
 alert-level-blue-announcement = There is a suspected threat to the station. Security can now perform random checks. Crewmembers are advised to be vigilant and report suspicious activity to security.
-# End Harmony Change - Allign description with SOP
+# End Harmony Change - Align description with SOP
 alert-level-blue-instructions = Crewmembers are advised to be vigilant and report suspicious activity to security.
 
 alert-level-red = Red


### PR DESCRIPTION
## About the PR
Right now, the Blue Alert text does not allign with Harmony's SOP. This PR changes that so they match.

SoP states:
There is a **_suspected_** threat on-board the station, or at a nearby location in space. This includes any signs of hostile activity that have not caused any damage to station or crew, but nonetheless seem present.

However the ingame text states:
There is a **_confirmed_** threat to the station. Security should perform random checks. Crewmembers are advised to be vigilant and report suspicious activity to security.

## Why / Balance
Alligns expectations from the ingame announcement system with the SoP as outlined on the Harmony wiki/guidebook.

## Technical details
-comments out the original text in Resources/Locale/en-US/alert-levels/alert-levels.ftl
-adds a new alert description in the same file.

## Media
![image](https://github.com/user-attachments/assets/86922565-edae-4472-b5ac-f08cc050d8be)


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Edits the description of Blue Alert ingame so that it matches Harmony's SoP.

