### PR TITLE
Remove corgium recipe

### DIFF
--- a/Resources/Prototypes/Recipes/Reactions/fun.yml
+++ b/Resources/Prototypes/Recipes/Reactions/fun.yml
@@ -244,14 +244,16 @@
     maxTotalIntensity: 250
     tileBreakScale: 0.00001
 
-- type: reaction
-  id: CorgiJuice
-  reactants:
-    UncookedAnimalProteins:
-      amount: 1
-    JuiceThatMakesYouWeh:
-      amount: 1
-    Happiness:
-      amount: 1
-  products:
-    CorgiJuice: 2
+# Start harmony change - remove corgium
+#- type: reaction
+#  id: CorgiJuice
+#  reactants:
+#    UncookedAnimalProteins:
+#      amount: 1
+#    JuiceThatMakesYouWeh:
+#      amount: 1
+#    Happiness:
+#      amount: 1
+#  products:
+#    CorgiJuice: 2
+# End harmony change


### PR DESCRIPTION
## About the PR
Kills the corgium recipe

## Why / Balance

It's bloat that nobody uses and doesn't provide anything meaningful

Also it's a more powerful poison than frezon or benzene for some reason?? (25 cellular per 10u compared to benzene which does 20)

this is not a complete removal so it leaves for admemes (and makes it so that i don't have to touch 50 files)

ALSO the sprites are hand crafted and not displacements so they break with our custom hardsuit sprites

## Technical details
commented out a recipe in Recipes/Reactions/fun.yml with harmony start and end comments

## Media
<img width="657" height="108" alt="obraz" src="https://github.com/user-attachments/assets/137ff71c-1dcf-4afe-899f-98c73fddd974" />


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- remove: Removed corgium recipe
