### PR TITLE
Re-add wizard subgamemode

### DIFF
--- a/Resources/Prototypes/Roles/Antags/wizard.yml
+++ b/Resources/Prototypes/Roles/Antags/wizard.yml
@@ -9,7 +9,7 @@
   id: Wizard
   name: roles-antag-wizard-name
   antagonist: true
-  # setPreference: true # Disabled as roundstart gamemode until reworked
+  setPreference: true # Harmony Change - reactivates midround wizard
   objective: roles-antag-wizard-objective # TODO: maybe give random objs and stationary ones from AntagObjectives and AntagRandomObjectives
   requirements: # I hate time locked roles but this should be enough time for someone to be acclimated
   - !type:OverallPlaytimeRequirement

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -147,7 +147,10 @@
   rules:
   - DummyNonAntagChance
   - Traitor
-  - SubGamemodesRuleNoWizard
+  # Harmony Start - reenableds midround
+  #- SubGamemodesRuleNoWizard
+  - SubGamemodesRule
+  # Harmony end
   - BasicStationEventScheduler
   - MeteorSwarmScheduler
   - SpaceTrafficControlEventScheduler
@@ -176,7 +179,10 @@
   rules:
   - Nukeops
   - DummyNonAntagChance
-  - SubGamemodesRuleNoWizard
+  # Harmony start - reactivates wizard midround
+  #- SubGamemodesRuleNoWizard
+  - SubGamemodesRule
+  # Harmony End
   - BasicStationEventScheduler
   - MeteorSwarmScheduler
   - SpaceTrafficControlEventScheduler
@@ -194,7 +200,10 @@
   rules:
   - DummyNonAntagChance
   - Revolutionary
-  - SubGamemodesRuleNoWizard
+  # Harmony start - reactivates wizard midround even if revs are bye bye
+  #- SubGamemodesRuleNoWizard
+  - SubGamemodesRule
+  # Harmony end
   - BasicStationEventScheduler
   - MeteorSwarmScheduler
   - SpaceTrafficControlEventScheduler


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
Readds wizard midround, basically revetrs [#40938](https://github.com/space-wizards/space-station-14/pull/40983/files)
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This removed any chance of wizard spawning, and we had already limited it to just sub gamemode, soo I just added it back
## Technical details
<!-- Summary of code changes for easier review. -->
Reverts [#40938](https://github.com/space-wizards/space-station-14/pull/40983/files)
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
No media needed
## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Wizard can now roll as a subgamemode again

