### PR TITLE
Reworked how Blood Bound interact with mindshields again

### DIFF
--- a/Content.Server/Mindshield/MindShieldSystem.cs
+++ b/Content.Server/Mindshield/MindShieldSystem.cs
@@ -2,6 +2,7 @@ using Content.Server.Administration.Logs;
 using Content.Server.Mind;
 using Content.Server.Popups;
 using Content.Server.Roles;
+using Content.Shared._Harmony.BloodBrothers.Components; // Harmony
 using Content.Shared.Database;
 using Content.Shared.Implants;
 using Content.Shared.Mindshield.Components;
@@ -41,7 +42,7 @@ public sealed class MindShieldSystem : EntitySystem
     /// </summary>
     private void MindShieldRemovalCheck(EntityUid implanted, EntityUid implant)
     {
-        if (HasComp<HeadRevolutionaryComponent>(implanted))
+        if (HasComp<HeadRevolutionaryComponent>(implanted) || HasComp<BloodBrotherComponent>(implanted) && !HasComp<InitialBloodBrotherComponent>(implanted)) // Harmony -- this didn't have to be hardcoded but it is
         {
             _popupSystem.PopupEntity(Loc.GetString("head-rev-break-mindshield"), implanted);
             QueueDel(implant);

--- a/Content.Shared/Revolutionary/SharedRevolutionarySystem.cs
+++ b/Content.Shared/Revolutionary/SharedRevolutionarySystem.cs
@@ -47,8 +47,6 @@ public abstract class SharedRevolutionarySystem : EntitySystem
             _sharedStun.TryUpdateParalyzeDuration(uid, stunTime);
             _popupSystem.PopupEntity(Loc.GetString("rev-break-control", ("name", name)), uid);
         }
-
-        _bloodBrotherSystem.OnBloodBrotherMindshielded((uid, comp), ref init); // Harmony (who doesn't love some good old hardcoding)
     }
 
     /// <summary>

--- a/Content.Shared/_Harmony/BloodBrothers/EntitySystems/SharedBloodBrotherSystem.cs
+++ b/Content.Shared/_Harmony/BloodBrothers/EntitySystems/SharedBloodBrotherSystem.cs
@@ -1,10 +1,6 @@
 ﻿using Content.Shared._Harmony.BloodBrothers.Components;
 using Content.Shared.Actions;
 using Content.Shared.Antag;
-using Content.Shared.IdentityManagement;
-using Content.Shared.Mindshield.Components;
-using Content.Shared.Popups;
-using Content.Shared.Stunnable;
 using Robust.Shared.GameStates;
 using Robust.Shared.Player;
 
