### PR TITLE
Removes incendiary magazines from Bagel armory

### DIFF
--- a/Resources/Prototypes/_Harmony/Maps/Modifications/bagel.yml
+++ b/Resources/Prototypes/_Harmony/Maps/Modifications/bagel.yml
@@ -2,6 +2,8 @@
   id: ModificationBagelRemoveIncendiary
   applyOn:
   - Bagel
-  removals:
-  - !type:EntityPrototypeSelector
-    prototype: MagazineLightRifleIncendiary
+  replacements:
+  - from:
+    - !type:EntityPrototypeSelector
+      prototype: MagazineLightRifleIncendiary
+    newPrototype: MagazineLightRifle


### PR DESCRIPTION
## About the PR
Uses map modification to remove roundstart .30 rifle incendiary magazines from the Bagel armory.

## Why / Balance
Security shouldn't have roundstart incendiary ammo

## Technical details
Added new map modification in _Harmony/Maps/Modifications/bagel.yml

## Media
<img width="674" height="572" alt="bagel" src="https://github.com/user-attachments/assets/be5c29aa-2eaa-428d-85ce-e2ef97c96793" />

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- remove: Removed roundstart .30 rifle incendiary magazines from Bagel armory
