### PR TITLE
Reduce test parallelism count

### DIFF
--- a/Content.IntegrationTests/AssemblyInfo.cs
+++ b/Content.IntegrationTests/AssemblyInfo.cs
@@ -5,4 +5,4 @@
 // https://github.com/dotnet/runtime/issues/107197
 // So we can't really parallelize integration tests harder either until the runtime fixes that,
 // *or* we fix serv3 to not spam expression trees.
-[assembly: LevelOfParallelism(3)]
+[assembly: LevelOfParallelism(2)] // Harmony - reduce from 3 to 2


### PR DESCRIPTION
What could go wrong in trusting a random GitHub comment telling me this is better