### PR TITLE
Hide xenoborgs from radar blips

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -1448,7 +1448,7 @@
           - ConstructionMaterial
     - item: XenoborgMaterialBag
     - item: PinpointerMothership
-    - item: HandheldGPSBasic
+    # - item: HandheldGPSBasic # Harmony: hide xenoborgs from radar blips
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: xenoborg-basic-module }
 
@@ -1583,7 +1583,7 @@
     - state: icon-xenoborg-space-movement
   - type: ItemBorgModule
     hands:
-    - item: HandheldGPSBasic
+    # - item: HandheldGPSBasic # Harmony: hide xenoborgs from radar blips
     - item: HandHeldMassScannerBorg
     - item: PinpointerMothership
     - item: HandheldStationMapUnpowered

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -1448,7 +1448,7 @@
           - ConstructionMaterial
     - item: XenoborgMaterialBag
     - item: PinpointerMothership
-    # - item: HandheldGPSBasic # Harmony: hide xenoborgs from radar blips
+    - item: BorgHandheldGPSBasicStealth # Harmony: make the xenoborg GPS stealthy
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: xenoborg-basic-module }
 
@@ -1583,7 +1583,7 @@
     - state: icon-xenoborg-space-movement
   - type: ItemBorgModule
     hands:
-    # - item: HandheldGPSBasic # Harmony: hide xenoborgs from radar blips
+    - item: BorgHandheldGPSBasicStealth # Harmony: make the xenoborg GPS stealthy
     - item: HandHeldMassScannerBorg
     - item: PinpointerMothership
     - item: HandheldStationMapUnpowered

--- a/Resources/Prototypes/_Harmony/Entities/Objects/Tools/gps.yml
+++ b/Resources/Prototypes/_Harmony/Entities/Objects/Tools/gps.yml
@@ -1,6 +1,7 @@
 - type: entity
   parent: BorgHandheldGPSBasic
   id: BorgHandheldGPSBasicStealth
+  suffix: Harmony, Stealth
   components:
   - type: RadarBlipStealth # I probably should've just requested changes on the
                            # original PR because this is NOT how ECS is supposed to work...

--- a/Resources/Prototypes/_Harmony/Entities/Objects/Tools/gps.yml
+++ b/Resources/Prototypes/_Harmony/Entities/Objects/Tools/gps.yml
@@ -1,0 +1,6 @@
+- type: entity
+  parent: BorgHandheldGPSBasic
+  id: BorgHandheldGPSBasicStealth
+  components:
+  - type: RadarBlipStealth # I probably should've just requested changes on the
+                           # original PR because this is NOT how ECS is supposed to work...


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
I removed all GPSs from the xenoborg modules.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Xenoborgs are supposed to be stealthy

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Xenoborgs no longer show up on mass scanners.