### PR TITLE
C-4 buff

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Bombs/plastic.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Bombs/plastic.yml
@@ -77,9 +77,9 @@
     - Trigger
   - type: Explosive # Powerful explosion in a very small radius. Doesn't break underplating.
     explosionType: DemolitionCharge
-    totalIntensity: 60
+    totalIntensity: 10 # Harmony - 60 -> 10
     intensitySlope: 5
-    maxIntensity: 30
+    maxIntensity: 15 # Harmony - 30 -> 15
     canCreateVacuum: false
   - type: ExplodeOnTrigger
     keysIn:


### PR DESCRIPTION
## About the PR
Partially reverts c-4 changes made in https://github.com/ss14-harmony/ss14-harmony/pull/727

## Why / Balance
C-4 was made too weak, it's useless for 2 TC and nobody uses it anymore, making it a complete noob trap.

After the nerf, crew now gets access to more powerful explosives for **literally free** that detonate instantly (seismic charge/detcord)

## Technical details
changed 1 value in plastic.yml, adjusted comments

## Media
<img width="282" height="474" alt="obraz" src="https://github.com/user-attachments/assets/88c6cf94-08b3-4782-9461-d53a2316ffb0" />

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- tweak: The C-4's destructive capability has been buffed.