### PR TITLE
Apply Movement Slowdown and Moved to Sec Lathe from Vend

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/sec.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/sec.yml
@@ -16,9 +16,11 @@
     ClothingBeltSecurityWebbing: 5
     CombatKnife: 3
     Zipties: 12
-    RiotShield: 2
-    RiotLaserShield: 2
-    RiotBulletShield: 2
+# Harmony Change: Removes Shields from the SecTech
+#    RiotShield: 2
+#    RiotLaserShield: 2
+#    RiotBulletShield: 2
+# End of Harmony Change
     RadioHandheldSecurity: 5
     SecurityBola: 4 #Harmony Change: Security Bolas added
   # security officers need to follow a diet regimen!

--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -69,7 +69,7 @@
   id: RiotShield
   description: A large tower shield. Good for controlling crowds.
   components:
-# Begin of Harmony Change: Shield Rework -- Suit Storage Slot
+# Begin of Harmony Change: Shield Rework -- Suit Storage Slot, Held/Worn Slowdown
     - type: Sprite
       sprite: _Harmony/Objects/Weapons/Melee/Shields/riot-shield.rsi
       state: icon
@@ -81,6 +81,12 @@
       quickEquip: false
       slots:
       - suitStorage
+    - type: HeldSpeedModifier
+      walkModifier: 0.8
+      sprintModifier: 0.8
+    - type: ClothingSpeedModifier
+      walkModifier: 0.9
+      sprintModifier: 0.9
 # End of Harmony Change
     - type: StaticPrice
       price: 90
@@ -103,11 +109,11 @@
   id: RiotLaserShield
   description: A shield built for withstanding lasers, but not much else.
   components:
-# Begin of Harmony Change: Shield Rework -- Suit Storage Slot
+# Begin of Harmony Change: Shield Rework -- Suit Storage Slot, Held/Worn Slowdown
     - type: Sprite
       sprite: _Harmony/Objects/Weapons/Melee/Shields/riot-laser-shield.rsi
       state: icon
-      #state: riot_laser-icon 
+      #state: riot_laser-icon
     - type: Item
       sprite: _Harmony/Objects/Weapons/Melee/Shields/riot-laser-shield.rsi
       size: Ginormous
@@ -117,6 +123,12 @@
       quickEquip: false
       slots:
       - suitStorage
+    - type: HeldSpeedModifier
+      walkModifier: 0.8
+      sprintModifier: 0.8
+    - type: ClothingSpeedModifier
+      walkModifier: 0.9
+      sprintModifier: 0.9
 # End of Harmony Change
     - type: Blocking
       passiveBlockModifier:
@@ -134,11 +146,11 @@
   id: RiotBulletShield
   description: A shield built for protecting against ballistics, but not much else.
   components:
-# Begin of Harmony Change: Shield Rework -- Suit Storage Slot
+# Begin of Harmony Change: Shield Rework -- Suit Storage Slot, Held/Worn Slowdown
     - type: Sprite
       sprite: _Harmony/Objects/Weapons/Melee/Shields/riot-bullet-shield.rsi
       state: icon
-      #state: riot_bullet-icon 
+      #state: riot_bullet-icon
     - type: Item
       sprite: _Harmony/Objects/Weapons/Melee/Shields/riot-bullet-shield.rsi
       size: Ginormous
@@ -147,7 +159,13 @@
       sprite: _Harmony/Objects/Weapons/Melee/Shields/riot-bullet-shield.rsi
       quickEquip: false
       slots:
-      - suitStorage 
+      - suitStorage
+    - type: HeldSpeedModifier
+      walkModifier: 0.8
+      sprintModifier: 0.8
+    - type: ClothingSpeedModifier
+      walkModifier: 0.9
+      sprintModifier: 0.9
 # End of Harmony Change
     - type: Blocking
       passiveBlockModifier:
@@ -167,7 +185,7 @@
   id: WoodenBuckler
   description: A small round wooden makeshift shield.
   components:
-# Begin of Harmony Change: Shield Rework -- Suit Storage Slot
+# Begin of Harmony Change: Shield Rework -- Suit Storage Slot, Held/Worn Slowdown
     - type: Sprite
       sprite: _Harmony/Objects/Weapons/Melee/Shields/buckler.rsi
       state: icon
@@ -181,6 +199,12 @@
       quickEquip: false
       slots:
       - suitStorage
+    - type: HeldSpeedModifier
+      walkModifier: 0.85
+      sprintModifier: 0.85
+    - type: ClothingSpeedModifier
+      walkModifier: 0.95
+      sprintModifier: 0.95
 # End of Harmony Change
     - type: Blocking
       passiveBlockModifier:
@@ -285,9 +309,9 @@
   id: MakeshiftShield
   description: A rundown looking shield, not good for much.
   components:
-# Begin of Harmony Change: Shield Rework -- Suit Storage Slot
+# Begin of Harmony Change: Shield Rework -- Suit Storage Slot, Held/Worn Slowdown
     - type: Sprite
-      sprite: _Harmony/Objects/Weapons/Melee/Shields/makeshift-shield.rsi 
+      sprite: _Harmony/Objects/Weapons/Melee/Shields/makeshift-shield.rsi
       state: icon
       #state: makeshift-icon
     - type: Item
@@ -298,7 +322,13 @@
       sprite: _Harmony/Objects/Weapons/Melee/Shields/makeshift-shield.rsi
       quickEquip: false
       slots:
-      - suitStorage 
+      - suitStorage
+    - type: HeldSpeedModifier
+      walkModifier: 0.70
+      sprintModifier: 0.70
+    - type: ClothingSpeedModifier
+      walkModifier: 0.8
+      sprintModifier: 0.8
   # End of Harmony Change
     - type: Blocking
       passiveBlockModifier:
