### PR TITLE
VGroid Mobs deal Blunt/Slash instead of Pierce/Slash

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
@@ -67,7 +67,7 @@
         #Harmony Change Start - Pierce --> Blunt
         #Piercing: 10
         Blunt: 10
-        #Harmony Change Start - Pierce --> Blunt
+        #Harmony Change End - Pierce --> Blunt
   - type: NpcFactionMember
     factions:
     - SimpleHostile
@@ -390,7 +390,7 @@
         #Harmony Change Start - Pierce --> Blunt
         #Piercing: 5
         Blunt: 5
-         #Harmony Change End - Pierce --> Blunt
+        #Harmony Change End - Pierce --> Blunt
   - type: Gun
     fireRate: 0.75
     projectileSpeed: 10.0 # When we get predicted guns and projectiles this should be raised to like 15, 15 mis-predicts too much right now unfortunately.


### PR DESCRIPTION
## About the PR
This PR aims to implement a change to goliath melee, moving them from dealing a hybrid of 10 slash/10 pierce to 10 slash/10 blunt, and move basilisk from 7 slash/5 pierce to 7 slash/ 5 blunt.

Right now, there is a balance issue presented by trying to make Goliath Hardsuits bad against PVP, but good against PVE, and that is that the Goliath suit fails to excell as it should on the vgroid due to the prevelence of Pierce damage on both Goliaths and Basilisks.

By changing these damage numbers, it promotes the Goliath suit to be the reward for conquering the mobs on the VGroid, rather than providing only a slight benefit against the things you've already killed.

There is a consideration here that perhaps this would make goliaths and basilisk undertuned, but both of these mobs are designed around punishing poor movement -and the main disadvantage of the Mining suit is its decreased manuverability. However if this would result in goliaths/basilisk feeling too weak I can forsee a world where we up their damage numbers, maybe to 15/15 and 10/10 respectively to make them feel more deadly.

## Why / Balance
Feel like I mostly covered it in the above section, but this is to pave the way for more healthy balancing variables for salvage suits, allowing for high melee damage resistances whilst not making them the apex in gunfights - which is not an enviroment a crew-alligned salvager should be excelling in, unlike a security hardsuit. This change creates a new set of enviromental balancing variables where we can more healthly experiment with suits having good resistances. 

## Technical details
- changes damage types for both the goliath and basilisk in Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml. Comments out old one and replaces in a comment block.

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**

:cl:
- tweak: Goliaths and Basilisks now deal a mix of blunt and slash instead of blunt and pierce.

