### PR TITLE
Adds Casino Visitor Shuttle: NT-Royale

### DIFF
--- a/Resources/Maps/_Harmony/Shuttles/ShuttleEvent/casino.yml
+++ b/Resources/Maps/_Harmony/Shuttles/ShuttleEvent/casino.yml
@@ -1,0 +1,2374 @@
+meta:
+  format: 7
+  category: Grid
+  engineVersion: 266.0.0
+  forkId: harmony
+  forkVersion: 877a5f009fb184cb7de7e8b9b7bcf3b4156772d3
+  time: 08/22/2025 01:53:20
+  entityCount: 331
+maps: []
+grids:
+- 1
+orphans:
+- 1
+nullspace: []
+tilemap:
+  3: Space
+  5: FloorDark
+  7: FloorGold
+  1: FloorShuttleBlack
+  4: FloorTechMaint
+  0: FloorWood
+  6: Lattice
+  2: Plating
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: NT-Royale
+    - type: Transform
+      pos: -0.484375,-0.46875
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        0,0:
+          ind: 0,0
+          tiles: AAAAAAAAAAAAAAAAAAABAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAQAAAAAAAACAAAAAAAABAAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAgAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAIAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAQAAAAAAAAUAAAAAAAACAAAAAAAABgAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAEAAAAAAAAFAAAAAAAAAgAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAAFAAAAAAAAAgAAAAAAAAIAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAABQAAAAAAAAIAAAAAAAAGAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAIAAAAAAAAGAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAA==
+          version: 7
+        -1,0:
+          ind: -1,0
+          tiles: AwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAACAAAAAAAABwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAgAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAIAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAACAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAgAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAEAAAAAAAACAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAAGAAAAAAAAAgAAAAAAAAUAAAAAAAABAAAAAAAAAQAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAIAAAAAAAAFAAAAAAAAAQAAAAAAAAEAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAACAAAAAAAAAgAAAAAAAAUAAAAAAAABAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAABgAAAAAAAAIAAAAAAAAFAAAAAAAABQAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAAGAAAAAAAAAgAAAAAAAAIAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAA==
+          version: 7
+        -1,-1:
+          ind: -1,-1
+          tiles: AwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAABgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAYAAAAAAAACAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAAEAAAAAAAAAgAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAgAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAIAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAACAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+        0,-1:
+          ind: 0,-1
+          tiles: AwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAgAAAAAAAAIAAAAAAAAGAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAAEAAAAAAAABAAAAAAAAAIAAAAAAAAGAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAIAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAABAAAAAAAAAIAAAAAAAAEAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAA==
+          version: 7
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+      dampingModifier: 0.25
+    - type: ImplicitRoof
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinCornerNe
+          decals:
+            0: 1,2
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinCornerNw
+          decals:
+            1: -3,2
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinCornerSe
+          decals:
+            3: 1,-2
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinCornerSw
+          decals:
+            2: -3,-2
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinLineE
+          decals:
+            13: 1,1
+            14: 1,0
+            15: 1,-1
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinLineN
+          decals:
+            10: -2,2
+            11: -1,2
+            12: 0,2
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinLineS
+          decals:
+            4: -2,-2
+            5: -1,-2
+            6: 0,-2
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinLineW
+          decals:
+            7: -3,-1
+            8: -3,0
+            9: -3,1
+    - type: GridAtmosphere
+      version: 2
+      data:
+        tiles:
+          0,0:
+            0: 30711
+          0,-1:
+            0: 63344
+          -1,0:
+            0: 65535
+          0,1:
+            0: 13063
+            1: 2048
+          -1,1:
+            0: 61007
+          0,2:
+            0: 17
+            1: 576
+          -1,2:
+            0: 204
+            1: 528
+          1,0:
+            0: 48
+          1,-1:
+            0: 12288
+          -2,1:
+            1: 2048
+          -1,-1:
+            0: 65524
+          -2,-2:
+            1: 32768
+          -1,-2:
+            1: 16
+            0: 60416
+          0,-2:
+            0: 12544
+            1: 32832
+        uniqueMixes:
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          immutable: True
+          moles:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+- proto: AirAlarm
+  entities:
+  - uid: 324
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-1.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 326
+      - 325
+      - 275
+      - 273
+      - 276
+      - 274
+      - 330
+      - 329
+      - 328
+    - type: Fixtures
+      fixtures: {}
+  - uid: 327
+    components:
+    - type: Transform
+      pos: 1.5,8.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 326
+      - 283
+      - 284
+      - 331
+    - type: Fixtures
+      fixtures: {}
+- proto: AirCanister
+  entities:
+  - uid: 277
+    components:
+    - type: Transform
+      pos: 1.5,-4.5
+      parent: 1
+- proto: Airlock
+  entities:
+  - uid: 221
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+- proto: AirlockExternalGlass
+  entities:
+  - uid: 215
+    components:
+    - type: Transform
+      pos: 3.5,-0.5
+      parent: 1
+  - uid: 216
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 1
+- proto: AirlockGlassShuttle
+  entities:
+  - uid: 217
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,1.5
+      parent: 1
+  - uid: 218
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-0.5
+      parent: 1
+- proto: AirlockMaint
+  entities:
+  - uid: 244
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 1
+- proto: AirSensor
+  entities:
+  - uid: 328
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 324
+  - uid: 331
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 327
+- proto: APCBasic
+  entities:
+  - uid: 121
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-3.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: Ashtray
+  entities:
+  - uid: 281
+    components:
+    - type: Transform
+      pos: 0.15625,-0.46119165
+      parent: 1
+- proto: AtmosDeviceFanDirectional
+  entities:
+  - uid: 237
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-0.5
+      parent: 1
+  - uid: 241
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,1.5
+      parent: 1
+- proto: BarSign
+  entities:
+  - uid: 204
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: BarSpoon
+  entities:
+  - uid: 208
+    components:
+    - type: Transform
+      pos: 2.101478,4.632683
+      parent: 1
+- proto: Bed
+  entities:
+  - uid: 109
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 1
+- proto: BedsheetBlack
+  entities:
+  - uid: 112
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 1
+- proto: BoozeDispenser
+  entities:
+  - uid: 101
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+- proto: CableApcExtension
+  entities:
+  - uid: 135
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+  - uid: 136
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 1
+  - uid: 137
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 1
+  - uid: 138
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 1
+  - uid: 139
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 140
+    components:
+    - type: Transform
+      pos: -0.5,-0.5
+      parent: 1
+  - uid: 141
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 142
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 143
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 1
+  - uid: 144
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 1
+  - uid: 145
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 146
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 147
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 1
+  - uid: 148
+    components:
+    - type: Transform
+      pos: -0.5,9.5
+      parent: 1
+  - uid: 149
+    components:
+    - type: Transform
+      pos: 0.5,8.5
+      parent: 1
+  - uid: 150
+    components:
+    - type: Transform
+      pos: -0.5,8.5
+      parent: 1
+  - uid: 151
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 1
+  - uid: 152
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 1
+  - uid: 153
+    components:
+    - type: Transform
+      pos: -0.5,7.5
+      parent: 1
+  - uid: 154
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 155
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 156
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 157
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 1
+  - uid: 158
+    components:
+    - type: Transform
+      pos: 4.5,1.5
+      parent: 1
+  - uid: 159
+    components:
+    - type: Transform
+      pos: 5.5,1.5
+      parent: 1
+  - uid: 160
+    components:
+    - type: Transform
+      pos: 1.5,-0.5
+      parent: 1
+  - uid: 161
+    components:
+    - type: Transform
+      pos: 2.5,-0.5
+      parent: 1
+  - uid: 162
+    components:
+    - type: Transform
+      pos: 3.5,-0.5
+      parent: 1
+  - uid: 163
+    components:
+    - type: Transform
+      pos: 4.5,-0.5
+      parent: 1
+  - uid: 164
+    components:
+    - type: Transform
+      pos: 5.5,-0.5
+      parent: 1
+  - uid: 165
+    components:
+    - type: Transform
+      pos: -0.5,-2.5
+      parent: 1
+  - uid: 166
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 1
+  - uid: 167
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 1
+  - uid: 168
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 1
+  - uid: 169
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 1
+  - uid: 170
+    components:
+    - type: Transform
+      pos: -3.5,1.5
+      parent: 1
+  - uid: 171
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 1
+  - uid: 172
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 1
+  - uid: 173
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 1
+  - uid: 174
+    components:
+    - type: Transform
+      pos: -3.5,-0.5
+      parent: 1
+  - uid: 175
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 1
+  - uid: 176
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 177
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 178
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 179
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 1
+  - uid: 180
+    components:
+    - type: Transform
+      pos: -2.5,6.5
+      parent: 1
+  - uid: 181
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 1
+  - uid: 182
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 1
+  - uid: 183
+    components:
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 1
+  - uid: 184
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 185
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 186
+    components:
+    - type: Transform
+      pos: 1.5,-2.5
+      parent: 1
+  - uid: 187
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 1
+  - uid: 188
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 1
+  - uid: 189
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 1
+  - uid: 190
+    components:
+    - type: Transform
+      pos: -2.5,-4.5
+      parent: 1
+  - uid: 191
+    components:
+    - type: Transform
+      pos: -0.5,-4.5
+      parent: 1
+  - uid: 192
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 1
+  - uid: 193
+    components:
+    - type: Transform
+      pos: 1.5,-4.5
+      parent: 1
+  - uid: 194
+    components:
+    - type: Transform
+      pos: -0.5,1.5
+      parent: 1
+- proto: CableHV
+  entities:
+  - uid: 117
+    components:
+    - type: Transform
+      pos: -1.5,-5.5
+      parent: 1
+  - uid: 122
+    components:
+    - type: Transform
+      pos: 0.5,-5.5
+      parent: 1
+  - uid: 128
+    components:
+    - type: Transform
+      pos: -0.5,-5.5
+      parent: 1
+  - uid: 323
+    components:
+    - type: Transform
+      pos: 1.5,-5.5
+      parent: 1
+- proto: CableMV
+  entities:
+  - uid: 118
+    components:
+    - type: Transform
+      pos: -1.5,-5.5
+      parent: 1
+  - uid: 120
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 1
+  - uid: 130
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 1
+  - uid: 131
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 1
+  - uid: 132
+    components:
+    - type: Transform
+      pos: -0.5,-2.5
+      parent: 1
+  - uid: 133
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 1
+  - uid: 134
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+- proto: CableTerminal
+  entities:
+  - uid: 95
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-5.5
+      parent: 1
+- proto: CardBoxBlack
+  entities:
+  - uid: 126
+    components:
+    - type: Transform
+      pos: 0.47773987,0.52307606
+      parent: 1
+- proto: CarpetBlack
+  entities:
+  - uid: 313
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 1
+- proto: CartridgeMagnum
+  entities:
+  - uid: 105
+    components:
+    - type: Transform
+      parent: 104
+    - type: Physics
+      canCollide: False
+  - uid: 106
+    components:
+    - type: Transform
+      parent: 104
+    - type: Physics
+      canCollide: False
+  - uid: 107
+    components:
+    - type: Transform
+      parent: 103
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: Catwalk
+  entities:
+  - uid: 278
+    components:
+    - type: Transform
+      pos: -1.5,-5.5
+      parent: 1
+  - uid: 279
+    components:
+    - type: Transform
+      pos: -0.5,-5.5
+      parent: 1
+  - uid: 280
+    components:
+    - type: Transform
+      pos: 0.5,-5.5
+      parent: 1
+  - uid: 314
+    components:
+    - type: Transform
+      pos: 4.5,-0.5
+      parent: 1
+  - uid: 318
+    components:
+    - type: Transform
+      pos: 4.5,1.5
+      parent: 1
+- proto: ChairPilotSeat
+  entities:
+  - uid: 196
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,8.5
+      parent: 1
+- proto: CigarCase
+  entities:
+  - uid: 213
+    components:
+    - type: Transform
+      pos: -2.4412117,-2.292807
+      parent: 1
+- proto: CigaretteSpent
+  entities:
+  - uid: 293
+    components:
+    - type: Transform
+      pos: 0.8912883,-1.1888598
+      parent: 1
+  - uid: 294
+    components:
+    - type: Transform
+      pos: 1.2350383,-1.0326098
+      parent: 1
+  - uid: 295
+    components:
+    - type: Transform
+      pos: 1.1569133,2.858015
+      parent: 1
+- proto: CigarSpent
+  entities:
+  - uid: 312
+    components:
+    - type: Transform
+      pos: 0.5868958,-0.40095758
+      parent: 1
+- proto: ClothingHandsGlovesColorBlack
+  entities:
+  - uid: 304
+    components:
+    - type: Transform
+      pos: -3.4430091,3.535641
+      parent: 1
+- proto: ClothingHeadHatFez
+  entities:
+  - uid: 317
+    components:
+    - type: Transform
+      pos: 0.35184413,9.762431
+      parent: 1
+- proto: ClothingOuterVest
+  entities:
+  - uid: 119
+    components:
+    - type: Transform
+      pos: 0.47496998,9.464117
+      parent: 1
+- proto: ClothingUniformJumpsuitBartender
+  entities:
+  - uid: 306
+    components:
+    - type: Transform
+      pos: 0.678095,9.557867
+      parent: 1
+- proto: ComputerPowerMonitoring
+  entities:
+  - uid: 195
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,8.5
+      parent: 1
+- proto: ComputerShuttle
+  entities:
+  - uid: 110
+    components:
+    - type: Transform
+      pos: -0.5,9.5
+      parent: 1
+- proto: CratePirate
+  entities:
+  - uid: 222
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 1
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 223
+          - 224
+          - 225
+          - 226
+          - 227
+          - 228
+          - 229
+          - 230
+          - 231
+          - 232
+          - 233
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+- proto: CurtainsBlackOpen
+  entities:
+  - uid: 114
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 1
+- proto: DiceBag
+  entities:
+  - uid: 127
+    components:
+    - type: Transform
+      pos: -1.4910102,-0.34411144
+      parent: 1
+- proto: DresserFilled
+  entities:
+  - uid: 115
+    components:
+    - type: Transform
+      pos: 1.5,7.5
+      parent: 1
+- proto: DrinkGildlagerBottleFull
+  entities:
+  - uid: 209
+    components:
+    - type: Transform
+      pos: -3.648522,4.601433
+      parent: 1
+- proto: DrinkGlass
+  entities:
+  - uid: 296
+    components:
+    - type: Transform
+      pos: -2.7962117,4.639265
+      parent: 1
+  - uid: 297
+    components:
+    - type: Transform
+      pos: -2.5618367,4.733015
+      parent: 1
+  - uid: 298
+    components:
+    - type: Transform
+      pos: -2.3430867,4.59239
+      parent: 1
+- proto: DrinkShaker
+  entities:
+  - uid: 206
+    components:
+    - type: Transform
+      pos: 2.679603,4.663933
+      parent: 1
+  - uid: 207
+    components:
+    - type: Transform
+      pos: 2.382728,4.570183
+      parent: 1
+- proto: DrinkShotGlass
+  entities:
+  - uid: 210
+    components:
+    - type: Transform
+      pos: -3.273522,4.288933
+      parent: 1
+  - uid: 211
+    components:
+    - type: Transform
+      pos: -3.304772,4.101433
+      parent: 1
+  - uid: 212
+    components:
+    - type: Transform
+      pos: -3.586022,3.9608078
+      parent: 1
+- proto: DrinkWhiskeyGlass
+  entities:
+  - uid: 198
+    components:
+    - type: Transform
+      pos: -2.6709938,6.5329103
+      parent: 1
+- proto: FirelockEdge
+  entities:
+  - uid: 329
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-0.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 324
+  - uid: 330
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,1.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 324
+- proto: FirelockGlass
+  entities:
+  - uid: 325
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 324
+  - uid: 326
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 324
+      - 327
+- proto: FlippoLighter
+  entities:
+  - uid: 201
+    components:
+    - type: Transform
+      pos: -3.6599617,-2.245932
+      parent: 1
+  - uid: 214
+    components:
+    - type: Transform
+      pos: -3.4724617,-2.433432
+      parent: 1
+- proto: GasPassiveVent
+  entities:
+  - uid: 282
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+    - type: AtmosPipeLayers
+      pipeLayer: Tertiary
+- proto: GasPipeBend
+  entities:
+  - uid: 240
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 285
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 286
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPipeBendAlt2
+  entities:
+  - uid: 272
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeStraight
+  entities:
+  - uid: 234
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 235
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 239
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 246
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 248
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 249
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 250
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 251
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 252
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 255
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 256
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 257
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 287
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPipeStraightAlt2
+  entities:
+  - uid: 258
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 259
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 260
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 261
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 262
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 263
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 264
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 265
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 266
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 267
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 268
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 269
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 270
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 289
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 290
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 291
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 292
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeTJunction
+  entities:
+  - uid: 253
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 254
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPipeTJunctionAlt2
+  entities:
+  - uid: 271
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 288
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPort
+  entities:
+  - uid: 238
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPressurePump
+  entities:
+  - uid: 247
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasVentPump
+  entities:
+  - uid: 275
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,3.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 324
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 276
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,0.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 324
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 284
+    components:
+    - type: Transform
+      pos: 0.5,7.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 327
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasVentScrubber
+  entities:
+  - uid: 273
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,3.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 324
+    - type: AtmosPipeColor
+      color: '#990000FF'
+    - type: AtmosPipeLayers
+      pipeLayer: Tertiary
+  - uid: 274
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-2.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 324
+    - type: AtmosPipeColor
+      color: '#990000FF'
+    - type: AtmosPipeLayers
+      pipeLayer: Tertiary
+  - uid: 283
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 327
+    - type: AtmosPipeColor
+      color: '#990000FF'
+    - type: AtmosPipeLayers
+      pipeLayer: Tertiary
+- proto: GeneratorBasic15kW
+  entities:
+  - uid: 129
+    components:
+    - type: Transform
+      pos: 0.5,-5.5
+      parent: 1
+- proto: GeneratorWallmountAPU
+  entities:
+  - uid: 322
+    components:
+    - type: Transform
+      pos: 1.5,-5.5
+      parent: 1
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 236
+    components:
+    - type: Transform
+      pos: -2.5,-4.5
+      parent: 1
+- proto: Grille
+  entities:
+  - uid: 48
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 53
+    components:
+    - type: Transform
+      pos: -2.5,9.5
+      parent: 1
+  - uid: 54
+    components:
+    - type: Transform
+      pos: -1.5,10.5
+      parent: 1
+  - uid: 55
+    components:
+    - type: Transform
+      pos: -0.5,10.5
+      parent: 1
+  - uid: 56
+    components:
+    - type: Transform
+      pos: 0.5,10.5
+      parent: 1
+  - uid: 57
+    components:
+    - type: Transform
+      pos: 1.5,9.5
+      parent: 1
+- proto: GrilleDiagonal
+  entities:
+  - uid: 60
+    components:
+    - type: Transform
+      pos: -2.5,10.5
+      parent: 1
+  - uid: 61
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,10.5
+      parent: 1
+- proto: GunSafe
+  entities:
+  - uid: 103
+    components:
+    - type: Transform
+      pos: -2.5,7.5
+      parent: 1
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 107
+          - 104
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+- proto: Gyroscope
+  entities:
+  - uid: 243
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,8.5
+      parent: 1
+- proto: IngotGold1
+  entities:
+  - uid: 223
+    components:
+    - type: Transform
+      parent: 222
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 224
+    components:
+    - type: Transform
+      parent: 222
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 226
+    components:
+    - type: Transform
+      parent: 222
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 227
+    components:
+    - type: Transform
+      parent: 222
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 228
+    components:
+    - type: Transform
+      parent: 222
+    - type: Stack
+      count: 2
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: PosterBroken
+  entities:
+  - uid: 321
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: PosterContrabandSmoke
+  entities:
+  - uid: 320
+    components:
+    - type: Transform
+      pos: -3.5,-3.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: PosterLegitHighClassMartini
+  entities:
+  - uid: 319
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: PowerCellRecharger
+  entities:
+  - uid: 108
+    components:
+    - type: Transform
+      pos: -1.5,9.5
+      parent: 1
+- proto: Poweredlight
+  entities:
+  - uid: 307
+    components:
+    - type: Transform
+      pos: -0.5,-4.5
+      parent: 1
+  - uid: 308
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,6.5
+      parent: 1
+  - uid: 309
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,8.5
+      parent: 1
+- proto: PoweredWarmSmallLight
+  entities:
+  - uid: 302
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 303
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-2.5
+      parent: 1
+  - uid: 305
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,1.5
+      parent: 1
+  - uid: 310
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-0.5
+      parent: 1
+  - uid: 311
+    components:
+    - type: Transform
+      pos: 4.5,1.5
+      parent: 1
+- proto: RagItem
+  entities:
+  - uid: 316
+    components:
+    - type: Transform
+      pos: -1.0588083,1.7430198
+      parent: 1
+- proto: SaxophoneInstrument
+  entities:
+  - uid: 301
+    components:
+    - type: Transform
+      pos: 1.6866301,-2.4724355
+      parent: 1
+- proto: ShuttleWindow
+  entities:
+  - uid: 49
+    components:
+    - type: Transform
+      pos: -1.5,10.5
+      parent: 1
+  - uid: 50
+    components:
+    - type: Transform
+      pos: -0.5,10.5
+      parent: 1
+  - uid: 51
+    components:
+    - type: Transform
+      pos: 0.5,10.5
+      parent: 1
+  - uid: 52
+    components:
+    - type: Transform
+      pos: 1.5,9.5
+      parent: 1
+  - uid: 242
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 245
+    components:
+    - type: Transform
+      pos: -2.5,9.5
+      parent: 1
+- proto: ShuttleWindowDiagonal
+  entities:
+  - uid: 58
+    components:
+    - type: Transform
+      pos: -2.5,10.5
+      parent: 1
+  - uid: 59
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,10.5
+      parent: 1
+- proto: SinkWide
+  entities:
+  - uid: 205
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 1
+- proto: SMESBasic
+  entities:
+  - uid: 125
+    components:
+    - type: Transform
+      pos: -0.5,-5.5
+      parent: 1
+- proto: SodaDispenser
+  entities:
+  - uid: 102
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+- proto: Stool
+  entities:
+  - uid: 300
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5928801,-2.4255605
+      parent: 1
+- proto: StoolBar
+  entities:
+  - uid: 85
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,0.5
+      parent: 1
+  - uid: 86
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 1
+  - uid: 87
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 88
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 89
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 90
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-0.5
+      parent: 1
+  - uid: 91
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-1.5
+      parent: 1
+  - uid: 92
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-1.5
+      parent: 1
+- proto: SubstationBasic
+  entities:
+  - uid: 123
+    components:
+    - type: Transform
+      pos: -1.5,-5.5
+      parent: 1
+- proto: TableCarpet
+  entities:
+  - uid: 78
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 1
+  - uid: 79
+    components:
+    - type: Transform
+      pos: -0.5,-0.5
+      parent: 1
+  - uid: 80
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 1
+  - uid: 81
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 82
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 83
+    components:
+    - type: Transform
+      pos: -0.5,1.5
+      parent: 1
+  - uid: 84
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 1
+- proto: TableReinforced
+  entities:
+  - uid: 111
+    components:
+    - type: Transform
+      pos: -1.5,9.5
+      parent: 1
+  - uid: 113
+    components:
+    - type: Transform
+      pos: 0.5,9.5
+      parent: 1
+  - uid: 124
+    components:
+    - type: Transform
+      pos: -2.5,6.5
+      parent: 1
+- proto: TableWood
+  entities:
+  - uid: 93
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,4.5
+      parent: 1
+  - uid: 94
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,4.5
+      parent: 1
+  - uid: 96
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 97
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 98
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 99
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,3.5
+      parent: 1
+  - uid: 200
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 1
+  - uid: 202
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 1
+- proto: Thruster
+  entities:
+  - uid: 62
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-6.5
+      parent: 1
+  - uid: 63
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-6.5
+      parent: 1
+  - uid: 64
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-4.5
+      parent: 1
+  - uid: 65
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-4.5
+      parent: 1
+  - uid: 66
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,6.5
+      parent: 1
+  - uid: 67
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,6.5
+      parent: 1
+  - uid: 68
+    components:
+    - type: Transform
+      pos: -3.5,9.5
+      parent: 1
+  - uid: 69
+    components:
+    - type: Transform
+      pos: 2.5,9.5
+      parent: 1
+- proto: TreasureCoinDiamond
+  entities:
+  - uid: 233
+    components:
+    - type: Transform
+      parent: 222
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: TreasureCoinGold
+  entities:
+  - uid: 230
+    components:
+    - type: Transform
+      parent: 222
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 232
+    components:
+    - type: Transform
+      parent: 222
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: TreasureCoinIron
+  entities:
+  - uid: 225
+    components:
+    - type: Transform
+      parent: 222
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 229
+    components:
+    - type: Transform
+      parent: 222
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: TreasureCoinSilver
+  entities:
+  - uid: 231
+    components:
+    - type: Transform
+      parent: 222
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: UprightPianoInstrument
+  entities:
+  - uid: 299
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-2.5
+      parent: 1
+- proto: VendingMachineBooze
+  entities:
+  - uid: 100
+    components:
+    - type: Transform
+      pos: -3.5,2.5
+      parent: 1
+    - type: AccessReader
+      access: []
+- proto: VendingMachineCigs
+  entities:
+  - uid: 203
+    components:
+    - type: Transform
+      pos: -3.5,-1.5
+      parent: 1
+- proto: VisitorBartenderSpawner
+  entities:
+  - uid: 315
+    components:
+    - type: Transform
+      pos: -0.5,7.5
+      parent: 1
+- proto: WallShuttle
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      pos: 5.5,2.5
+      parent: 1
+  - uid: 3
+    components:
+    - type: Transform
+      pos: 4.5,2.5
+      parent: 1
+  - uid: 4
+    components:
+    - type: Transform
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 5
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 1
+  - uid: 6
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 7
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 1
+  - uid: 8
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 9
+    components:
+    - type: Transform
+      pos: 2.5,6.5
+      parent: 1
+  - uid: 10
+    components:
+    - type: Transform
+      pos: 2.5,8.5
+      parent: 1
+  - uid: 11
+    components:
+    - type: Transform
+      pos: 2.5,7.5
+      parent: 1
+  - uid: 12
+    components:
+    - type: Transform
+      pos: 1.5,8.5
+      parent: 1
+  - uid: 13
+    components:
+    - type: Transform
+      pos: -2.5,8.5
+      parent: 1
+  - uid: 14
+    components:
+    - type: Transform
+      pos: -3.5,8.5
+      parent: 1
+  - uid: 15
+    components:
+    - type: Transform
+      pos: -3.5,7.5
+      parent: 1
+  - uid: 16
+    components:
+    - type: Transform
+      pos: -3.5,6.5
+      parent: 1
+  - uid: 17
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 1
+  - uid: 18
+    components:
+    - type: Transform
+      pos: -4.5,5.5
+      parent: 1
+  - uid: 19
+    components:
+    - type: Transform
+      pos: -4.5,4.5
+      parent: 1
+  - uid: 20
+    components:
+    - type: Transform
+      pos: -4.5,3.5
+      parent: 1
+  - uid: 21
+    components:
+    - type: Transform
+      pos: -4.5,2.5
+      parent: 1
+  - uid: 22
+    components:
+    - type: Transform
+      pos: -4.5,1.5
+      parent: 1
+  - uid: 23
+    components:
+    - type: Transform
+      pos: -4.5,0.5
+      parent: 1
+  - uid: 24
+    components:
+    - type: Transform
+      pos: -4.5,-0.5
+      parent: 1
+  - uid: 25
+    components:
+    - type: Transform
+      pos: -4.5,-1.5
+      parent: 1
+  - uid: 26
+    components:
+    - type: Transform
+      pos: -4.5,-3.5
+      parent: 1
+  - uid: 27
+    components:
+    - type: Transform
+      pos: -4.5,-2.5
+      parent: 1
+  - uid: 28
+    components:
+    - type: Transform
+      pos: -3.5,-3.5
+      parent: 1
+  - uid: 29
+    components:
+    - type: Transform
+      pos: -3.5,-4.5
+      parent: 1
+  - uid: 30
+    components:
+    - type: Transform
+      pos: -3.5,-5.5
+      parent: 1
+  - uid: 31
+    components:
+    - type: Transform
+      pos: -2.5,-5.5
+      parent: 1
+  - uid: 32
+    components:
+    - type: Transform
+      pos: -2.5,-6.5
+      parent: 1
+  - uid: 33
+    components:
+    - type: Transform
+      pos: -1.5,-6.5
+      parent: 1
+  - uid: 34
+    components:
+    - type: Transform
+      pos: -0.5,-6.5
+      parent: 1
+  - uid: 35
+    components:
+    - type: Transform
+      pos: 0.5,-6.5
+      parent: 1
+  - uid: 36
+    components:
+    - type: Transform
+      pos: 1.5,-6.5
+      parent: 1
+  - uid: 37
+    components:
+    - type: Transform
+      pos: 1.5,-5.5
+      parent: 1
+  - uid: 38
+    components:
+    - type: Transform
+      pos: 2.5,-5.5
+      parent: 1
+  - uid: 39
+    components:
+    - type: Transform
+      pos: 2.5,-4.5
+      parent: 1
+  - uid: 40
+    components:
+    - type: Transform
+      pos: 2.5,-3.5
+      parent: 1
+  - uid: 41
+    components:
+    - type: Transform
+      pos: 3.5,-3.5
+      parent: 1
+  - uid: 42
+    components:
+    - type: Transform
+      pos: 3.5,-2.5
+      parent: 1
+  - uid: 43
+    components:
+    - type: Transform
+      pos: 3.5,-1.5
+      parent: 1
+  - uid: 44
+    components:
+    - type: Transform
+      pos: 4.5,-1.5
+      parent: 1
+  - uid: 45
+    components:
+    - type: Transform
+      pos: 5.5,-1.5
+      parent: 1
+  - uid: 46
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+  - uid: 47
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 1
+  - uid: 70
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 1
+  - uid: 71
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 72
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 73
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 74
+    components:
+    - type: Transform
+      pos: -2.5,-3.5
+      parent: 1
+  - uid: 75
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 1
+  - uid: 76
+    components:
+    - type: Transform
+      pos: 1.5,-3.5
+      parent: 1
+  - uid: 77
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+- proto: WeaponRevolverPirate
+  entities:
+  - uid: 104
+    components:
+    - type: Transform
+      parent: 103
+    - type: ContainerContainer
+      containers:
+        revolver-ammo: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 105
+          - 106
+    - type: RevolverAmmoProvider
+      chambers:
+      - True
+      - True
+      - null
+      - True
+      - null
+      ammoSlots:
+      - null
+      - null
+      - 106
+      - null
+      - 105
+      currentSlot: 2
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: WindoorSecure
+  entities:
+  - uid: 116
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,0.5
+      parent: 1
+  - uid: 197
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,7.5
+      parent: 1
+- proto: WindowReinforcedDirectional
+  entities:
+  - uid: 199
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,6.5
+      parent: 1
+  - uid: 219
+    components:
+    - type: Transform
+      pos: -3.5,1.5
+      parent: 1
+  - uid: 220
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-0.5
+      parent: 1
+...

