### PR TITLE
PKA Description + Guidebook talk about pressure sensitivity

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/pka.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/pka.yml
@@ -2,7 +2,10 @@
   name: proto-kinetic accelerator
   id: WeaponProtoKineticAccelerator
   parent: [WeaponProtoKineticAcceleratorBase, BaseCargoContraband]
-  description: Fires low-damage kinetic bolts at a short range.
+  #Begin Harmony Change - Updates description to accomodate changes to pka atmos mechanics.
+  #description: Fires low-damage kinetic bolts at a short range.
+  description: Fires pressure-sensitive kinetic bolts at a short range. Use in vacuum for best results.
+  #End Harmony Change - Updates description to accomodate changes to pka atmos mechanics.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Basic/kinetic_accelerator.rsi

--- a/Resources/ServerInfo/Guidebook/Cargo/Salvage.xml
+++ b/Resources/ServerInfo/Guidebook/Cargo/Salvage.xml
@@ -36,6 +36,7 @@
   All Salvage Specialists must be armed, in case they need to defend themselves from hostiles.
 
   - [color=cyan]Proto-Kinetic Accelerator[/color]: This gun has infinite ammunition, allowing you to slowly mine and fly through space. Science can print upgrades to make it hit harder, shoot farther, and cycle faster.
+<!-- Harmony Change - Atmospheric-sensitive PKAs -->- The [color=cyan]Proto-Kinetic Accelerator[/color] is sensitive to atmospheric conditions, and will do considerably less damage in a pressurized enviroment. Use it in space for the best results.
 
   <Box>
     <GuideEntityEmbed Entity="Pickaxe"/>


### PR DESCRIPTION

## About the PR
This Pr updates the salvage guidebook entry and pka description to mention the fact that they're hampered by being in a pressurized enviroment.

## Why / Balance
People keep getting caught out because this is a ported feature not part of upstream. This should hopefully make it a bit more obvious.
Any issues now are caused by people not reading the tooltips/guidebook, and not just by an unadvertised feature hidden in the changelogs.

## Technical details
- adds a comment block to Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/pka.yml and replaced the description for the pka with a new one.
- updates Resources/ServerInfo/Guidebook/Cargo/Salvage.xml to have a new entry under the PKA section.

## Media
<img width="369" height="284" alt="1" src="https://github.com/user-attachments/assets/1bbe1aae-bf12-414e-8858-87a49e1d8801" />
<img width="671" height="323" alt="2" src="https://github.com/user-attachments/assets/3629e6b7-a616-4453-99cd-37b3acd4307a" />

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: The PKA's description has been adjusted to more accurately reflect its mechanics, now mentioning it's pressure-sensitive.
- tweak: The Salvage guidebook entry has been updated to reflect changes to the PKA to make it pressure sensitive.


