### PR TITLE
Removes duplicate bulldog magazine offers

### DIFF
--- a/Resources/Prototypes/_Harmony/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Harmony/Catalog/uplink_catalog.yml
@@ -143,35 +143,12 @@
 
 # Ammo
 
-# For the Bulldog
-- type: listing
-  id: UplinkShotgunBuckshotMagazineHarmony
-  name: uplink-shotgun-drum-pellet-name
-  description: uplink-shotgun-drum-pellet-desc
-  icon: { sprite: /Textures/Objects/Weapons/Guns/Ammunition/Magazine/Shotgun/m12.rsi, state: pellets }
-  productEntity: MagazineShotgun
-  cost:
-    Telecrystal: 2
-  categories:
-  - UplinkAmmo
-
 # For the Blood-Red Energy Carbine
 - type: listing
   id: UplinkBloodRedCarbineAmmoHarmony
   name: uplink-blood-red-carbine-ammo-name
   description: uplink-blood-red-carbine-ammo-desc
   productEntity: EnergyCarbineCartridgeSyndicateHarmony
-  cost:
-    Telecrystal: 2
-  categories:
-  - UplinkAmmo
-
-- type: listing
-  id: UplinkShotgunSlugMagazineHarmony
-  name: uplink-shotgun-drum-slug-name
-  description: uplink-shotgun-drum-slug-desc
-  icon: { sprite: /Textures/Objects/Weapons/Guns/Ammunition/Magazine/Shotgun/m12.rsi, state: slug }
-  productEntity: MagazineShotgunSlug
   cost:
     Telecrystal: 2
   categories:


### PR DESCRIPTION
## About the PR
removes duplicate bulldog magazine offers from the traitor uplink

## Why / Balance
unintended bug that was introduced by https://github.com/ss14-harmony/ss14-harmony/pull/623 , upstream has added their own version of this and we forgot to remove them when we upstream merged

## Technical details
removes 2 offers in uplink_catalog.yml in harmony namespace

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Fixed Bulldog magazine uplink offers appearing twice