### PR TITLE
Returns the advanced chems to Pre-#38811 values

### DIFF
--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -865,25 +865,35 @@
   color: "#520e30"
   metabolisms:
     Medicine:
-      # metabolismRate: 0.25 # Harmony - Revert Advanced Chem Change
       effects:
+      - !type:EvenHealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 0
+          max: 20
+        damage:
+          Toxin: -6
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
           min: 0
-          max: 30
+          max: 20
         damage:
           groups:
-            Toxin: -3 # Harmony - -1.5 > -3 - Revert Advanced Chem Change
-            Brute: 0.5 # Harmony - 0.25 > 0.5 - Revert Advanced Chem Change
+            Brute: 1.5
+      - !type:EvenHealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 20
+        damage:
+          Toxin: -2
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
-          min: 30
+          min: 20
         damage:
           groups:
-            Toxin: -1 # Harmony - -0.5 > -1 - Revert Advanced Chem Change
-            Brute: 3
+            Brute: 6
       - !type:AdjustReagent
         conditions:
         - !type:ReagentThreshold
@@ -992,19 +1002,19 @@
   color: "#e0a5b9"
   metabolisms:
     Medicine:
-      # metabolismRate: 0.1 # Harmony - Revert Advanced Chem Change
+      # metabolismRate: 0.25 # Harmony - Revert Advanced Chem Change
       effects:
       - !type:HealthChange
         damage:
           types:
-            Caustic: -3 # Harmony - -0.6 > -3 - Revert Advanced Chem Change
+            Caustic: -3 # Harmony - -1.25 > -3 - Revert Advanced Chem Change
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
-          min: 16 # Harmony - 21 > 16 - Revert Advanced Chem Change
+          min: 16
         damage:
           types:
-            Heat: 2 # Harmony - 0.2 > 2 - Revert Advanced Chem Change
+            Heat: 2 # Harmony - 1 > 2 - Revert Advanced Chem Change
       - !type:Jitter
         conditions:
         - !type:ReagentThreshold
@@ -1048,16 +1058,17 @@
   color: "#283332"
   metabolisms:
     Medicine:
-      # metabolismRate: 0.1 # Harmony - Revert Advanced Chem Change
+      # metabolismRate: 0.25 # Harmony - Revert Advanced Chem Change
       effects:
       - !type:HealthChange
         damage:
           types:
-            Slash: -3 # Harmony - -0.6 > -3 - Revert Advanced Chem Change
+            Slash: -3 # Harmony - -2 > -3 - Revert Advanced Chem Change
+            # Heat: 0.2 # 0.8 per u
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
-          min: 12 # Harmony - 21 > 12 - Revert Advanced Chem Change
+          min: 12
         damage:
           types:
             Cold: 3 # Harmony - 1.5 > 3 - Revert Advanced Chem Change
@@ -1072,20 +1083,21 @@
   color: "#b9bf93"
   metabolisms:
     Medicine:
-      # metabolismRate: 0.1 # Harmony - Revert Advanced Chem Change
+      # metabolismRate: 0.25 # Harmony - Revert Advanced Chem Change
       effects:
       - !type:HealthChange
         damage:
           types:
-            Piercing: -4 # Harmony - -0.6 > -4 - Revert Advanced Chem Change
-            Blunt: 0.1 # Harmony - 0.05 > 0.1 - Revert Advanced Chem Change
+            Piercing: -4 # Harmony - -2.5 > -4 - Revert Advanced Chem Change
+            Blunt: 0.1 # Harmony - Returns blunt side-effect
+            # Radiation: 0.05
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
-          min: 11 # Harmony - 21 > 11 - Revert Advanced Chem Change
+          min: 11 # Harmony - 12 > 11 - Revert Advanced Chem Change
         damage:
           types:
-            Blunt: 5 # Harmony - 1 > 5 - Revert Advanced Chem Change
+            Blunt: 5 # Harmony - 3 > 5 - Revert Advanced Chem Change
 
 - type: reagent
   id: Bruizine
@@ -1097,19 +1109,23 @@
   color: "#ff3636"
   metabolisms:
     Medicine:
-      # metabolismRate: 0.1 # Harmony - Revert Advanced Chem Change
+      # metabolismRate: 0.25 # Harmony - Revert Advanced Chem Change
       effects:
       - !type:HealthChange
         damage:
           types:
-            Blunt: -3.5 # Harmony - -0.6 > -3.5 - Revert Advanced Chem Change
+      # Harmony Change Start - Revert Advanced Chem Change
+            Blunt: -3.5 # -2.25 > -3.5
+      # - !type:SatiateHunger
+      #   factor: -1
+      # Harmony Change End
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
-          min: 10.5 # Harmony - 19 > 10.5 - Revert Advanced Chem Change
+          min: 10.5
         damage:
           types:
