### PR TITLE
Fixing clothing animation resets

### DIFF
--- a/Content.Client/Clothing/ClientClothingSystem.cs
+++ b/Content.Client/Clothing/ClientClothingSystem.cs
@@ -69,7 +69,7 @@ public sealed class ClientClothingSystem : ClothingSystem
         if (args.Sprite == null)
             return;
 
-        UpdateAllSlots(uid, component);
+        // UpdateAllSlots(uid, component); // Harmony - doesn't fucking work for sex displacement updates anyway
 
         // No clothing equipped -> make sure the layer is hidden, though this should already be handled by on-unequip.
         if (_sprite.LayerMapTryGet((uid, args.Sprite), HumanoidVisualLayers.StencilMask, out var layer, false))


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
Currently AppearanceChangeEvent is called quite broadly, which is fine overall, but in the case of clothing, it leads to **_any_** form of visualizer instantly resetting animated clothing back to their first frame. Things like being on fire, getting stunned, toggling combat mode, and **_ANY_** change in your health, no matter how small, no matter if it is positive or negative. 

The specific line that I comment out is the cause of this, and it only exists to address sex clothing displacement. The only use case for this that I can think of is DNA scrambling. The problem? 

It doesn't even work.

It is redundant and messes up animations, something less felt on a piece of clothing that cycles between 3 frames, but much more on anything that tries to play a longer cycle.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

https://github.com/user-attachments/assets/3bddb602-47ba-46bc-9115-a99feb3d2698



https://github.com/user-attachments/assets/d0c889a6-a592-4f78-a56e-b43984c67f90

Notice the subtle stuttering in the before, and complete pause when combat mode starts getting toggled. The stuttering is from passive regeneration, forcing it back to frame one, each time.

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed clothing animations suddenly resetting.
