### PR TITLE
You can no longer roll the Nuke Disk with Die a Glorius Death

### DIFF
--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -365,5 +365,5 @@
     blacklist:
       components:
       - EscapeShuttleCondition
-      - DieObjective # This prevents NukeDisk from rolling after DAGD
+      - DieCondition # This prevents NukeDisk from rolling after DAGD
 # End harmony change

--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -365,4 +365,5 @@
     blacklist:
       components:
       - EscapeShuttleCondition
+      - DieObjective # This prevents NukeDisk from rolling after DAGD
 # End harmony change


### PR DESCRIPTION
## About the PR
This PR prevents the steal Nuke Disk Objective from rolling after a traitor has rolled DAGD.

## Why / Balance
Given that the pool of objectives shrinks when you roll DAGD, only the nuke disk seems to become available as an objective. This means that many times when we see DAGD we also see the nuke disk objective. This also should not be possible since steal objectives are blacklisted from DAGD except for the nuke disk for some reason.

This means DAGD are more likely to also have to steal the nuke disk as part of their objectives. This changes the pool to mostly RR and Kill objectives instead.

## Technical details
Added DieObjective to blacklist on nuke disk.

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.

**Changelog**
:cl:
- add: Removed the chance that you roll a steal the nuke disk objective, when you are DAGD