### PR TITLE
Genpop IDs Now Send a Radio Message on Expiry

### DIFF
--- a/Content.Server/Access/Systems/IdCardSystem.cs
+++ b/Content.Server/Access/Systems/IdCardSystem.cs
@@ -11,6 +11,7 @@ using Content.Shared.Popups;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Content.Server.Kitchen.EntitySystems;
+using Content.Server.Radio.EntitySystems; //Harmony Change - For Radio Expire ID Message
 
 namespace Content.Server.Access.Systems;
 
@@ -22,7 +23,7 @@ public sealed class IdCardSystem : SharedIdCardSystem
     [Dependency] private readonly IAdminLogManager _adminLogger = default!;
     [Dependency] private readonly ChatSystem _chat = default!;
     [Dependency] private readonly MicrowaveSystem _microwave = default!;
-
+    [Dependency] private readonly RadioSystem _radio = default!; //Harmony Change - For Radio Expire ID Message
     public override void Initialize()
     {
         base.Initialize();
@@ -112,5 +113,12 @@ public sealed class IdCardSystem : SharedIdCardSystem
                 ChatTransmitRange.Normal,
                 true);
         }
+        // Harmony Change Start - ID card radio system
+        if (ent.Comp.ExpireMessageRadio != null)
+        {
+            var message = Loc.GetString(ent.Comp.ExpireMessageRadio, ("name", ent.Owner));
+            _radio.SendRadioMessage(ent.Owner, message, ent.Comp.RadioChannel, ent.Owner);
+        }
+        // Harmony change end
     }
 }

--- a/Content.Server/Access/Systems/IdCardSystem.cs
+++ b/Content.Server/Access/Systems/IdCardSystem.cs
@@ -24,6 +24,7 @@ public sealed class IdCardSystem : SharedIdCardSystem
     [Dependency] private readonly ChatSystem _chat = default!;
     [Dependency] private readonly MicrowaveSystem _microwave = default!;
     [Dependency] private readonly RadioSystem _radio = default!; //Harmony Change - For Radio Expire ID Message
+
     public override void Initialize()
     {
         base.Initialize();

--- a/Content.Shared/Access/Components/ExpireIdCardComponent.cs
+++ b/Content.Shared/Access/Components/ExpireIdCardComponent.cs
@@ -2,7 +2,7 @@ using Content.Shared.Access.Systems;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
-using Content.Shared.Radio; /// Harmony Change - For Radio Message
+using Content.Shared.Radio; // Harmony Change - For Radio Message
 
 namespace Content.Shared.Access.Components;
 
@@ -43,7 +43,7 @@ public sealed partial class ExpireIdCardComponent : Component
     [DataField]
     public LocId? ExpireMessage;
 
-    /// Harmony Change Start - Radio Channel for Temp IDs
+    // Harmony Change Start - Radio Channel for Temp IDs
 
     /// <summary>
     /// Line spoken by the card on a radio channel when it expires
@@ -61,6 +61,7 @@ public sealed partial class ExpireIdCardComponent : Component
     /// Decides if we want to call a radio or not, off by default.
     /// </summary>
     [DataField]
-    public bool AlertRadio = false;
-    /// Harmony Change End
+    public bool AlertRadio;
+
+    // Harmony Change End
 }

--- a/Content.Shared/Access/Components/ExpireIdCardComponent.cs
+++ b/Content.Shared/Access/Components/ExpireIdCardComponent.cs
@@ -59,6 +59,7 @@ public sealed partial class ExpireIdCardComponent : Component
 
     /// <summary>
     /// Decides if we want to call a radio or not, off by default.
+    /// We'd rather not want any potential expansions to this system to automatically ping Security, after all
     /// </summary>
     [DataField]
     public bool AlertRadio;

--- a/Content.Shared/Access/Components/ExpireIdCardComponent.cs
+++ b/Content.Shared/Access/Components/ExpireIdCardComponent.cs
@@ -2,6 +2,7 @@ using Content.Shared.Access.Systems;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+using Content.Shared.Radio; /// Harmony Change - For Radio Message
 
 namespace Content.Shared.Access.Components;
 
