### PR TITLE
Changed mapped salvage incendiary rounds to pistol magazine

### DIFF
--- a/Resources/Maps/Ruins/displaced_telescience.yml
+++ b/Resources/Maps/Ruins/displaced_telescience.yml
@@ -4182,7 +4182,7 @@ entities:
           showEnts: False
           occludes: True
           ents: []
-- proto: MagazinePistol # Harmony Change - Changed Incendiary Round Magazine to an empty pistol magazine
+- proto: MagazinePistol # Harmony Change - Changed Incendiary Round Magazine to a pistol magazine
   entities:
   - uid: 331
     components:

--- a/Resources/Maps/Ruins/displaced_telescience.yml
+++ b/Resources/Maps/Ruins/displaced_telescience.yml
@@ -4182,7 +4182,7 @@ entities:
           showEnts: False
           occludes: True
           ents: []
-- proto: MagazinePistolIncendiary
+- proto: MagazinePistol # Harmony Change - Removed Incendiary Round Magazine
   entities:
   - uid: 331
     components:

--- a/Resources/Maps/Ruins/displaced_telescience.yml
+++ b/Resources/Maps/Ruins/displaced_telescience.yml
@@ -4182,7 +4182,7 @@ entities:
           showEnts: False
           occludes: True
           ents: []
-- proto: MagazinePistol # Harmony Change - Removed Incendiary Round Magazine
+- proto: MagazinePistol # Harmony Change - Changed Incendiary Round Magazine to an empty pistol magazine
   entities:
   - uid: 331
     components:


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
Changed the mapped incendiary round magazine on displaced_telescience.yml to a .35 magazine.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The salvage ruin displaced_telescience.yml had a mapped incendiary round magazine for .35 auto. Since harmony has removed them altogether, Salvagers should not have access to this item. Replaced it with a .35 auto magazine so if a traitor comes across it, it's still somewhat useful, just doesn't outright provide an otherwise unobtainable item.

## Technical details
<!-- Summary of code changes for easier review. -->
1 line YML change

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
Before: 
<img width="926" height="595" alt="unchanged" src="https://github.com/user-attachments/assets/e6200fd3-0b58-4b03-b18a-47fe45f7c645" />


After:
<img width="938" height="541" alt="changed" src="https://github.com/user-attachments/assets/f1dceffe-daf6-4867-9cb7-b2e61ab6fb60" />



## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Changed the mapped incendiary rounds on the displaced telescience ruin to a .35 magazine