### PR TITLE
Remove the Mk-58 from roundstart officers

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
@@ -31,8 +31,10 @@
   storage:
     back:
     - Flash
-    - MagazinePistol
-    - WeaponPistolMk58
+    # Harmony Change, Remove roundstart Mk-58 and ammo
+    #- MagazinePistol
+    #- WeaponPistolMk58
+    # Harmony End
 
 - type: chameleonOutfit
   id: SecurityOfficerChameleonOutfit


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
Removed the roundstart Mk-58 from officers
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I believe this change will positively impact the game, because in its current state officers dont really need to retreat as they can pull out their sidearm and just gun down suspects. I believe this is unhealthy and this dynamic should be removed.
## Technical details
<!-- Summary of code changes for easier review. -->
Resources/Prototypes/Roles/Jobs/Security/security_officer.yml - removes two lines
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
No media needed
## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Security officers now no longer come with roundstart Mk-58 or ammo
