### PR TITLE
Remove unused explosion type

### DIFF
--- a/Resources/Prototypes/_Harmony/explosion.yml
+++ b/Resources/Prototypes/_Harmony/explosion.yml
@@ -1,8 +1,0 @@
-- type: explosion
-  id: LaserBombHarmony
-  damagePerIntensity:
-    types:
-      Heat: 6
-  lightColor: "#ff4300"
-  fireColor: "#ff4300"
-  texturePath: /Textures/Effects/fire.rsi


### PR DESCRIPTION
## About the PR
Removes unused explosion type introduced by https://github.com/ss14-harmony/ss14-harmony/pull/362

## Why / Balance
unused + affects performance

## Technical details
removed harmony explosion.yml file

## Media

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
Not player facing
