### PR TITLE
Remove speed boots

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/Packs/science.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/science.yml
@@ -30,7 +30,7 @@
   recipes:
   - ClothingShoesBootsMagSci
   - ClothingShoesBootsMoon
-  - ClothingShoesBootsSpeed
+#  - ClothingShoesBootsSpeed # Harmony change: removed speed boots
   - ClothingShoesBootsJump
   - ClothingBackpackHolding
   - ClothingBackpackSatchelHolding

--- a/Resources/Prototypes/Recipes/Lathes/misc.yml
+++ b/Resources/Prototypes/Recipes/Lathes/misc.yml
@@ -151,14 +151,16 @@
   materials:
     Steel: 600
 
-- type: latheRecipe
-  id: ClothingShoesBootsSpeed
-  result: ClothingShoesBootsSpeed
-  completetime: 2
-  materials:
-    Steel: 1500
-    Plastic: 1000
-    Silver: 500
+# Harmony change start: remove speed boots
+#- type: latheRecipe
+#  id: ClothingShoesBootsSpeed
+#  result: ClothingShoesBootsSpeed
+#  completetime: 2
+#  materials:
+#    Steel: 1500
+#    Plastic: 1000
+#    Silver: 500
+# Harmony change end
 
 - type: latheRecipe
   id: ClothingShoesBootsJump

--- a/Resources/Prototypes/Research/civilianservices.yml
+++ b/Resources/Prototypes/Research/civilianservices.yml
@@ -206,17 +206,19 @@
 
 # Tier 3
 
-- type: technology
-  id: QuantumFiberWeaving
-  name: research-technology-quantum-fiber-weaving
-  icon:
-    sprite: Clothing/Shoes/Boots/speedboots.rsi
-    state: icon
-  discipline: CivilianServices
-  tier: 3
-  cost: 10000
-  recipeUnlocks:
-  - ClothingShoesBootsSpeed
+# Harmony change start: remove speed boots
+#- type: technology
+#  id: QuantumFiberWeaving
+#  name: research-technology-quantum-fiber-weaving
+#  icon:
+#    sprite: Clothing/Shoes/Boots/speedboots.rsi
+#    state: icon
+#  discipline: CivilianServices
+#  tier: 3
+#  cost: 10000
+#  recipeUnlocks:
+#  - ClothingShoesBootsSpeed
+# Harmony change end
 
 - type: technology
   id: BluespaceChemistry


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
Speed boots are no longer obtainable.

## Why / Balance
Speed boots are grossly overpowered. They are a 50% speed boost for minutes straight, with the only downsides being unable to wear things like jackboots (not important when you're *always* faster and the combat knife isn't particularly relevant) and no-slips (only affects traitors). Limited battery life can be offset by just... bringing a spare power cell. The only reason they aren't abused is that they are a tier 3 research from Science. When speed boots are researched, Security needs them in order to keep up with potential Science antags, so the antags without speed boots suffer. Either that or the RND server gets destroyed entirely (or Science is otherwise kneecapped) by an antag who wants to secure a monopoly on speed boots, who is now that much stronger. And meth was considered overpowered at 35% while actively metabolising, which was not a matter of a whole minute, and actively dealing poison if not cut.

## Technical details
Commented out the speed boots lathe recipe prototype.
Commented out the speed boots lathe recipe from the list of protolathe recipes.
Commented out the speed boots Science research.

## Media
<img width="690" height="407" alt="image" src="https://github.com/user-attachments/assets/b27e6cb5-261a-4f95-a3cf-a9fbacc20548" />

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: 
- remove: Speed boots are no longer obtainable.