### PR TITLE
Move cat ears from Special to HeadTop

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/cat_parts.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/cat_parts.yml
@@ -1,6 +1,6 @@
 - type: marking
   id: CatEars
-  bodyPart: HeadTop
+  bodyPart: HeadTop # Harmony
   groupWhitelist: [Human]
   coloring:
     default:


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
Moved the cat ear marking from Special to HeadTop

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Cat ears were broken by the latest upstream merge and no longer render when selected. Moving them to HeadTop is the easiest fix, and makes more sense anyways since the cat ears aren't an unselectable joke marking on Harmony like they are upstream, so it hardly feels warranting of its own category.

## Technical details
<!-- Summary of code changes for easier review. -->
Single line YAML change
Auto coloring based on hair appears to be broken, regardless of this change.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
Cat ears in the Special slot, not rendering. Note that they auto-color to skin color rather than hair.
<img width="1887" height="853" alt="SS14 Loader_dMPGxyyE1b" src="https://github.com/user-attachments/assets/3894780e-378e-4ff0-8b8e-a79cba810942" />
Cat ears in the Head (Top) slot, rendering properly.
<img width="1887" height="938" alt="SS14 Loader_oqlWYSew4t" src="https://github.com/user-attachments/assets/b5d8f425-a851-4966-979a-8ab7d3ec7fca" />
Ingame
<img width="1105" height="668" alt="image" src="https://github.com/user-attachments/assets/b894887d-7161-48d4-9537-c5791fd5b67b" />

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
Characters with cat ears will have to re-add them thanks to the category change.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Moved human cat ears from the Special category to the Head (Top) category.
