### PR TITLE
L6 speed nerf

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -85,6 +85,17 @@
   - type: Appearance
   - type: StaticPrice
     price: 10000
+# Start Harmony change
+  - type: ClothingSpeedModifier
+    walkModifier: 0.9
+    sprintModifier: 0.9
+  - type: HeldSpeedModifier
+    walkModifier: 0.9
+    sprintModifier: 0.9
+  - type: SpeedModifiedOnWield
+    walkModifier: 0.9
+    sprintModifier: 0.9
+# End Harmony change
 
 - type: entity
   name: L6C ROW


### PR DESCRIPTION
## About the PR
Holding the L6 SAW in your back slot or in your hands adds a 10% slowdown

Wielding the L6 SAW provides a further 10% slowdown

## Why / Balance
This gun is way too strong for nukies when combined with movement chems and the free ammo bundle on the infiltrator, as desoxy now has a painkilling effect (effectively giving you full strength and movement speed as long as you aren't in crit), combined with the commander hardsuit you have effectively somewhere around 80%-ish pierce resistance while being able to deal an insane amount of damage.

I'd rather not microbalance when I don't have to but nukie rounds are being singlehandedly ruined by people who realize that a 100 round fully automatic weapon with little to no inaccuracy when point blank is amazing

Traitor balance shouldn't really matter because the L6 is prohibitively expensive and geared towards mass murder, so it should have some downsides

## Technical details
yaml

## Media

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
**Changelog**
:cl:
- tweak: Nerfed the L6 SAW; Movement speed is now decreased while held and even more when wielded.