### PR TITLE
Replace the Hypopen in the Syndicate uplink with the Syndicate Hypospray

### DIFF
--- a/Resources/Locale/en-US/_Harmony/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/_Harmony/store/uplink-catalog.ftl
@@ -42,6 +42,9 @@ uplink-rifle-magazine-bandit-desc = Rifle magazine with 15 cartridges. Compatibl
 
 # Chemicals
 
+uplink-hypospray-name = Syndicate Hypospray
+uplink-hypospray-desc = A chemical hypospray capable of instantly injecting 2.5u of reagents per use. Has an internal chemical storage of 15u and starts empty.
+
 uplink-defib-name = Interdyne Defibrillator
 uplink-defib-desc = A compact defibrillator. It can be used to revive your fellow comrades, or as an effective melee weapon! You should probably throw away your acidifier if you expect to use this.
 

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -639,20 +639,20 @@
           - SurplusBundle
 
 #Chemicals
-
-- type: listing
-  id: UplinkHypopen
-  name: uplink-hypopen-name
-  description: uplink-hypopen-desc
-  icon: { sprite: /Textures/Objects/Misc/pens.rsi, state: pen }
-  productEntity: HypopenBox
-  discountCategory: rareDiscounts
-  discountDownTo:
-    Telecrystal: 2 # Harmony change
-  cost:
-    Telecrystal: 4 # Harmony change
-  categories:
-  - UplinkChemicals
+#Start of Harmony Change : Removes the hypopen from the syndicate and nukie uplinks
+#- type: listing
+#  id: UplinkHypopen
+#  name: uplink-hypopen-name
+#  description: uplink-hypopen-desc
+#  icon: { sprite: /Textures/Objects/Misc/pens.rsi, state: pen }
+#  productEntity: HypopenBox
+#  discountCategory: rareDiscounts
+#  discountDownTo:
+#    Telecrystal: 2 # Harmony change
+#  cost:
+#    Telecrystal: 4 # Harmony change
+#  categories:
+#  - UplinkChemicals
 
 - type: listing
   id: UplinkHypoDart

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -42,7 +42,7 @@
 
 - type: entity
   name: gorlex hypospray
-  parent: BaseItem
+  parent: [ BaseItem, BaseSyndicateContraband ]
   description: Using reverse engineered designs from NT, Cybersun produced these in limited quantities for Gorlex Marauder operatives.
   id: SyndiHypo
   components:

--- a/Resources/Prototypes/_Harmony/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Harmony/Catalog/uplink_catalog.yml
@@ -168,6 +168,20 @@
 # Chemicals
 
 - type: listing
+  id: UplinkHypospray
+  name: uplink-hypospray-name
+  description: uplink-hypospray-desc
+  icon: { sprite: /Textures/Objects/Specific/Medical/syndihypo.rsi, state: hypo }
+  productEntity: SyndiHypoTraitor
+  discountCategory: rareDiscounts
+  discountDownTo:
+    Telecrystal: 2
+  cost:
+    Telecrystal: 4
+  categories:
+  - UplinkChemicals
+
+- type: listing
   id: UplinkDefib
   name: uplink-defib-name
   description: uplink-defib-desc

--- a/Resources/Prototypes/_Harmony/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/_Harmony/Entities/Objects/Specific/Medical/hypospray.yml
@@ -1,0 +1,12 @@
+- type: entity
+  name: syndicate hypospray
+  parent: SyndiHypo
+  description: Using reverse engineered designs from NT, Cybersun made these hyposprays as a cheaper, less effective version of the ones they provided to Gorlex Marauders.
+  id: SyndiHypoTraitor
+  components:
+  - type: SolutionContainerManager
+    solutions:
+      hypospray:
+        maxVol: 15
+  - type: Hypospray
+    transferAmount: 2.5


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
Port of https://github.com/space-wizards/space-station-14/pull/38711 to Harmony
The hypopen has been removed from the uplink. It has been replaced by the Syndicate Hypospray, which is not a stealth item, injects half as quickly as the old hypopen (2.5u a click), but has an increased chemical storage (up to 15u).

It also makes the Gorlex hypospray Syndicate contraband. The Syndicate hypospray parents off of it so this means the syndicate hypospray is also contraband.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The hypopen is absurdly overpowered, even if nocturine receives the 6 second sleep delay. It allows for instant administration of chemicals into other players absurdly quickly, which when used with nocturine, pax or lexorin creates an uncounterable situation. It is also a stealth item for some reason, meaning that even if the traitor walked up to you with it in their hand, you weren't able to react until there were already chems in your system. It also meant there was zero value in stealing the CMO's hypospray as you could get one that was functionally the same for all purposes a traitor needed from your uplink.

This new hypospray gives the victim adequate time to react to having chemicals forced into their system as it can only inject half as much of a chemical in a given timespan. It is also obviously a syndicate item, meaning that they may be able to react to the traitor before they can get their first injection off.

As for making the gorlex hypospray Syndicate contraband, I'm not sure why it wasn't in the first place.

The Hypopen was not changed so as to not affect thieves. Being hypo'd by a thief is FAR less problematic than being hypo'd by a syndie.

## Technical details
Removed the listing for the hypopen from uplink_catalog, replaced it with one for the syndicate hypospray
Added a new prototype for the syndicate hypospray (SyndiHypoTraitor). It currently uses the same sprite as the gorlex hypospray (syndihypo.rsi)

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
[Demonstration video](https://youtu.be/_2fbiW539n8)
<img width="600" height="203" alt="image" src="https://github.com/user-attachments/assets/fdf542f2-81ae-4320-a00e-2dca88a9d3a2" />


## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: SuperGDPWYL, 2DSiggy
- remove: The hypopen has been removed from the uplink.
- add: A new type of hypospray, the syndicate hypospray, has been added to the uplink. It injects 2.5u of a reagent per click but has an increased storage of 15u.
-  tweak: The gorlex hypospray is now Syndicate contraband.