### PR TITLE
Removes Extreme presents from santa anomaly crits

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
@@ -1150,7 +1150,7 @@
         maxAmount: 5
         maxRange: 5
       spawns:
-      - PresentRandomUnsafe
+     #- PresentRandomUnsafe #Harmony Change - comments out unsafe present.
       - PresentRandom
       - PresentRandomCoal
       - PresentRandomCash
@@ -1162,7 +1162,8 @@
         maxAmount: 20
         maxRange: 6
       spawns:
-      - PresentRandomInsane
+    # - PresentRandomInsane # Harmony change - comments out insane present
+      - PresentRandom #Harmony change - replaces insane present with normal variety.
   - type: ProjectileAnomaly
     projectilePrototype: DrinkLemonLimeCranberryCan
     minProjectiles: 1


### PR DESCRIPTION
## About the PR
Does what it says on the tin, removes extreme and unsafe presents being able to be spawned by the present anomaly going supercritical. instead it just spawns the regular safer presents. Requested by the harmony admin team. I crit 3 anomalies and didn't get anything of note (there are still some interesting items like merc web vests in the pool to keep things interesting).

## Why / Balance
No, a non-antag scientist shouldn't get a blood-red. Or a universal ID. Or end the round by spawning ratvar. We also really dont need to encourage non-antags to be critting anomalies and majorly impacting the round. 

## Technical details
-Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml edits two lines in the file to uncomment the prototypes.

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.

**Changelog**
:cl:
- tweak: Present anomalies no longer spawn unsafe presents.
- tweak: Present anomalies critting no longer spawn extreme presents.

