### PR TITLE
You can now latejoin as a conspirator.

### DIFF
--- a/Resources/Prototypes/_Harmony/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Harmony/GameRules/roundstart.yml
@@ -136,6 +136,7 @@
       min: 4
       max: 7
       playerRatio: 7
+      lateJoinAdditional: true
       briefing:
         text: conspirator-role-greeting
         color: "#724F29"


### PR DESCRIPTION
This PR and all others I make regarding conspirators are also available under the MIT license.

<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
You can now be chosen as a conspirator if you latejoin.

## Why / Balance
Not really any reason not to allow it. Also fixes issues like 3 conspirator rounds.

## Technical details
1 line YAML change

## Media
minor fix

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: You can now latejoin as a conspirator.