### PR TITLE
Remove Tasers

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -336,7 +336,7 @@
     - id: RubberStampHos
     - id: BoxHoSCircuitboards
     - id: WeaponDisabler
-    - id: WeaponTaser
+    # - id: WeaponTaser # Harmony
     - id: WantedListCartridge
     - id: DrinkHosFlask
 

--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -28,7 +28,7 @@
     children:
     - id: FlashlightSeclite
     # - id: WeaponDisabler # Harmony
-    - id: WeaponTaser
+    # - id: WeaponTaser # Harmony
     - id: ClothingBeltSecurityFilled
     - id: Flash
     - id: ClothingEyesGlassesSecurity
@@ -73,7 +73,7 @@
     - id: FlashlightSeclite
       prob: 0.8
     # - id: WeaponDisabler # Harmony
-    - id: WeaponTaser
+    # - id: WeaponTaser # Harmony
     - id: ClothingUniformJumpsuitSecGrey
       prob: 0.3
     - id: ClothingHeadHelmetBasic
@@ -107,7 +107,7 @@
   table: !type:AllSelector
     children:
     - id: ClothingEyesGlassesSecurity
-    - id: WeaponTaser
+    # - id: WeaponTaser # Harmony
     # - id: WeaponDisabler # Harmony
     - id: TrackingImplanter
       amount: 2


### PR DESCRIPTION
## About the PR
Removal of tasers from Sec lockers

## Why / Balance
There's no reason Sec should have tools as strong as this for dealing with antagonists, especially with how hard we've been trying to push back the stun meta. Personally I think stuns are (were) in a fine spot right now, but this not only walks all of that back but takes off running in the other direction. As we learned from the previous stun meta, when stuns become too strong, they're just used to more easily lethal somebody. This also completely kills the ability to run melee as an antagonist in any conceivable way, as a single taser shot will stop you dead in your tracks. ANY antagonist that relies on melee is completely fucked by the taser, because even if they're immune to knockdowns, a taser will still slow them down significantly.

Additionally, tasers outrange EMP implants, so even using that as a crutch won't do you any good. It's just going to become a battle of "who can tase and magdump the other first?". Yes, you can push yourself out of knockdown, and you need your hand empty to do so, but do you think you'd have the time to react and do that before Sec follows up? What about other players? It's an absolutely ridiculous item that punishes casual players to an even greater degree. I can't think of anybody that would want to be on the receiving end of this, and it is wholly going to scare away newer players from trying to roll antag.

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- remove: Removed tasers from Sec
