### PR TITLE
Give Station AI and Salvage Borg Salv Comm Access

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -16,6 +16,7 @@
     - Security
     - Service
     - Supply
+    - Salvage # Harmony Chage - Adds Salvage Radio Channel
   - type: ActiveRadio
     channels:
     - Binary
@@ -27,6 +28,7 @@
     - Security
     - Service
     - Supply
+    - Salvage # Harmony Chage - Adds Salvage Radio Channel
   - type: IgnoreUIRange
   - type: StationAiHeld
   - type: StationAiOverlay

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -16,7 +16,7 @@
     - Security
     - Service
     - Supply
-    - Salvage # Harmony Chage - Adds Salvage Radio Channel
+    - Salvage # Harmony Change - Adds Salvage Radio Channel
   - type: ActiveRadio
     channels:
     - Binary
@@ -28,7 +28,7 @@
     - Security
     - Service
     - Supply
-    - Salvage # Harmony Chage - Adds Salvage Radio Channel
+    - Salvage # Harmony Change - Adds Salvage Radio Channel
   - type: IgnoreUIRange
   - type: StationAiHeld
   - type: StationAiOverlay

--- a/Resources/Prototypes/borg_types.yml
+++ b/Resources/Prototypes/borg_types.yml
@@ -91,6 +91,7 @@
   radioChannels:
   - Supply
   - Science
+  - Salvage # Harmony Change - Adds Salvage Radio Channel
 
   # Visual
   inventoryTemplateId: borgTall


### PR DESCRIPTION
## About the PR
Gives the Station AI and the Salvage borg chassis access to the Salvage Comms channel

## Why / Balance
Missed in https://github.com/ss14-harmony/ss14-harmony/pull/902

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<img width="412" height="120" alt="Screenshot 2026-01-28 191752" src="https://github.com/user-attachments/assets/6946fa6d-ee68-4408-925e-b6014c4d68f5" />
<img width="421" height="108" alt="Screenshot 2026-01-28 192032" src="https://github.com/user-attachments/assets/c4c85e6d-beb5-42f0-bd71-cd3b0f7702d2" />


## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- fix: Salvage Borgs and the Station AI can now use the Salvage Communication Channel

