### PR TITLE
Removes Despair from the Cursed Mask pool

### DIFF
--- a/Content.Shared/Clothing/Components/CursedMaskComponent.cs
+++ b/Content.Shared/Clothing/Components/CursedMaskComponent.cs
@@ -27,7 +27,7 @@ public sealed partial class CursedMaskComponent : Component
     /// <summary>
     /// Damage modifier applied when the "Despair" expression is present.
     /// </summary>
-    // Harmony change start
+    // Harmony change start, removes Despair mask
     /*[DataField]
     public DamageModifierSet DespairDamageModifier = new(); */
     // Harmony change end
@@ -62,6 +62,6 @@ public enum CursedMaskExpression : byte
 {
     Neutral,
     Joy,
-    // Despair, // Harmony change
+    // Despair, // Harmony change, removes Despair mask
     Anger
 }

--- a/Content.Shared/Clothing/Components/CursedMaskComponent.cs
+++ b/Content.Shared/Clothing/Components/CursedMaskComponent.cs
@@ -27,8 +27,10 @@ public sealed partial class CursedMaskComponent : Component
     /// <summary>
     /// Damage modifier applied when the "Despair" expression is present.
     /// </summary>
-    [DataField]
-    public DamageModifierSet DespairDamageModifier = new();
+    // Harmony change start
+    /*[DataField]
+    public DamageModifierSet DespairDamageModifier = new(); */
+    // Harmony change end
 
     /// <summary>
     /// Whether or not the mask is currently attached to an NPC.

--- a/Content.Shared/Clothing/Components/CursedMaskComponent.cs
+++ b/Content.Shared/Clothing/Components/CursedMaskComponent.cs
@@ -60,6 +60,6 @@ public enum CursedMaskExpression : byte
 {
     Neutral,
     Joy,
-    Despair,
+    // Despair, // Harmony change
     Anger
 }

--- a/Content.Shared/Clothing/SharedCursedMaskSystem.cs
+++ b/Content.Shared/Clothing/SharedCursedMaskSystem.cs
@@ -53,14 +53,16 @@ public abstract class SharedCursedMaskSystem : EntitySystem
             args.Args.ModifySpeed(ent.Comp.JoySpeedModifier);
     }
 
-    private void OnModifyDamage(Entity<CursedMaskComponent> ent, ref InventoryRelayedEvent<DamageModifyEvent> args)
+    // Harmony change start
+    /* private void OnModifyDamage(Entity<CursedMaskComponent> ent, ref InventoryRelayedEvent<DamageModifyEvent> args)
     {
         if (ent.Comp.CurrentState == CursedMaskExpression.Despair)
             args.Args.Damage = DamageSpecifier.ApplyModifierSet(args.Args.Damage,
                 DamageSpecifier.PenetrateArmor(ent.Comp.DespairDamageModifier,
-                    args.Args.ArmorPenetration)); // Goob edit
-    }
-
+                    args.Args.ArmorPenetration)); // Goob edit 
+    } */
+    // Harmony change end
+    
     protected void RandomizeCursedMask(Entity<CursedMaskComponent> ent, EntityUid wearer)
     {
         var random = new System.Random((int) _timing.CurTick.Value);

--- a/Content.Shared/Clothing/SharedCursedMaskSystem.cs
+++ b/Content.Shared/Clothing/SharedCursedMaskSystem.cs
@@ -28,7 +28,7 @@ public abstract class SharedCursedMaskSystem : EntitySystem
         SubscribeLocalEvent<CursedMaskComponent, ExaminedEvent>(OnExamine);
 
         SubscribeLocalEvent<CursedMaskComponent, InventoryRelayedEvent<RefreshMovementSpeedModifiersEvent>>(OnMovementSpeedModifier);
-        SubscribeLocalEvent<CursedMaskComponent, InventoryRelayedEvent<DamageModifyEvent>>(OnModifyDamage);
+        // SubscribeLocalEvent<CursedMaskComponent, InventoryRelayedEvent<DamageModifyEvent>>(OnModifyDamage); // Harmony change
     }
 
     private void OnClothingEquip(Entity<CursedMaskComponent> ent, ref ClothingGotEquippedEvent args)

--- a/Content.Shared/Clothing/SharedCursedMaskSystem.cs
+++ b/Content.Shared/Clothing/SharedCursedMaskSystem.cs
@@ -28,7 +28,7 @@ public abstract class SharedCursedMaskSystem : EntitySystem
         SubscribeLocalEvent<CursedMaskComponent, ExaminedEvent>(OnExamine);
 
         SubscribeLocalEvent<CursedMaskComponent, InventoryRelayedEvent<RefreshMovementSpeedModifiersEvent>>(OnMovementSpeedModifier);
-        // SubscribeLocalEvent<CursedMaskComponent, InventoryRelayedEvent<DamageModifyEvent>>(OnModifyDamage); // Harmony change
+        // SubscribeLocalEvent<CursedMaskComponent, InventoryRelayedEvent<DamageModifyEvent>>(OnModifyDamage); // Harmony change for removal of Despair mask
     }
 
     private void OnClothingEquip(Entity<CursedMaskComponent> ent, ref ClothingGotEquippedEvent args)
@@ -53,7 +53,7 @@ public abstract class SharedCursedMaskSystem : EntitySystem
             args.Args.ModifySpeed(ent.Comp.JoySpeedModifier);
     }
 
-    // Harmony change start
+    // Harmony change start, removes Despair mask systems
     /* private void OnModifyDamage(Entity<CursedMaskComponent> ent, ref InventoryRelayedEvent<DamageModifyEvent> args)
     {
         if (ent.Comp.CurrentState == CursedMaskExpression.Despair)

--- a/Resources/Prototypes/Entities/Clothing/Masks/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/specific.yml
@@ -61,18 +61,20 @@
       enum.CursedMaskVisuals.State:
         mask:
           Neutral: { state: icon }
-          Despair: { state: icon-despair }
+          # Despair: { state: icon-despair } # Harmony change
           Joy: { state: icon-joy }
           Anger: { state: icon-anger }
   - type: Tag
     tags: [] # ignore "WhitelistChameleon" tag
   - type: SelfEquipOnly
   - type: CursedMask
-    despairDamageModifier:
-      coefficients:
-        Blunt: 0.6
-        Slash: 0.6
-        Piercing: 0.4
+    # Harmony change start
+    # despairDamageModifier:
+      # coefficients:
+        # Blunt: 0.6
+        # Slash: 0.6
+        # Piercing: 0.4
+    # Harmony change end
   - type: HideLayerClothing
     slots:
     - Snout


### PR DESCRIPTION
## About the PR
Removed the "Despair" expression from the Cursed Mask. Also, my C# knowledge is less than stellar so it's a bit fuck it we ball. Shit doesn't crash, though.

## Why / Balance
Despair granted 40% Blunt resist, 40% Slash resist, and **60% Pierce resist** to the wearer. Especially with how resistances stack, a spread that broad (compare to the Syndicate Gas Mask, which provides 5% resistance to Blunt, Slash, Pierce, and Heat) just cannot really be justified. The consequences of a bad roll are not nearly enough to balance these kinds of reductions, and damage reduction in general is only going to be gamed as awareness of the feature grows. 

## Technical details
Removes all code for the Despair mask from CursedMaskComponent.cs and and SharedCursedMaskSystem.cs

## Media
N/A

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
- remove: Removed Despair from the pool rollable by the Cursed Mask

