### PR TITLE
Syndicate Locker Now Contains Stealthy Jetpack

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
@@ -12,7 +12,7 @@
         children:
         - id: ClothingBeltMilitaryWebbing
         - id: ClothingHandsGlovesCombat
-        - id: JetpackBlackFilled
+        - id: HarmonyJetpackBlackFilledStealth # Harmony Change, JetpackBlackFilled > HarmonyJetpackBlackFilledStealth, Nukies should not show up on Mass Scanners
         - id: ClothingUniformJumpsuitOperative
         - id: ClothingUniformJumpskirtOperative
         - id: ClothingHeadsetAltSyndicate


### PR DESCRIPTION
## About the PR
Cybersun high command made a requisitions mistake and has provided our Gorlex operators with the wrong gear.
This has been updated on the manifest and new gear has been issued. Death to NanoTrasen.

## Why / Balance
The whole point of the Stealthy jetpack was to hide the nukie approach.
This just fixes the lockers on the nukie planet to contain the stealthy jet pack.

This fixes issue #1291 

## Technical details
LockerSyndicatePersonalFilled now comes with HarmonyJetpackBlackFilledStealth instead of JetpackBlackFilled

## Media
<img width="501" height="392" alt="image" src="https://github.com/user-attachments/assets/fe3c63d1-8e3c-4117-b11f-435c89c17b95" />

## Requirements
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.


**Changelog**
:cl:
- fix: Gorlex operators now have the correct Jet Pack in their lockers
