### PR TITLE
Mantis gloves are no longer edible

### DIFF
--- a/Resources/Prototypes/_Harmony/Entities/Clothing/Hands/base_clothinghands.yml
+++ b/Resources/Prototypes/_Harmony/Entities/Clothing/Hands/base_clothinghands.yml
@@ -1,0 +1,29 @@
+- type: entity
+  abstract: true
+  parent: Clothing
+  id: ClothingHandsNonEdibleButcherableBase # mashed basehands and butcherablehands together into 1 prototype because it's only used for mantis gloves
+  components:
+  - type: Sprite
+    state: icon
+  - type: Clothing
+    slots: [gloves]
+  - type: Item
+    size: Small
+    storedRotation: -90
+  - type: Tag
+    tags:
+    - ClothMade
+    - Recyclable
+    - WhitelistChameleon
+  - type: DamageOnInteractProtection
+    damageProtection:
+      flatReductions:
+        Heat: 5
+  - type: PhysicalComposition
+    materialComposition:
+      Cloth: 50
+  - type: Butcherable
+    butcheringType: Knife
+    spawned:
+    - id: MaterialCloth1
+      amount: 1

--- a/Resources/Prototypes/_Harmony/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/_Harmony/Entities/Clothing/Hands/gloves.yml
@@ -1,5 +1,20 @@
 - type: entity
-  parent: ClothingHandsGlovesLatex
+  abstract: true
+  parent: ClothingHandsNonEdibleButcherableBase
+  id: ClothingHandsGlovesNonEdibleLatex
+  name: latex gloves
+  description: Thin sterile latex gloves. Basic PPE for any doctor.
+  components:
+  - type: Sprite
+    sprite: Clothing/Hands/Gloves/latex.rsi
+  - type: Clothing
+    sprite: Clothing/Hands/Gloves/latex.rsi
+  - type: Fiber
+    fiberMaterial: fibers-latex
+  - type: FingerprintMask
+
+- type: entity
+  parent: ClothingHandsGlovesNonEdibleLatex
   id: ClothingHandsGlovesMantis
   suffix: Mantis
   components:


### PR DESCRIPTION
## About the PR
Mantis gloves are no longer edible.

## Why / Balance
It broke tests because https://github.com/ss14-harmony/ss14-harmony/pull/883 gave them a solution manager which ClothingHandsBase already has.

Also this was unintended behavior in the first place because you shouldn't mechanically be able to just eat your mantis gloves.

## Technical details
Resources/Prototypes/_Harmony/Entities/Clothing/Hands/base_clothing.yml - added ClothingHandsNonEdibleButcherableBase prototype

Resources/Prototypes/_Harmony/Entities/Clothing/Hands/gloves.yml - added 1 abstract non-edible latex gloves prototype and changed a parent for mantis gloves

## Media

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- fix: Mantis gloves are no longer edible
