### PR TITLE
RSC buff

### DIFF
--- a/Resources/Prototypes/_Harmony/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/_Harmony/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -20,7 +20,7 @@
     - suitStorage
   - type: AmmoCounter
   - type: Gun
-    fireRate: 0.75
+    fireRate: 1.25 # Slightly better than a mosin (0.75)
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto
@@ -35,6 +35,7 @@
     slots:
       gun_magazine:
         name: Magazine
+        startingItem: SpeedLoaderLightRifle
         insertSound: /Audio/_Harmony/Weapons/Guns/MagIn/rsc_insert.ogg
         ejectSound: /Audio/_Harmony/Weapons/Guns/MagOut/rsc_eject.ogg
         priority: 2
@@ -44,6 +45,7 @@
         whitelistFailPopup: gun-magazine-whitelist-fail
       gun_chamber:
         name: Chamber
+        startingItem: CartridgeLightRifle
         priority: 1
         whitelist:
           tags:


### PR DESCRIPTION
## About the PR
Increases firerate of RSC from 0.75 to 1.25

RSC now starts loaded in rifle crates

## Why / Balance
I loathe microbalancing but as it exists this gun is just blight on our repo because nobody uses it

Currently the RSC has no reason to exist as it is literally _**worse than the mosin**_ (less capacity), **_starts unloaded_**, and the pistol crate is way better than the rifle crate while only being 2500 more expensive

For its' intended purpose of being handed out en-masse during warops, I have seen it be used exactly once for that purpose and I think the crew would've had a better chance of just using the rifles as clubs to beat the nukies to death with.

This doesn't make it overpowered as pistols or any other gun remain 5x more usable, but it does give it a purpose other than "haha mass order guns during nukies funny"

## Technical details
This is 3 line changes in a YAML file.

## Media
https://github.com/user-attachments/assets/7212b86d-f41a-4dfb-8bfb-0de5640315f4

## Requirements
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- tweak: RSC now starts loaded in crates and has better firerate