### PR TITLE
Nukies can now gamble

### DIFF
--- a/Resources/Prototypes/_Harmony/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Harmony/Catalog/uplink_catalog.yml
@@ -218,7 +218,7 @@
   description: uplink-super-surplus-bundle-desc
   productEntity: CrateSyndicateSuperSurplusBundle
   cost:
-    Telecrystal: 90
+    Telecrystal: 80
   categories:
   - UplinkDisruption
   conditions:


### PR DESCRIPTION
## About the PR
Adds the surplus to nukie uplink for 80 TC

## Why / Balance
Gamble ops are funny and sacrificing 2 nukies worth of TC with a potentially better payout is a cool dynamic.

Alternate price I propose is 90-100 due to warops but at that point it might be going into "so useless it's bloat" territory

## Technical details
added an offer in uplink_catalog.yml in harmony namespace

## Media
<img width="392" height="309" alt="obraz" src="https://github.com/user-attachments/assets/4dc771d2-3aff-4f41-9483-c87bd5cf1535" />


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- tweak: Nuclear operatives can now buy super surpluses for 80 TC. 99% of operatives quit before they get a Holy Hand Grenade.
