### PR TITLE
Adds medieval items to an emagged Medical Techfab

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -475,6 +475,9 @@
     - HarmonyMedicalStatic # Harmony
     dynamicPacks:
     - Chemistry
+  - type: EmagLatheRecipes #Harmony change- add effects when emagged
+    emagStaticPacks: #Because Med + Evil
+    - Medieval
   - type: Machine
     board: MedicalTechFabCircuitboard
   - type: StealTarget

--- a/Resources/Prototypes/_Harmony/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/_Harmony/Entities/Clothing/Head/helmets.yml
@@ -1,0 +1,13 @@
+- type: entity
+  parent: ClothingHeadHelmetTemplar
+  id: ClothingHeadHelmetTemplarReal
+  description: Functional helmet fashioned to resemble the knights of old.
+  components:
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.85
+        Slash: 0.85
+        Piercing: 0.85
+        Heat: 0.85
+        Shock: 1.2

--- a/Resources/Prototypes/_Harmony/Recipes/Lathes/lathepacks.yml
+++ b/Resources/Prototypes/_Harmony/Recipes/Lathes/lathepacks.yml
@@ -56,6 +56,16 @@
   - ClothingEyesEyepatchHudMedical
   - ClothingEyesHudMedical
 
+## Medieval
+- type: latheRecipePack
+  id: Medieval
+  recipes:
+  - Claymore
+  - Cutlass
+  - BowImprovised
+  - ClothingHeadHelmetTemplarReal
+  - ArrowImprovised
+
 ## Security
 - type: latheRecipePack
   id: HarmonySecurityEquipmentStatic

--- a/Resources/Prototypes/_Harmony/Recipes/Lathes/medieval.yml
+++ b/Resources/Prototypes/_Harmony/Recipes/Lathes/medieval.yml
@@ -1,0 +1,41 @@
+# Recipes
+
+- type: latheRecipe
+  id: Claymore
+  result: Claymore
+  completetime: 6
+  materials:
+    Steel: 800
+
+- type: latheRecipe
+  id: Cutlass
+  result: Cutlass
+  completetime: 4
+  materials:
+    Steel: 600
+
+- type: latheRecipe
+  id: BowImprovised
+  result: BowImprovised
+  completetime: 4
+  materials:
+    Wood: 500
+    Cloth: 100
+
+- type: latheRecipe
+  id: ClothingHeadHelmetTemplarReal
+  result: ClothingHeadHelmetTemplarReal
+  completetime: 4
+  materials:
+    Steel: 800
+
+- type: latheRecipe #Slightly cheaper than making them by hand
+  id: ArrowImprovised
+  result: ArrowImprovised
+  completetime: 1
+  materials:
+    Steel: 50
+    Glass: 50
+    Cloth: 50
+
+


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
When emagged, a Medical Techfab is able to print Claymores, Cutlasses, Improvised Shortbows, Glass Shard Arrows, and a new version of the Knight Helmet that actually provides some armor.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The Medfab currently has no changes if it's emagged, so I thought adding something might be fun. Also because when you take Med and add Evil, you get Medieval.

## Technical details
<!-- Summary of code changes for easier review. -->
Adds a medieval.yml file to Resources/Prototypes/_Harmony/Recipes/Lathes, a pack containing those recipes to the Packs folder, and that pack to the medical techfab when it's emagged. Also adds a new version of the Knight Helmet to helmets.yml

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
<img width="1158" height="937" alt="image" src="https://github.com/user-attachments/assets/d6d660f7-1d91-4422-bae2-ca42a3ff0ae2" />

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Emagging a Medical Techfab allows for printing a selection of Medieval-themed items.

