### PR TITLE
Screens no longer say KILL on EOR

### DIFF
--- a/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
+++ b/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
@@ -244,6 +244,8 @@ public sealed partial class EmergencyShuttleSystem : SharedEmergencyShuttleSyste
 
             // by popular request
             // https://discord.com/channels/310555209753690112/770682801607278632/1189989482234126356
+            // Start of Harmony change to make it so screens no longer say KILL
+            /*
             if (_random.Next(1000) == 0)
             {
                 payload.Add(ScreenMasks.Text, ShuttleTimerMasks.Kill);
@@ -251,6 +253,9 @@ public sealed partial class EmergencyShuttleSystem : SharedEmergencyShuttleSyste
             }
             else
                 payload.Add(ScreenMasks.Text, ShuttleTimerMasks.Bye);
+            */
+            payload.Add(ScreenMasks.Text, ShuttleTimerMasks.Bye);
+            // End of Harmony change
 
             _deviceNetworkSystem.QueuePacket(shuttle, null, payload, net.TransmitFrequency);
         }


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
Title

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Harmony has rules on EORG, screens randomly saying KILL in red text without admins setting it to do as such causes player and admin confusion on what is happening.

## Technical details
<!-- Summary of code changes for easier review. -->
Commented out lines in Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs that would randomly make the screens say KILL.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
<img width="230" height="178" alt="image" src="https://github.com/user-attachments/assets/97135ff3-49ff-4879-a3dd-e7458c118ae4" />

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Screens can no longer say "KILL" when the round ends.