### PR TITLE
Replace WT550 crate with Drozd crate

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
@@ -8,10 +8,14 @@
     containers:
       entity_storage: !type:AllSelector
         children:
-        - id: WeaponSubMachineGunWt550
+# Start harmony change - Change to Drozd from WT550, change WT mags to SMG mags
+#       - id: WeaponSubMachineGunWt550
+        - id: WeaponSubMachineGunDrozd
           amount: 2
-        - id: MagazinePistolSubMachineGunTopMounted
+#       - id: MagazinePistolSubMachineGunTopMounted
+        - id: MagazinePistolSubMachineGun
           amount: 4
+# End Harmony change
 
 - type: entity
   parent: [ CrateWeaponSecure, BaseSecurityContraband ]


### PR DESCRIPTION
## About the PR
Salvage wrecks could spawn with SMG crates that have WT550, replaced them with Drozds

## Why / Balance
Removed salvage's fun

Probably a bugfix because WT550 crates aren't meant to be attainable

## Technical details
Yaml

## Media

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

**Changelog**
:cl:
- tweak: SMG crates that spawn on Salvage wrecks now contain a Drozd and SMG magazines instead of a WT550 and top-loaded mags.