### PR TITLE
Traitor tweaks: Uplink discounts

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -321,9 +321,11 @@
   name: uplink-singularity-grenade-name
   description: uplink-singularity-grenade-desc
   productEntity: SingularityGrenade
-#  discountCategory: usualDiscounts # Harmony change - de-bloats discounts
+# Start Harmony change - de-bloats discounts
+#  discountCategory:
 #  discountDownTo:
 #    Telecrystal: 1
+# End Harmony change
   cost:
     Telecrystal: 2
   categories:
@@ -334,9 +336,11 @@
   name: uplink-whitehole-grenade-name
   description: uplink-whitehole-grenade-desc
   productEntity: WhiteholeGrenade
-#  discountCategory: usualDiscounts # Harmony change - de-bloats discounts
+# Start Harmony change - de-bloats discounts
+#  discountCategory: usualDiscounts
 #  discountDownTo:
 #    Telecrystal: 1
+# End Harmony change
   cost:
     Telecrystal: 2
   categories:
@@ -660,9 +664,11 @@
   description: uplink-hypodart-desc
   icon: { sprite: /Textures/Objects/Fun/Darts/dart_red.rsi, state: icon }
   productEntity: HypoDartBox
-#  discountCategory: veryRareDiscounts # Harmony change - de-bloats discounts
+# Start Harmony change - de-bloats discounts
+#  discountCategory: veryRareDiscounts
 #  discountDownTo:
 #    Telecrystal: 1
+# End Harmony change
   cost:
     Telecrystal: 2
   categories:
@@ -890,9 +896,11 @@
   name: uplink-ultrabright-lantern-name
   description: uplink-ultrabright-lantern-desc
   productEntity: LanternFlash
-#  discountCategory: usualDiscounts # Harmony change - de-bloats discounts
+# Start Harmony change - de-bloats discounts
+#  discountCategory: usualDiscounts
 #  discountDownTo:
 #    Telecrystal: 1
+# End Harmony change
   cost:
     Telecrystal: 2
   categories:
@@ -1597,9 +1605,11 @@
   name: uplink-black-jetpack-name
   description: uplink-black-jetpack-desc
   productEntity: JetpackBlackFilled
-#  discountCategory: veryRareDiscounts # Harmony change - de-bloats discounts
+# Start Harmony change - de-bloats discounts
+#  discountCategory:
 #  discountDownTo:
 #    Telecrystal: 1
+# End Harmony change
   cost:
     Telecrystal: 2
   categories:


### PR DESCRIPTION
## About the PR
My now reformed continuation of https://github.com/ss14-harmony/ss14-harmony/pull/655 with some additional things thrown in.

This PR de-bloats uplink discounts, makes rolling rarer discounts more impactful and reduces rarity of certain offers via these changes:

1. Removed Singularity and Whitehole grenade discount (Usual -> Nothing)
2. Removed Martyr Module discount (Very Rare -> Nothing)
3. Removed Flash Lantern discount (Usual -> Nothing)
4. Removed Hypodart Box discount (Very Rare -> Nothing)
5. Removed Jetpack discount (Very Rare -> Nothing)
6. Changed Agent ID discount (Very Rare -> Rare)
7. Changed Scram Implanter discount (Very Rare -> Rare)
8. Changed No-Slips discount (Very Rare -> Rare)
9. Removed C-4 discount (Very Rare -> Nothing)

## Why / Balance
**_I wrote this section while very tired, there can be mistakes here and there._**

I'm going to put forward a few of my takes here. Whether you agree with them or not, they were the reason I made these changes.

_Discounts that can't atleast slightly affect the decision of a traitor to pick them if they appear shouldn't exist._

Muddying the pool with unneeded discounts only serves to make the game more unfun for players because it reduces their impact. While they should never ALWAYS be good, they should at least be reliably average for traitors who don't mind trying out alternative approaches other than their usual strategy. 

I think that Very Rare discounts should be reserved for items that are either already steep in price, or "power" items such as the Bulldog and C-20, OR items such as the emag which can make or break certain solo loadouts when discounted. Anything that muddies this pool of discounts serves only to frustrate players when they roll the already astronomically low very rare discount chance and get total garbage.

Items that cost 2-3 TC before discounts have no purpose being discounted unless they are already pretty good for their current price, they only serve to muddle the pool. The likely reason for these items being discounted would be to "encourage their use", but a 1 TC difference is not going to make or break an item that is already dirt cheap if the item isn't even useful in the first place.

**Going to go through the specific changes point by point:**

1. These have practically never been used since their rework, ever. I think I have seen them used twice for no-grav trolling and evac bombing. They appear in the uplink, to encourage their use I suppose? But nobody would ever buy these for a legitimate strategy either way, discounted or not.
2. I did not see this item as fit to recieve a Very Rare discount, as while it can be used for gibbing and spacing, it also requires a hefty investment in the form of an emag (And an access breaker if you aren't a scientist). Such a rare sale for only a 1-2 TC maximum discount as well, when that difference would never break or make a purchase of this anyway..?
3. This item should be in the "useless" category, but it technically has a gimmicky use as a flash. Why is this so frequently discounted when nobody uses it anyway, and it ALREADY has a dirt-cheap cost? When would a 1 TC difference EVER matter in the context of buying this? This is is plain bloat.
4. In my entire history of playing Space Station 14 I think I have seen this purchase mentioned about three times and seen it used twice. It's not even a good discount, you have a 2% chance to get a single dart for 1 TC less? This is even more evident bloat than the Flash Lantern discount.
5. Pretty much the same argument as No.4. You can very easily steal a mini jetpack from EVA and there is not a single situation I can think of for a traitor where this would make or break a purchase. Bloat. (Are these the items that are supposed to compete with a Chinalake discount..?)
6. It is priced at 3 TC and even being discounted down to 1 would still not make or break this purchase for most people, especially since the removal of thieving gloves from traitors, which makes getting stealthy accesses through stealing PDA's impossible.. It is still a powerful item and the discount may be worth it to some people in certain cases, which is why I opted to turn it into a Rare discount instead.
7. This item is not powerful enough in my opinion to warrant being a Very Rare discount. It does still qualify for a discount, since it has a high base price, which is why I opted to make it a Rare discount instead of removing it altogether.
8. No slips qualify as being a good enough item for their price to still warrant a small discount being useful to certain people, but isn't a gamebreaking discount on its' own to warrant being put into Very Rare, so I decided to make it a Rare discount instead
9. C-4 does not deserve to be put into the "Very Rare" category as it is 1.  already a dirt cheap item, and 2. it is significantly weaker than the upstream counterpart.

## Technical details
All changes made in uplink_catalog.yml in upstream namespace, added harmony comments where applicable

## Media

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- tweak: Certain uplink discounts were adjusted or removed to be more reliably average.