### PR TITLE
Gives service borgs whitelisted hand slot for food/drink

### DIFF
--- a/Resources/Locale/en-US/robotics/borg_modules.ftl
+++ b/Resources/Locale/en-US/robotics/borg_modules.ftl
@@ -15,3 +15,4 @@ borg-slot-modules-empty = Modules
 borg-slot-powercell-empty = Powercells
 borg-slot-inflatable-door-empty = Inflatable Door
 borg-slot-inflatable-wall-empty = Inflatable Wall
+borg-slot-free-left = Free Slot

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -1117,6 +1117,26 @@
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: service-module }
 
 - type: entity
+  id: BorgModuleFreeHands
+  parent: [ BaseBorgModuleService, BaseProviderBorgModule ]
+  name: free hands cyborg module
+  description: Provides the cyborg with free hands for general manipulation.
+  components:
+  - type: Sprite
+    layers:
+    - state: service
+    - state: icon-pen 
+  - type: ItemBorgModule
+    hands:
+    - hand:
+        emptyLabel: borg-slot-free-left
+        emptyRepresentative: 
+    - hand:
+        emptyLabel: borg-slot-free-right
+        emptyRepresentative:
+
+
+- type: entity
   id: BorgModuleMusique
   parent: [ BaseBorgModuleService, BaseProviderBorgModule ]
   name: musique cyborg module

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -1113,6 +1113,18 @@
           components:
           - FitsInDispenser
     - item: BarSpoon
+    - hand:
+        emptyLabel: borg-slot-free-left
+        emptyRepresentative: 
+        whitelist:
+          components:
+           - Edible
+          tags:
+            - Document
+            - Book
+            - Write
+            - Cigarette
+            - Smokable
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: service-module }
 

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -1129,26 +1129,6 @@
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: service-module }
 
 - type: entity
-  id: BorgModuleFreeHands
-  parent: [ BaseBorgModuleService, BaseProviderBorgModule ]
-  name: free hands cyborg module
-  description: Provides the cyborg with free hands for general manipulation.
-  components:
-  - type: Sprite
-    layers:
-    - state: service
-    - state: icon-pen 
-  - type: ItemBorgModule
-    hands:
-    - hand:
-        emptyLabel: borg-slot-free-left
-        emptyRepresentative: 
-    - hand:
-        emptyLabel: borg-slot-free-right
-        emptyRepresentative:
-
-
-- type: entity
   id: BorgModuleMusique
   parent: [ BaseBorgModuleService, BaseProviderBorgModule ]
   name: musique cyborg module

--- a/Resources/Prototypes/borg_types.yml
+++ b/Resources/Prototypes/borg_types.yml
@@ -209,6 +209,7 @@
   - BorgModuleClowning
   - BorgModuleGardening
   - BorgModuleHarvesting
+  - BorgModuleFreeHands
   radioChannels:
   - Science
   - Service

--- a/Resources/Prototypes/borg_types.yml
+++ b/Resources/Prototypes/borg_types.yml
@@ -209,7 +209,6 @@
   - BorgModuleClowning
   - BorgModuleGardening
   - BorgModuleHarvesting
-  - BorgModuleFreeHands
   radioChannels:
   - Science
   - Service


### PR DESCRIPTION

## About the PR
Gives the Service Borg a whitelisted hand slot in the service module, allowing them to pick up any of the following:
 - Food (and ingredients, flour bags etc)
 - Drinks (And glasses/mugs etc)
 - Paper/Books/Documents
 - Cigarettes/Smokables

## Why / Balance
Service borgs currently can't perform many of the service jobs such as bartending and chef due to their inability to pick up objects like glasses, flour, beakers etc. This would allow the service borg the ability to do these jobs and help out where necessary, whilst also prohibiting the borgs from picking up guns/weapons etc.

## Technical details
its yaml code.
Specifically, the whitelist is for everything with "EdibleComponent", as well as the tags: "Document", "Book", "Write", "Cigarette", "Smokable".

## Media
<img width="583" height="698" alt="image" src="https://github.com/user-attachments/assets/f2ee0c4d-9ce8-4fd9-82a8-3f748f7abe87" />
<img width="620" height="256" alt="image" src="https://github.com/user-attachments/assets/853719eb-a986-458f-8bd7-01f9e370704c" />

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
changes borg_modules.yml, specifically the BorgModuleService.

**Changelog**
:cl:
- add: Added a free hand slot to the Service Borg's Service module, It can pick up food, drink, beakers, cigarettes, and other service-related goods.
