### PR TITLE
Adjusts Clown/Mime Hardsuits

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -1200,7 +1200,7 @@
   name: clown EVA suit helmet
   #description: A clown hardsuit helmet.
   description: A clown EVA suit helmet.
-  #Harmony Change start - hardsuit --> EVA suit, and comments out original name & description
+  #Harmony Change end - hardsuit --> EVA suit, and comments out original name & description
   components:
   - type: BreathMask
   - type: Sprite
@@ -1220,7 +1220,7 @@
   name: mime EVA suit helmet
   #description: A mime hardsuit helmet.
   description: A mime EVA suit helmet.
- #Harmony Change start - hardsuit --> EVA suit, and comments out original name & description
+ #Harmony Change end - hardsuit --> EVA suit, and comments out original name & description
   components:
   - type: BreathMask
   - type: Sprite

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -1160,8 +1160,10 @@
 #MISC. HARDSUITS
 #Clown Hardsuit
 - type: entity
-  #parent: ClothingOuterHardsuitBase Harmony Change - parents off of the EVA suit its crafted from instead.
-  parent: ClothingOuterEVASuitBase #Harmony Change
+ # Harmony Change start - parents off of the EVA suit its crafted from instead.
+  #parent: ClothingOuterHardsuitBase
+  parent: ClothingOuterEVASuitBase
+ # Harmony Change end - parents off of the EVA suit its crafted from instead.
   id: ClothingOuterHardsuitClown
   #Harmony Change Start - hardsuit --> EVA suit, and comments out original name
   #name: clown hardsuit
@@ -1177,7 +1179,7 @@
   - type: PressureProtection
     highPressureMultiplier: 0.5
     lowPressureMultiplier: 1000
-# Start Harmony Change - Remove damage resistance from Clown Suit.
+# Start Harmony Change - Remove damage resistance and movement speed from Clown Suit.
 #  - type: ExplosionResistance
 #    damageCoefficient: 0.9
 #  - type: Armor
@@ -1187,12 +1189,10 @@
 #        Slash: 0.9
 #        Piercing: 0.9
 #        Caustic: 0.8
-# End Harmony Change - Remove damage resistance from Clown Suit.
-# Start Harmony Change - comments out movement speed mod.
 #- type: ClothingSpeedModifier
     #walkModifier: 0.9
     #sprintModifier: 0.9
-# End Harmony Change - comments out movement speed mod.
+# End Harmony Change - Remove damage resistance and movement speed from Clown Suit.
   - type: HeldSpeedModifier
   - type: Construction
     graph: ClownHardsuit
@@ -1215,7 +1215,7 @@
   name: mime EVA suit
   #description: A custom-made mime hardsuit.
   description: A custom-made mime EVA suit.
-#Harmony Change start - hardsuit --> EVA suit, and comments out original name & description
+#Harmony Change end - hardsuit --> EVA suit, and comments out original name & description
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/mime.rsi


### PR DESCRIPTION
## About the PR
As it stands after balance adjustments to the salvage hardsuits. and the removal of the generic hardsuit, the clown and mime hardsuits were left in an unintentionally stronger state than their intended purpose. This PR aims to move them back to a more appropriate statline.

## Why / Balance
- The clown hardsuited parented off of the basic hardsuit, despite being crafted with an EVA suit. this lead to it having hardsuit stats. This is a bigger problem on upstream, but after previous balancing passes this made the clown/mime hardsuits a better pick for salvaging than the actual salvaging spacesuits.
- By making them take the stats off of the item they're created from, it feels more cohesive. Why is an EVA suit becoming 10% faster when you strap some crayons onto it?
- Renames the items from hardsuit to EVA suit to better match what they actually are. Hardsuits and EVA suits are different things and should be addressed as such.

## Technical details
- Comments out code and replaces it in Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml to rename the helmets
- Comments out code and replaces it in Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml to rename the hardsuits to eva suits, as well as comments out the resistances.

## Media
<img width="294" height="119" alt="forpr" src="https://github.com/user-attachments/assets/878f59ed-185a-4175-be3c-05af6108f3f7" />

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**

:cl:
- tweak: Clown and Mime hardsuits have been renamed to EVA suits, and had their stats adjusted to reflect this.


