### PR TITLE
Added a More Expensive Micro-Bomb for Traitors

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1642,6 +1642,27 @@
   categories:
   - UplinkImplants
 
+# Harmony Start
+- type: listing
+  id: UplinkMicroBombImplantLite
+  name: uplink-micro-bomb-implanter-name
+  description: uplink-micro-bomb-implanter-desc
+  icon: { sprite: /Textures/Actions/Implants/implants.rsi, state: explosive }
+  productEntity: MicroBombImplanter
+  discountCategory: veryRareDiscounts
+  discountDownTo:
+    Telecrystal: 1 # I don't know why our customers never come back.
+  cost:
+    Telecrystal: 8
+  categories:
+  - UplinkImplants
+  conditions:
+  - !type:StoreWhitelistCondition
+    blacklist:
+      tags:
+      - NukeOpsUplink
+# Harmony End
+
 # Wearables
 
 - type: listing

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1642,27 +1642,6 @@
   categories:
   - UplinkImplants
 
-# Harmony Start
-- type: listing
-  id: UplinkMicroBombImplantLite
-  name: uplink-micro-bomb-implanter-name
-  description: uplink-micro-bomb-implanter-desc
-  icon: { sprite: /Textures/Actions/Implants/implants.rsi, state: explosive }
-  productEntity: MicroBombImplanter
-  discountCategory: veryRareDiscounts
-  discountDownTo:
-    Telecrystal: 1 # I don't know why our customers never come back.
-  cost:
-    Telecrystal: 8
-  categories:
-  - UplinkImplants
-  conditions:
-  - !type:StoreWhitelistCondition
-    blacklist:
-      tags:
-      - NukeOpsUplink
-# Harmony End
-
 # Wearables
 
 - type: listing

--- a/Resources/Prototypes/_Harmony/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Harmony/Catalog/uplink_catalog.yml
@@ -237,6 +237,25 @@
       tags:
       - NukeOpsUplink
 
+- type: listing
+  id: UplinkMicroBombImplantLite
+  name: uplink-micro-bomb-implanter-name
+  description: uplink-micro-bomb-implanter-desc
+  icon: { sprite: /Textures/Actions/Implants/implants.rsi, state: explosive }
+  productEntity: MicroBombImplanter
+  discountCategory: veryRareDiscounts
+  discountDownTo:
+    Telecrystal: 1 # I don't know why our customers never come back.
+  cost:
+    Telecrystal: 8
+  categories:
+  - UplinkImplants
+  conditions:
+  - !type:StoreWhitelistCondition
+    blacklist:
+      tags:
+      - NukeOpsUplink
+
 # Wearables
 
 - type: listing


### PR DESCRIPTION
## About the PR
Added a non-blacklisted version of the Microbomb to the traitor uplink. Originally this is only available to nukies at a really cheap cost of only 2 Telecrystals. This PR aims to make it available at a different cost to traitors.

## Why / Balance
Originally micro-bombs were only available to nukies for 2 TC.
This PR aims to bring them to the normal traitor uplink but at a higher cost.

~~Unlike the Macro-Bomb, this bomb does not go off when you die. It only goes off when a player presses the explosion button, twice. This is the same mechanic as the syndi-roach.~~
This item and its use are still restricted by harmony rules to not be used on evac.
Re-testing it, it will explode when you die.

## Technical details
Added a different version of the item to the uplink yaml.
This frees us up to change the cost for normal traitors. 

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- add: Added micro-bombs to the traitor uplink for normal tots