-            Poison: 4 # Harmony - 1.5 > 4 - Revert Advanced Chem Change
+            Poison: 4 # Harmony - 2.5 > 4 - Revert Advanced Chem Change
 
 - type: reagent
   id: Holywater
@@ -1213,25 +1229,25 @@
             Shock: -4 # Harmony - 1.5 > 4 - Revert Advanced Chem Change
       - !type:AdjustReagent
         reagent: Licoxide
-        amount: -4
+        amount: -4 # Harmony - -2 > -4 - Revert Advanced Chem Change
       - !type:AdjustReagent
         reagent:  Tazinide
-        amount: -4
+        amount: -4 # Harmony - -2 > -4 - Revert Advanced Chem Change
       # makes you a little chilly when not oding
       - !type:AdjustTemperature
-        amount: -5000
+        amount: -5000 # Harmony - -2500 > -5000 - Revert Advanced Chem Change
       # od makes you freeze to death
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
-          min: 12 # Harmony - 15.5 > 12 - Revert Advanced Chem Change
+          min: 12
         damage:
           types:
-            Cold: 2 # Harmony - 0.2 > 2 - Revert Advanced Chem Change
+            Cold: 2 # Harmony - 1 > 2 - Revert Advanced Chem Change
       - !type:AdjustTemperature
         conditions:
         - !type:ReagentThreshold
-          min: 12 # Harmony - 15.5 > 12 - Revert Advanced Chem Change
+          min: 12
         amount: -30000
       - !type:Jitter
         conditions:


### PR DESCRIPTION
## About the PR
Reverts both https://github.com/space-wizards/space-station-14/pull/39472 and https://github.com/space-wizards/space-station-14/pull/38811

## Why / Balance
After continued playtesting and discussion (found [here](https://discord.com/channels/1139716325627932682/1402791675734003885/1408895927904633006)), there is a prevaling desire to see chems returned to their Pre-38811 values.

The original PRs sought to increase the useage of precursor chems (such as Bicaridine) by reducing the usefulness of the advanced chems, however this has more resulted in a decreased use of the advanced chems and not an increased use of the basic chems. The common sentiment on this in Harmony discussions that I have seen is that this is not a desired outcome. Advanced chems are an upgrade that takes time, skill, and resources to create, and therefore they should be more consistently used.

Another angle the original upstream PRs sought to tackle was reducing the effectiveness of chems in combat scenarios, especially when used by antagonists. However, it seems this outcome has not quite manifested, as antagonists have simply found other effective ways of combat healing. As a result, all that has been accomplished is adding extra friction to medical procedures.

Medical as a department exists as the people that determine when someone gets to come back and play. By making the chems slower overall, a backlog of patients has been created which results in corpses being untreated and critical patients being in critical for longer. This often becomes a point of friction that is not fun for the patient or the doctor, and can sometimes lead to the patient being frustrated by the doctor even when the doctor is performing their duties adequately.

Unlike with the previous iteration, there has been no movement to alter chems on upstream at the moment. Chems as they are currently are disuading medical mains from playing, which is one of the key indicators that these chems are unhealthy for Harmony.

The other key indicator is doctors stating they do not administer Punct or Lace, two advanced chems. I think if an advanced chem isn't being used even when its been floored is a strong indicator that this system does not work.

I chose for a full reversion to chem-made chems. I purposefully left Ultravasculine as-is, as I recall botanists and doctors calling that "a good change". Rather than trying to microtweak the upstream concepts, reverting them to the original concept was chosen because both the speed and side effects were called as issue points. Reverting to the original gives us a better foundation to work off from and return to if we wanted to try and balance the chems ourselves.

The common sentiment is that as long as chems are the sole and primary method of effective medbay healing, and are intended to be such, making them weaker leads to an unfun medbay environment. This would be less of a problem if we had surgery or other such more indepth medical healing options.

## Technical details
All changes are YAML isolated to a single file.

## Media
<img width="656" height="366" alt="image" src="https://github.com/user-attachments/assets/caa5e107-dfd3-4ce9-a35f-b8ac2bc29779" />
<img width="649" height="233" alt="image" src="https://github.com/user-attachments/assets/a79ede71-702e-4632-a3ea-d8aa13de475e" />
<img width="647" height="233" alt="image" src="https://github.com/user-attachments/assets/e1c1fd06-3adb-4fa3-826a-36e801a07c06" />
<img width="647" height="232" alt="image" src="https://github.com/user-attachments/assets/e86ef236-7865-4898-8580-49bcc3bac1ad" />
<img width="654" height="368" alt="image" src="https://github.com/user-attachments/assets/5fac7d49-205c-4eb8-a4ca-b3d25828b306" />
<img width="658" height="305" alt="image" src="https://github.com/user-attachments/assets/1391a27c-a0ac-46fd-80c7-c4ec2030a400" />


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- tweak: The advanced chemicals Bruizine, Lacerinol, Puncturase, Insuzine, and Sigynate all metabolize faster again.
- tweak: Bicaridine no longer heals evenly

