### PR TITLE
Fixes incorrect uplink offer icons

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1736,7 +1736,10 @@
   id: UplinkHardsuitSyndie
   name: uplink-hardsuit-syndie-name
   description: uplink-hardsuit-syndie-desc
-  icon: { sprite: /Textures/Clothing/OuterClothing/Hardsuits/syndicate.rsi, state: icon }
+# Start Harmony change - Changed sprite path
+# icon: { sprite: /Textures/Clothing/OuterClothing/Hardsuits/syndicate.rsi, state: icon }
+  icon: { sprite: /Textures/_Harmony/Clothing/OuterClothing/Hardsuits/syndicate.rsi, state: icon }
+# End Harmony change
   productEntity: ClothingBackpackDuffelSyndicateHardsuitBundle
   discountCategory: veryRareDiscounts
   discountDownTo:
@@ -1766,7 +1769,10 @@
   id: UplinkHardsuitSyndieElite
   name: uplink-hardsuit-syndieelite-name
   description: uplink-hardsuit-syndieelite-desc
-  icon: { sprite: /Textures/Clothing/OuterClothing/Hardsuits/syndieelite.rsi, state: icon }
+# Start Harmony change - Changed sprite path
+# icon: { sprite: /Textures/Clothing/OuterClothing/Hardsuits/syndieelite.rsi, state: icon }
+  icon: { sprite: /Textures/_Harmony/Clothing/OuterClothing/Hardsuits/syndieelite.rsi, state: icon }
+# End Harmony change
   productEntity: ClothingBackpackDuffelSyndicateEliteHardsuitBundle
   cost:
     Telecrystal: 12


### PR DESCRIPTION
## About the PR
Updates elite/bloodred hardsuit icons to appear instead of upstream icons.

## Why / Balance
Overlooked by the original resprite PR.

## Technical details
8 lines of YAML

## Media
<img width="381" height="244" alt="e1" src="https://github.com/user-attachments/assets/d35e3029-266e-42c5-9d81-1a6f986a797c" />


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
- fix: Fixed upstream icons appearing in place of resprited icons