@@ -658,3 +688,8 @@
                   max: 2
     - type: StaticPrice
       price: 150
+# Harmony Change: Adds Held Slowdown
+    - type: HeldSpeedModifier
+      walkModifier: 0.85
+      sprintModifier: 0.85
+# End of Harmony Change

--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -82,11 +82,11 @@
       slots:
       - suitStorage
     - type: HeldSpeedModifier
-      walkModifier: 0.8
-      sprintModifier: 0.8
-    - type: ClothingSpeedModifier
       walkModifier: 0.9
       sprintModifier: 0.9
+    - type: ClothingSpeedModifier
+      walkModifier: 0.95
+      sprintModifier: 0.95
 # End of Harmony Change
     - type: StaticPrice
       price: 90
@@ -124,11 +124,11 @@
       slots:
       - suitStorage
     - type: HeldSpeedModifier
-      walkModifier: 0.8
-      sprintModifier: 0.8
-    - type: ClothingSpeedModifier
       walkModifier: 0.9
       sprintModifier: 0.9
+    - type: ClothingSpeedModifier
+      walkModifier: 0.95
+      sprintModifier: 0.95
 # End of Harmony Change
     - type: Blocking
       passiveBlockModifier:
@@ -161,11 +161,11 @@
       slots:
       - suitStorage
     - type: HeldSpeedModifier
-      walkModifier: 0.8
-      sprintModifier: 0.8
-    - type: ClothingSpeedModifier
       walkModifier: 0.9
       sprintModifier: 0.9
+    - type: ClothingSpeedModifier
+      walkModifier: 0.95
+      sprintModifier: 0.95
 # End of Harmony Change
     - type: Blocking
       passiveBlockModifier:
@@ -200,8 +200,8 @@
       slots:
       - suitStorage
     - type: HeldSpeedModifier
-      walkModifier: 0.85
-      sprintModifier: 0.85
+      walkModifier: 0.9
+      sprintModifier: 0.9
     - type: ClothingSpeedModifier
       walkModifier: 0.95
       sprintModifier: 0.95
@@ -324,11 +324,11 @@
       slots:
       - suitStorage
     - type: HeldSpeedModifier
-      walkModifier: 0.70
-      sprintModifier: 0.70
-    - type: ClothingSpeedModifier
       walkModifier: 0.8
       sprintModifier: 0.8
+    - type: ClothingSpeedModifier
+      walkModifier: 0.9
+      sprintModifier: 0.9
   # End of Harmony Change
     - type: Blocking
       passiveBlockModifier:
@@ -638,6 +638,11 @@
       components:
       - type: DisarmMalus
         malus: 0.6
+  # Harmony Change: Adds Held Slowdown
+      - type: HeldSpeedModifier
+        walkModifier: 0.9
+        sprintModifier: 0.9
+  # End of Harmony Change
     - type: ItemToggleSize
       activatedSize: Huge
     - type: Sprite
@@ -688,8 +693,3 @@
                   max: 2
     - type: StaticPrice
       price: 150
-# Harmony Change: Adds Held Slowdown
-    - type: HeldSpeedModifier
-      walkModifier: 0.85
-      sprintModifier: 0.85
-# End of Harmony Change

--- a/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
@@ -63,7 +63,10 @@
   - Stunbaton
   - CombatKnife
   - RiotShield
-
+#Start of Harmony Change: Adds the Laser and Bullet Shields to Security Research
+  - RiotLaserShield
+  - RiotBulletShield
+# End of Harmony Change
 ## Dynamic recipes
 
 - type: latheRecipePack

--- a/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
@@ -67,6 +67,7 @@
   - RiotLaserShield
   - RiotBulletShield
 # End of Harmony Change
+
 ## Dynamic recipes
 
 - type: latheRecipePack

--- a/Resources/Prototypes/_Harmony/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/_Harmony/Recipes/Lathes/security.yml
@@ -51,3 +51,19 @@
     Glass: 500
     Plastic: 250
     Uranium: 300
+
+- type: latheRecipe
+  parent: BaseShieldRecipe
+  id: RiotLaserShield
+  result: RiotLaserShield
+  materials:
+    Steel: 400
+    Glass: 400
+
+- type: latheRecipe
+  parent: BaseShieldRecipe
+  id: RiotBulletShield
+  result: RiotBulletShield
+  materials:
+    Steel: 400
+    Glass: 400


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
- Removes round-start ballistic shields from the sectech.
- Adds the bullet and laser shields as recipes in the secfab
- Gives some shields slowdown when held
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Since they were updated to fit on the suit-storage slot, shields have been an issue on green alert. This PR removes them from being obtainable round-start without going through the Warden or Head of Security to print you one with the secfab. It also introduces a held slowdown for these shields so they're not as effective in combat.
## Technical details
<!-- Summary of code changes for easier review. -->

### _Harmony Namescape
Resources/Prototypes/_Harmony/Recipes/Lathes/security.yml -- Added recipes for the bullet and laser shields

### Upstream Files
Resources/Prototypes/Catalog/VendingMachines/Inventories/sec.yml -- Removes shields from the sectech
Resources/Prototypes/Entities/Objects/Shields/shields.yml -- Added slowdown to shield prototypes
Resources/Prototypes/Recipes/Lathes/Packs/security.yml -- Adds the bullet and laser shields to the sec techfab

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
<img width="748" height="496" alt="{6D3F58DC-8346-4663-B898-3E405EEEBF43}" src="https://github.com/user-attachments/assets/b56ebc50-ddd3-4f02-8b6a-038287903565" />

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Security riot shields are no longer obtainable through the sectech
- tweak: Added slowdown to most crew-based shields
