### PR TITLE
Bola nerf

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/bola.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/bola.yml
@@ -6,10 +6,6 @@
   components:
   - type: Item
     size: Normal
-# Start Harmony change - Changed shape
-    shape:
-    - 0,0,1,1
-# End Harmony change
   - type: Sprite
     sprite: _Harmony/Objects/Weapons/Throwable/bola.rsi #Harmony Change: Sprite pathway changed.
     state: icon

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/bola.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/bola.yml
@@ -6,6 +6,10 @@
   components:
   - type: Item
     size: Normal
+# Start Harmony change - Changed shape
+    shape:
+    - 0,0,1,1
+# End Harmony change
   - type: Sprite
     sprite: _Harmony/Objects/Weapons/Throwable/bola.rsi #Harmony Change: Sprite pathway changed.
     state: icon
@@ -41,9 +45,11 @@
         Blunt: 5
   - type: Ensnaring
     freeTime: 2.0
-    breakoutTime: 3.5 #all bola should generally be fast to remove
-    walkSpeed: 0.5 #makeshift bola shouldn't slow too much
-    sprintSpeed: 0.5
+# Start Harmony change
+    breakoutTime: 2.5 # 3.5 -> 2.5
+    walkSpeed: 0.75 # 0.5 -> 0.75
+    sprintSpeed: 0.75 # 0.5 -> 0.75
+# End Harmony change
     staminaDamage: 0 # anything but this is gamebreaking
     canThrowTrigger: true
     canMoveBreakout: true


### PR DESCRIPTION
## About the PR
Bola movement speed modifier reduced to 75% from 50%

Bola removal time decreased to 2.5 from 3.5

## Why / Balance
Bolas are easily one of the most powerful items security has at their disposal, surpassing even lethals. Landing one on an antagonist practically guarantees they will be forced to disengage, if not just immediately stop them outright. Security can use them to literally gore any antagonist with impunity, including full and prepared nukie teams. They are **_COMPLETELY UNREACTABLE AND NOT PREDICTED, you can be bola'd before you even see the bola in your attacker's hands._**

Security can make bolas for less than 5 steel a piece, they are EXTREMELY easy to mass produce and mass store in security belts to throw at traitors.

Your movement speed can be **_CUT IN HALF_** due to a single mistake. A competent player can wail on you for 3.5 seconds while you try to break free. I have no idea why this exists as it currently does, as all other weapons in the game don't even remotely compare to how effective bolas are.

With movement chems and hypopen finally being nerfed upstream we can start to nerf the overtuned security equipment that was made as a bandaid to counter them.

Even after the nerf they will still be amazing crowd control, a 25% cut in movement speed is still very debilitating and 2.5 seconds is enough time to land good hits with melee, lethals, or non lethals.

## Technical details
yaml

## Media

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- tweak: Bolas are now faster to remove and slow targets slightly less.