### PR TITLE
Reduce available botany slots to 2

### DIFF
--- a/Resources/Prototypes/Maps/box.yml
+++ b/Resources/Prototypes/Maps/box.yml
@@ -26,7 +26,7 @@
             Quartermaster: [ 1, 1 ]
             #Service (14)
             Bartender: [ 2, 2 ]
-            Botanist: [ 3, 3 ]
+            Botanist: [ 2, 2 ]
             Chef: [ 2, 2 ]
             Janitor: [ 2, 2 ]
             Chaplain: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/box.yml
+++ b/Resources/Prototypes/Maps/box.yml
@@ -26,7 +26,7 @@
             Quartermaster: [ 1, 1 ]
             #Service (14)
             Bartender: [ 2, 2 ]
-            Botanist: [ 2, 2 ]
+            Botanist: [ 2, 2 ] # Harmony change, - 3, 3 > 2, 2 reduced botany slots
             Chef: [ 2, 2 ]
             Janitor: [ 2, 2 ]
             Chaplain: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/marathon.yml
+++ b/Resources/Prototypes/Maps/marathon.yml
@@ -27,7 +27,7 @@
             Quartermaster: [ 1, 1 ]
             #service (11 - 13)
             Bartender: [ 2, 2 ]
-            Botanist: [ 2, 2 ] # Harmony change, - 3, 3 > 2, 2 reduced botany slots
+            Botanist: [ 2, 2 ] # Harmony change, - 2, 3 > 2, 2 reduced botany slots
             Chef: [ 2, 2 ]
             Janitor: [ 1, 2 ]
             Chaplain: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/marathon.yml
+++ b/Resources/Prototypes/Maps/marathon.yml
@@ -27,7 +27,7 @@
             Quartermaster: [ 1, 1 ]
             #service (11 - 13)
             Bartender: [ 2, 2 ]
-            Botanist: [ 2, 3 ]
+            Botanist: [ 2, 2 ]
             Chef: [ 2, 2 ]
             Janitor: [ 1, 2 ]
             Chaplain: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/marathon.yml
+++ b/Resources/Prototypes/Maps/marathon.yml
@@ -27,7 +27,7 @@
             Quartermaster: [ 1, 1 ]
             #service (11 - 13)
             Bartender: [ 2, 2 ]
-            Botanist: [ 2, 2 ]
+            Botanist: [ 2, 2 ] # Harmony change, - 3, 3 > 2, 2 reduced botany slots
             Chef: [ 2, 2 ]
             Janitor: [ 1, 2 ]
             Chaplain: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/oasis.yml
+++ b/Resources/Prototypes/Maps/oasis.yml
@@ -26,7 +26,7 @@
             Quartermaster: [ 1, 1 ]
             #service (15 - 16)
             Bartender: [ 2, 2 ]
-            Botanist: [ 2, 2 ]
+            Botanist: [ 2, 2 ] # Harmony change, - 3, 3 > 2, 2 reduced botany slots
             Chef: [ 2, 2 ]
             Janitor: [ 3, 3 ]
             Chaplain: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/oasis.yml
+++ b/Resources/Prototypes/Maps/oasis.yml
@@ -26,7 +26,7 @@
             Quartermaster: [ 1, 1 ]
             #service (15 - 16)
             Bartender: [ 2, 2 ]
-            Botanist: [ 2, 3 ]
+            Botanist: [ 2, 2 ]
             Chef: [ 2, 2 ]
             Janitor: [ 3, 3 ]
             Chaplain: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/oasis.yml
+++ b/Resources/Prototypes/Maps/oasis.yml
@@ -26,7 +26,7 @@
             Quartermaster: [ 1, 1 ]
             #service (15 - 16)
             Bartender: [ 2, 2 ]
-            Botanist: [ 2, 2 ] # Harmony change, - 3, 3 > 2, 2 reduced botany slots
+            Botanist: [ 2, 2 ] # Harmony change, - 2, 3 > 2, 2 reduced botany slots
             Chef: [ 2, 2 ]
             Janitor: [ 3, 3 ]
             Chaplain: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/plasma.yml
+++ b/Resources/Prototypes/Maps/plasma.yml
@@ -29,7 +29,7 @@
             Quartermaster: [ 1, 1 ]
             #service (15 - 17)
             Bartender: [ 2, 2 ]
-            Botanist: [ 2, 2 ] # Harmony change, - 3, 3 > 2, 2 reduced botany slots
+            Botanist: [ 2, 2 ] # Harmony change, - 2, 3 > 2, 2 reduced botany slots
             Chef: [ 2, 2 ]
             Janitor: [ 3, 3 ]
             Chaplain: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/plasma.yml
+++ b/Resources/Prototypes/Maps/plasma.yml
@@ -29,7 +29,7 @@
             Quartermaster: [ 1, 1 ]
             #service (15 - 17)
             Bartender: [ 2, 2 ]
-            Botanist: [ 2, 3 ]
+            Botanist: [ 2, 2 ]
             Chef: [ 2, 2 ]
             Janitor: [ 3, 3 ]
             Chaplain: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/plasma.yml
+++ b/Resources/Prototypes/Maps/plasma.yml
@@ -29,7 +29,7 @@
             Quartermaster: [ 1, 1 ]
             #service (15 - 17)
             Bartender: [ 2, 2 ]
-            Botanist: [ 2, 2 ]
+            Botanist: [ 2, 2 ] # Harmony change, - 3, 3 > 2, 2 reduced botany slots
             Chef: [ 2, 2 ]
             Janitor: [ 3, 3 ]
             Chaplain: [ 1, 1 ]


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
Reduced available botany slots on Box, Marathon, Oasis, and Plasma to 2.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
No 50 cap server needs three botanists. Reduced latejoin and round start botany slots to 2 from 3. Even in higher pop server, there is barely enough content for two, let alone three botanists. I know Oasis is meant to be a 70 pop map, but I've played Oasis a few times on Harmony and made the change in anticipation for it. Also, regardless of map, Botany simply does not play well with more than two IMHO.

edit: spoke with lucky and prime is probably the only map that has enough trays for three, so i will leave it at three. If we want to reduce it to two, will gladly change.
## Technical details
<!-- Summary of code changes for easier review. -->
Simple commented YML line changes
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
<img width="357" height="561" alt="box" src="https://github.com/user-attachments/assets/840a48b3-4add-42e8-8f1e-a4538a01757e" />
<img width="357" height="558" alt="Marathon" src="https://github.com/user-attachments/assets/d0885d6e-79f4-49b8-a0a2-36502cd4ab86" />
<img width="359" height="555" alt="Oasis" src="https://github.com/user-attachments/assets/a28b8782-5b50-4f6d-8d57-6f3919bcc112" />
<img width="363" height="562" alt="Plasma" src="https://github.com/user-attachments/assets/83ed3e71-21cc-421a-b0b7-5ea5e8c52e3c" />

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Reduced available botany slots on Box, Marathon, Oasis and Plasma