@@ -13,8 +9,6 @@ namespace Content.Shared._Harmony.BloodBrothers.EntitySystems;
 public abstract class SharedBloodBrotherSystem : EntitySystem
 {
     [Dependency] private readonly SharedActionsSystem _actionsSystem = default!;
-    [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
-    [Dependency] private readonly SharedStunSystem _stunSystem = default!;
 
     public override void Initialize()
     {
@@ -43,24 +37,6 @@ public abstract class SharedBloodBrotherSystem : EntitySystem
         ref ComponentGetStateAttemptEvent args)
     {
         args.Cancelled = !CanGetState(args.Player);
-    }
-
-    public void OnBloodBrotherMindshielded(Entity<MindShieldComponent> entity, ref MapInitEvent args)
-    {
-        if (HasComp<InitialBloodBrotherComponent>(entity))
-            return;
-
-        if (!TryComp<BloodBrotherComponent>(entity, out var bloodBrother))
-            return;
-
-        var name = Identity.Entity(entity, EntityManager);
-        RemCompDeferred<BloodBrotherComponent>(entity);
-        if (bloodBrother.DeconversionStunTime != null)
-            _stunSystem.TryUpdateParalyzeDuration(entity, bloodBrother.DeconversionStunTime);
-        _popupSystem.PopupEntity(
-            Loc.GetString("blood-brother-break-control", ("name", name)),
-            entity,
-            PopupType.MediumCaution);
     }
 
     private bool CanGetState(ICommonSession? player)

--- a/Resources/Locale/en-US/_Harmony/game-ticking/game-presets/preset-bloodbrother.ftl
+++ b/Resources/Locale/en-US/_Harmony/game-ticking/game-presets/preset-bloodbrother.ftl
@@ -16,8 +16,6 @@ blood-brother-role-greeting =
 
 blood-brother-briefing = Collaborate with your blood bound to accomplish all your objectives.
 
-blood-brother-break-control = {CAPITALIZE(THE($name))} has remembered their true allegiance!
-
 # Conversion
 
 blood-brother-convert-failed-no-mind = {CAPITALIZE(THE($converted))} does not have a mind

--- a/Resources/ServerInfo/_Harmony/Guidebook/ServerRules/SpaceLaw/HarmonySLCrimeList.xml
+++ b/Resources/ServerInfo/_Harmony/Guidebook/ServerRules/SpaceLaw/HarmonySLCrimeList.xml
@@ -58,7 +58,6 @@
     </ColorBox>
     <ColorBox Color="#593a4e">
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
-        Refusal of Mental Shielding (E)
       </Box>
     </ColorBox>
     <ColorBox>
@@ -866,26 +865,6 @@
     <ColorBox>
       <Box>
         Code
-      </Box>
-    </ColorBox>
-    <ColorBox Color="#593a4e">
-      <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
-        Refusal of Mental Shielding
-      </Box>
-    </ColorBox>
-    <ColorBox>
-      <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
-        To refuse to comply with a reasonable Mind Shielding procedure.
-      </Box>
-    </ColorBox>
-    <ColorBox>
-      <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
-        Applies if the suspect is excessively uncooperative or the implant fails to function due to the mental state of the prisoner already being too far gone. If the implant fails execution is heavily recommended.
-      </Box>
-    </ColorBox>
-    <ColorBox>
-      <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
-        5-00
       </Box>
     </ColorBox>
     <ColorBox Color="#4d2e2e">

--- a/Resources/ServerInfo/_Harmony/Guidebook/ServerRules/SpaceLaw/HarmonySpaceLaw.xml
+++ b/Resources/ServerInfo/_Harmony/Guidebook/ServerRules/SpaceLaw/HarmonySpaceLaw.xml
@@ -43,7 +43,7 @@
 
   [bold]Tracking Implants:[/bold] Trackers can be applied to any suspect that has been convicted of a violent crime (the red linked crimes).
 
-  [bold]Mind Shields:[/bold] Shields can be administered to any inmate who has been clearly mind controlled, lost control of themselves, or a suspect charged with unlawful control. Unlike standard implantation you may hold a prisoner until you finish issuing Mind Shields, so long as it's done in a timely fashion. If a suspect refuses to cooperate or the implant fails to function they can be charged with Refusal of Mental Shielding.
+  [bold]Mind Shields:[/bold] Shields can be administered to any inmate who has been clearly mind controlled, lost control of themselves, or a suspect charged with unlawful control. Unlike standard implantation you may hold a prisoner until you finish issuing Mind Shields, so long as it's done in a timely fashion.
 
   ### Removal
 


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
To allow proper porting of Harmony Blood-Bound to MIT forks should this be merged, in accordance with all of youtissoum's Blood-Bound PRs, all code in this PR is available under the MIT license. That said, if you're porting this PR over, you might want to consider the impact it'll have on Revolutionaries if you have them.


## About the PR
- Blood bound can no longer be deconverted.
- Mindshields implanted into the converted blood bound will now break, like they are a head revolutionary.
- Refusal of Mental Shielding has been removed. It only existed to let security execute headrevs, which we don't have.

## Why / Balance
There is no reason not to mindshield every prisoner beyond an incredibly vague line in space law. You lose nothing (just. take the mindshield back out.) and gain potentially permanently deconverting an antagonist and kneecapping their teammate. Even if you don't do it for no reason, if two people are working together without TC... Harmony's no metashield, you can definitely argue one of them is "clearly mind controlled".

The only reason not to is that the admin ruling on this incredibly vague and unclear singular paragraph in space law is a very specific statement saying you need absolute proof. The only way to learn this is #admin-questions or getting bwoinked for it.
<img width="1248" height="231" alt="image" src="https://github.com/user-attachments/assets/e3024219-19a8-4833-897a-7c03f23ad423" />

And, I'm sorry, if you need a ruling this obscure and specific regarding an incredibly vague paragraph in space law that wasn't even written with Blood Bound in mind, maybe the mechanics behind it need to be changed. The rules are the only thing stopping an antag from getting kneecapped when mechanical solutions exist for this.

The original change was made to reduce the power of demindshielding and converting Command and Security, and make intentionally sandbagging to get converted less desirable, but it absolutely kneecapped doing so and made it never worth it whatsoever, while also opening up the option for Security to absolutely fuck over BBs to the extent that it had to have a band-aid put on it via an obscure ruling. With this, you can still have your evil Command and Security and they'll last the round, but they'll be obvious to Security and have no ability to be subtle near them due to their lack of mindshield and inability to have one. Sandbagging to get yourself converted now has a tangible downside and is far less appealing than it is when it's just "do i wanna be antag or not antag...", without opening it up for regular BBs to get fucked over.

As for not being able to deconvert a publicly converted BB... that's not why the PR was initially made and wasn't the intention behind the PR, being able to do this was not the case originally, it wasn't the case in SS13, it implies the blood oath is "weak" mind control that's only as strong as revolutionary mind control (the weakest), and it opens up too much potential abuse to allow it to happen (rules that aren't even WRITTEN DOWN are the only thing stopping you from doing it to every prisoner. at least now it's not worth the effort) in this niche situation. Also it just kind of sucks for everyone. You can't make it not suck. I'd rather that niche situation being not amazing over the potential that any BB pair can be kneecapped if the converted gets caught.



As for the other change, Refusal of Mental Shielding as a charge has no use on Harmony. There is no reason for someone to ever be charged with it without this PR (and also, CAPITAL CRIME?? this only exists for revs)


## Technical details
- Removed all code regarding deconverting Blood Bound.
- Added a check to the mindshield system upstream that checks if the mindshielded person is a HeadRev and extended it to converted BB (it's hardcoded upstream </3)
- Removed Refusal of Mental Shielding from the guidebook.

## Media
<img width="1325" height="539" alt="image" src="https://github.com/user-attachments/assets/f5a68833-bcaa-40f6-a357-9319963b4986" />
<img width="646" height="139" alt="image" src="https://github.com/user-attachments/assets/62b61e40-6eb0-4cce-a6c8-b5af76521341" />


## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Blood bound can no longer be deconverted. 
- tweak: The converted blood bound will now break any mindshields implanted into them, like a head revolutionary.
- remove: Refusal of Mental Shielding has been removed from Space Law.