@@ -41,4 +42,25 @@ public sealed partial class ExpireIdCardComponent : Component
     /// </summary>
     [DataField]
     public LocId? ExpireMessage;
+
+    /// Harmony Change Start - Radio Channel for Temp IDs
+
+    /// <summary>
+    /// Line spoken by the card on a radio channel when it expires
+    /// </summary>
+    [DataField]
+    public LocId? ExpireMessageRadio;
+
+    /// <summary>
+    /// What radio channel do we broadcast our expire message on?
+    /// </summary>
+    [DataField]
+    public ProtoId<RadioChannelPrototype> RadioChannel = "Security";
+
+    /// <summary>
+    /// Decides if we want to call a radio or not, off by default.
+    /// </summary>
+    [DataField]
+    public bool AlertRadio = false;
+    /// Harmony Change End
 }

--- a/Resources/Locale/en-US/_Harmony/access/components/genpop.ftl
+++ b/Resources/Locale/en-US/_Harmony/access/components/genpop.ftl
@@ -1,0 +1,1 @@
+genpop-prisoner-id-expire-radio = {$name} has now expired, as the prisoner's sentence is now complete.

--- a/Resources/Locale/en-US/_Harmony/access/components/genpop.ftl
+++ b/Resources/Locale/en-US/_Harmony/access/components/genpop.ftl
@@ -1,1 +1,1 @@
-genpop-prisoner-id-expire-radio = {$name} has now expired, as the prisoner's sentence is now complete.
+genpop-prisoner-id-expire-radio = {$name} has now expired, as the prisoner's sentence is complete.

--- a/Resources/Locale/en-US/_Harmony/access/components/genpop.ftl
+++ b/Resources/Locale/en-US/_Harmony/access/components/genpop.ftl
@@ -1,1 +1,1 @@
-genpop-prisoner-id-expire-radio = {$name} has now expired, as the prisoner's sentence is complete.
+genpop-prisoner-id-expire-radio = {$name} has expired, as the prisoner's sentence is complete.

--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -749,6 +749,13 @@
     expireMessage: genpop-prisoner-id-expire
     expiredAccess:
     - GenpopLeave
+    #Harmony Change Start - Adds Radio Alert Systems
+    alertRadio: true
+    expireMessageRadio: genpop-prisoner-id-expire-radio
+  - type: ActiveRadio
+    channels:
+    - Security
+    #Harmony Change End
   - type: Speech
     speechVerb: Robotic
   - type: Tag


### PR DESCRIPTION
## About the PR
Genpop temporary ids now have a radio component tied to them that spits out a message on the security radio when a prisoners sentence has expired.

EDIT 11/07/2026: Changes made in this PR are dual licensed via MIT and AGPL

## Why / Balance
As it stands, if you are not manually tracking a prisoners sentence with your own timer, or you see them leave genpop, theres no indication a prisoner has finished their sentence. This means that everyone on the sec channel now knows when a prisoner is able to leave. This prevents instances I've seen in the past where an officer stops someone in a corridor presumabing they're a prison escapee, but its just a case of the Warden didn't notice they were done with their sentence.

## Technical details
- Content.server/Access/Systems/IdCardSystem.cs has been modified to include relevant radio capablities on the id card.
- Content.Shared/Access/Components/ExpireIdCardComponent.cs modified to add datafields for various relevant fields (namely the expire message and what channel to play it on). This keeps it compatible with any changes to the generic temporary ID card system in future.
- Resources/Locale/en-US/_Harmony/access/components/genpop.ftl has been created to hold relevant text fields.
- Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml has been modified to add relevant type tags to add the radio feature to the ID card.

## Media

<img width="431" height="151" alt="testmedia" src="https://github.com/user-attachments/assets/237be350-deee-41d6-8c21-867a7e44ca91" />


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**

:cl:
- tweak: When a genpop id's sentence ends, a radio message is now broadcast on the security channel.


