### PR TITLE
Removes MimicVendor gamerule

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -14,7 +14,7 @@
     - id: IonStorm # its calm like 90% of the time smh
     - id: KudzuGrowth
     - id: MassHallucinations
-    - id: MimicVendorRule
+    # - id: MimicVendorRule # Harmony Change
     - id: MouseMigration
     - id: PowerGridCheck
     - id: RandomSentience


### PR DESCRIPTION
## About the PR
Removes the MimicVendor gamerule from the calm events pool

## Why / Balance
Mimic implementation is boring at best, irritating at worst. It rolling feels like a waste of an event roll, and general sentiment seems to be that it would be better removed until it receives some sort of update.

## Technical details
Comments out MimicVendorRule from the BasicCalmEvents table in Resources/Prototypes/GameRules/events.yml

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- remove: Removed the MimicVendor gamerule from the random pool