--- a/Resources/Prototypes/GameRules/unknown_shuttles.yml
+++ b/Resources/Prototypes/GameRules/unknown_shuttles.yml
@@ -22,6 +22,7 @@
     - id: UnknownShuttleSpacebus
     - id: UnknownShuttleChemLab # Harmony
     - id: UnknownShuttleBrigmedic # Harmony
+    - id: UnknownShuttleCasino # Harmony
 
 - type: entityTable
   id: UnknownShuttlesFreelanceTable

--- a/Resources/Prototypes/_Harmony/GameRules/unknown_shuttles.yml
+++ b/Resources/Prototypes/_Harmony/GameRules/unknown_shuttles.yml
@@ -18,6 +18,15 @@
   - type: LoadMapRule
     preloadedGrid: ShuttleBrigmedic
 
+- type: entity
+  id: UnknownShuttleCasino
+  parent: BaseUnknownShuttleRule
+  components:
+  - type: StationEvent
+    startAnnouncement: station-event-unknown-shuttle-incoming #!!
+  - type: LoadMapRule
+    preloadedGrid: ShuttleCasino
+
 # Harmony Hostile Shuttles
 
 - type: entity

--- a/Resources/Prototypes/_Harmony/Shuttles/shuttle_incoming_event.yml
+++ b/Resources/Prototypes/_Harmony/Shuttles/shuttle_incoming_event.yml
@@ -10,6 +10,11 @@
   path: /Maps/_Harmony/Shuttles/ShuttleEvent/brigmedic.yml
   copies: 1
 
+- type: preloadedGrid
+  id: ShuttleCasino
+  path: /Maps/_Harmony/Shuttles/ShuttleEvent/casino.yml
+  copies: 1
+
 # Harmony Hostile Shuttles
 
 - type: preloadedGrid


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->

This adds a new Visiting Bartender shuttle named NT-Royale; a gambling themed casino-bar complete with cards, dice, coins, gold bars, and a full bar setup. It comes with a gambling table, treasure chest with six gold bars and five coins to act as a "pot," and FULL DISCLOSURE - there's a pirate revolver with three bullets in the cockpit's gun safe, for people to potentially play games like russian roulette or 21.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

With the new addition of the deck of cards to Harmony, many people have been enjoying spending time playing cards, gambling, and hanging out in little casino-rooms. I think an addition of a casino shuttle will be a really fun addition for ghostgang and the station alike, and be a bartending shuttle that people are more likely to take the ghostrole for because of the fun theme. (LET'S GO GAMBLING !!)

## Technical details
<!-- Summary of code changes for easier review. -->

/Resources/Maps/_Harmony/Shuttles/ShuttleEvent/casino.yml -> NT-Royale placed into the game files
/Resources/Prototypes/_Harmony/Shuttles/shuttle_incoming_event.yml -> adds NT-Royale to... incoming shuttle prototypes?
/Resources/Prototypes/GameRules/unknown_shuttles.yml -> adds NT-Royale to friendly table
/Resources/Prototypes/_Harmony/GameRules/unknown_shuttles.yml -> adds NT-Royale to unknown friendly shuttle prototypes

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

Alright! Here's the shuttle in it's default form as it spawns in:
<img width="540" height="839" alt="ntroyalewholedefault" src="https://github.com/user-attachments/assets/b5d28bde-87d2-4f8b-ac05-e4739049f60c" />

Here's me playing around with the cards and how you can set it up:
<img width="825" height="815" alt="ntroyaleinterior" src="https://github.com/user-attachments/assets/ad35ba01-13fa-442c-8b26-14279bf97af0" />

Here's the power monitoring console (Draw is around 15,675? Everything is powered, including thrusters):
<img width="1121" height="755" alt="ntroyalepowermonitor" src="https://github.com/user-attachments/assets/1540dfbd-4218-4204-b4a8-0c5f36ca143a" />

And here's the render! Cause why not!
<img width="352" height="576" alt="casino-0" src="https://github.com/user-attachments/assets/c0e1d771-7e2a-4b59-9ddb-073f29438b75" />


## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: NT-Royale, Casino Visitor Shuttle
