### PR TITLE
Tweaked survival kits now have food tins instead of MREs

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -13,7 +13,7 @@
         - id: EmergencyOxygenTankFilled
         - id: EmergencyMedipen
         - id: Flare
-        # Start of Harmony Change: NT budget changed, you now need to visit the Chef for Food
+        # Start of Harmony Change: Remove MRE from survival box
         #- id: FoodSnackNutribrick
         # End of Harmony Change
         - id: DrinkWaterBottleFull
@@ -35,7 +35,7 @@
         - id: EmergencyNitrogenTankFilled
         - id: EmergencyMedipen
         - id: Flare
-        # Start of Harmony Change: NT budget changed, you now need to visit the Chef for Food
+        # Start of Harmony Change: Remove MRE from survival box
         #- id: FoodSnackNutribrick
         # End of Harmony Change
         - id: DrinkWaterBottleFull
@@ -61,7 +61,7 @@
         - id: ExtendedEmergencyOxygenTankFilled
         - id: EmergencyMedipen
         - id: Flare
-# Start of Harmony Change: NT budget changed, you now need to visit the Chef for Food
+# Start of Harmony Change: Remove MRE from survival box
         #- id: FoodSnackNutribrick
 # End of Harmony Change
         - id: DrinkWaterBottleFull
@@ -87,7 +87,7 @@
         - id: ExtendedEmergencyNitrogenTankFilled
         - id: EmergencyMedipen
         - id: Flare
-        # Start of Harmony Change: NT budget changed, you now need to visit the Chef for Food
+        # Start of Harmony Change: Remove MRE from survival box
         #- id: FoodSnackNutribrick
         # End of Harmony Change
         - id: DrinkWaterBottleFull
@@ -140,7 +140,7 @@
         - id: EmergencyNitrogenTankFilled
         - id: EmergencyMedipen
         - id: Flare
-        # Start of Harmony Change: NT budget changed, you now need to visit the Chef for Food
+        # Start of Harmony Change: Remove MRE from survival box
         #- id: FoodSnackNutribrick
         # End of Harmony Change
         - id: DrinkWaterBottleFull
@@ -170,7 +170,7 @@
         - id: EmergencyOxygenTankFilled
         - id: EmergencyMedipen
         - id: Flare
-        # Start of Harmony Change: NT budget changed, you now need to visit the Chef for Food
+        # Start of Harmony Change: Remove MRE from survival box
         #- id: FoodSnackNutribrick
         # End of Harmony Change
         - id: DrinkWaterBottleFull
@@ -195,7 +195,7 @@
         - id: EmergencyNitrogenTankFilled
         - id: EmergencyMedipen
         - id: Flare
-        # Start of Harmony Change: NT budget changed, you now need to visit the Chef for Food
+        # Start of Harmony Change: Remove MRE from survival box
         #- id: FoodSnackNutribrick
         # End of Harmony Change
         - id: DrinkWaterBottleFull
@@ -230,8 +230,8 @@
         - id: EmergencyFunnyOxygenTankFilled
         - id: EmergencyMedipen
         - id: Flare
-        # Start of Harmony Change: NT budget changed, you now need to visit the Chef for Food
-        #- id: FoodSnackNutribrick
+        # Start of Harmony Change: Remove MRE from survival box
+        - id: FoodPieBananaCream
         # End of Harmony Change
         - id: DrinkWaterBottleFull
   - type: Tag
@@ -252,8 +252,8 @@
         - id: EmergencyNitrogenTankFilled
         - id: EmergencyMedipen
         - id: Flare
-        # Start of Harmony Change: NT budget changed, you now need to visit the Chef for Food
-        #- id: FoodSnackNutribrick
+        # Start of Harmony Change: Remove MRE from survival box
+        - id: FoodPieBananaCream
         # End of Harmony Change
         - id: DrinkWaterBottleFull
   - type: Label

--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -216,7 +216,10 @@
         - id: EmergencyFunnyOxygenTankFilled
         - id: EmergencyMedipen
         - id: Flare
-        - id: FoodPieBananaCream #Harmony Commit Change: Remove MRE from survival box
+        # Start of Harmony Change: Remove MRE from survival box
+        #- id: FoodSnackNutribrick
+        - id: FoodPieBananaCream
+        # End of Harmony Change
         - id: DrinkWaterBottleFull
   - type: Tag
     tags:
@@ -236,7 +239,10 @@
         - id: EmergencyNitrogenTankFilled
         - id: EmergencyMedipen
         - id: Flare
-        - id: FoodPieBananaCream #Harmony Commit Change: Remove MRE from survival box
+        # Start of Harmony Change: Remove MRE from survival box
+        #- id: FoodSnackNutribrick
+        - id: FoodPieBananaCream
+        # End of Harmony Change
         - id: DrinkWaterBottleFull
   - type: Label
     currentLabel: reagent-name-nitrogen

--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -13,7 +13,10 @@
         - id: EmergencyOxygenTankFilled
         - id: EmergencyMedipen
         - id: Flare
-        #- id: FoodSnackNutribrick Harmony Commit Change: Remove MRE from survival box
+        # Start of Harmony Change: Tweaked survival kits now have food tins instead of MREs
+        #- id: FoodSnackNutribrick
+        - id: FoodTinMRE
+        # End of Harmony Change
         - id: DrinkWaterBottleFull
   - type: Sprite
     layers:
@@ -33,7 +36,10 @@
         - id: EmergencyNitrogenTankFilled
         - id: EmergencyMedipen
         - id: Flare
-        #- id: FoodSnackNutribrick Harmony Commit Change: Remove MRE from survival box
+        # Start of Harmony Change: Tweaked survival kits now have food tins instead of MREs
+        #- id: FoodSnackNutribrick
+        - id: FoodTinMRE
+        # End of Harmony Change
         - id: DrinkWaterBottleFull
   - type: Sprite
     layers:
@@ -57,7 +63,10 @@
         - id: ExtendedEmergencyOxygenTankFilled
         - id: EmergencyMedipen
         - id: Flare
-        #- id: FoodSnackNutribrick Harmony Commit Change: Remove MRE from survival box
+        # Start of Harmony Change: Tweaked survival kits now have food tins instead of MREs
+        #- id: FoodSnackNutribrick
+        - id: FoodTinMRE
+        # End of Harmony Change
         - id: DrinkWaterBottleFull
   - type: Sprite
     layers:
@@ -81,7 +90,10 @@
         - id: ExtendedEmergencyNitrogenTankFilled
         - id: EmergencyMedipen
         - id: Flare
-        #- id: FoodSnackNutribrick Harmony Commit Change: Remove MRE from survival box
+        # Start of Harmony Change: Tweaked survival kits now have food tins instead of MREs
+        #- id: FoodSnackNutribrick
+        - id: FoodTinMRE
+        # End of Harmony Change
         - id: DrinkWaterBottleFull
   - type: Sprite
     layers:
@@ -109,7 +121,10 @@
         - id: EmergencyOxygenTankFilled
         - id: EmergencyMedipen
         - id: Flare
-        #- id: FoodSnackNutribrick Harmony Commit Change: Remove MRE from survival box
+        # Start of Harmony Change: Tweaked survival kits now have food tins instead of MREs
+        #- id: FoodSnackNutribrick
+        - id: FoodTinMRE
+        # End of Harmony Change
         - id: DrinkWaterBottleFull
   - type: Sprite
     layers:
@@ -132,7 +147,10 @@
         - id: EmergencyNitrogenTankFilled
         - id: EmergencyMedipen
         - id: Flare
-        #- id: FoodSnackNutribrick Harmony Commit Change: Remove MRE from survival box
+        # Start of Harmony Change: Tweaked survival kits now have food tins instead of MREs
+        #- id: FoodSnackNutribrick
+        - id: FoodTinMRE
+        # End of Harmony Change
         - id: DrinkWaterBottleFull
   - type: Sprite
     layers:
@@ -160,7 +178,10 @@
         - id: EmergencyOxygenTankFilled
         - id: EmergencyMedipen
         - id: Flare
-        #- id: FoodSnackNutribrick Harmony Commit Change: Remove MRE from survival box
+        # Start of Harmony Change: Tweaked survival kits now have food tins instead of MREs
+        #- id: FoodSnackNutribrick
+        - id: FoodTinMRE
+        # End of Harmony Change
         - id: DrinkWaterBottleFull
   - type: Sprite
     layers:
@@ -183,7 +204,10 @@
         - id: EmergencyNitrogenTankFilled
         - id: EmergencyMedipen
         - id: Flare
-        #- id: FoodSnackNutribrick Harmony Commit Change: Remove MRE from survival box
+        # Start of Harmony Change: Tweaked survival kits now have food tins instead of MREs
+        #- id: FoodSnackNutribrick
+        - id: FoodTinMRE
+        # End of Harmony Change
         - id: DrinkWaterBottleFull
   - type: Sprite
     layers:
@@ -216,7 +240,7 @@
         - id: EmergencyFunnyOxygenTankFilled
         - id: EmergencyMedipen
         - id: Flare
-        # Start of Harmony Change: Remove MRE from survival box
+        # Start of Harmony Change: Tweaked survival kits now have food tins instead of MREs
         #- id: FoodSnackNutribrick
         - id: FoodPieBananaCream
         # End of Harmony Change
@@ -239,7 +263,7 @@
         - id: EmergencyNitrogenTankFilled
         - id: EmergencyMedipen
         - id: Flare
-        # Start of Harmony Change: Remove MRE from survival box
+        # Start of Harmony Change: Tweaked survival kits now have food tins instead of MREs
         #- id: FoodSnackNutribrick
         - id: FoodPieBananaCream
         # End of Harmony Change

--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -13,7 +13,9 @@
         - id: EmergencyOxygenTankFilled
         - id: EmergencyMedipen
         - id: Flare
-        - id: FoodSnackNutribrick
+        # Start of Harmony Change: NT budget changed, you now need to visit the Chef for Food
+        #- id: FoodSnackNutribrick
+        # End of Harmony Change
         - id: DrinkWaterBottleFull
   - type: Sprite
     layers:
@@ -33,7 +35,9 @@
         - id: EmergencyNitrogenTankFilled
         - id: EmergencyMedipen
         - id: Flare
-        - id: FoodSnackNutribrick
+        # Start of Harmony Change: NT budget changed, you now need to visit the Chef for Food
+        #- id: FoodSnackNutribrick
+        # End of Harmony Change
         - id: DrinkWaterBottleFull
   - type: Sprite
     layers:
@@ -83,7 +87,9 @@
         - id: ExtendedEmergencyNitrogenTankFilled
         - id: EmergencyMedipen
         - id: Flare
-        - id: FoodSnackNutribrick
+        # Start of Harmony Change: NT budget changed, you now need to visit the Chef for Food
+        #- id: FoodSnackNutribrick
+        # End of Harmony Change
         - id: DrinkWaterBottleFull
   - type: Sprite
     layers:
@@ -134,7 +140,9 @@
         - id: EmergencyNitrogenTankFilled
         - id: EmergencyMedipen
         - id: Flare
-        - id: FoodSnackNutribrick
+        # Start of Harmony Change: NT budget changed, you now need to visit the Chef for Food
+        #- id: FoodSnackNutribrick
+        # End of Harmony Change
         - id: DrinkWaterBottleFull
   - type: Sprite
     layers:
@@ -162,7 +170,9 @@
         - id: EmergencyOxygenTankFilled
         - id: EmergencyMedipen
         - id: Flare
-        - id: FoodSnackNutribrick
+        # Start of Harmony Change: NT budget changed, you now need to visit the Chef for Food
+        #- id: FoodSnackNutribrick
+        # End of Harmony Change
         - id: DrinkWaterBottleFull
   - type: Sprite
     layers:
@@ -185,7 +195,9 @@
         - id: EmergencyNitrogenTankFilled
         - id: EmergencyMedipen
         - id: Flare
-        - id: FoodSnackNutribrick
+        # Start of Harmony Change: NT budget changed, you now need to visit the Chef for Food
+        #- id: FoodSnackNutribrick
+        # End of Harmony Change
         - id: DrinkWaterBottleFull
   - type: Sprite
     layers:
@@ -218,7 +230,9 @@
         - id: EmergencyFunnyOxygenTankFilled
         - id: EmergencyMedipen
         - id: Flare
-        - id: FoodSnackNutribrick
+        # Start of Harmony Change: NT budget changed, you now need to visit the Chef for Food
+        #- id: FoodSnackNutribrick
+        # End of Harmony Change
         - id: DrinkWaterBottleFull
   - type: Tag
     tags:
@@ -238,7 +252,9 @@
         - id: EmergencyNitrogenTankFilled
         - id: EmergencyMedipen
         - id: Flare
-        - id: FoodSnackNutribrick
+        # Start of Harmony Change: NT budget changed, you now need to visit the Chef for Food
+        #- id: FoodSnackNutribrick
+        # End of Harmony Change
         - id: DrinkWaterBottleFull
   - type: Label
     currentLabel: reagent-name-nitrogen

--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -57,7 +57,9 @@
         - id: ExtendedEmergencyOxygenTankFilled
         - id: EmergencyMedipen
         - id: Flare
-        - id: FoodSnackNutribrick
+# Start of Harmony Change: NT budget changed, you now need to visit the Chef for Food
+        #- id: FoodSnackNutribrick
+# End of Harmony Change
         - id: DrinkWaterBottleFull
   - type: Sprite
     layers:

--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -13,9 +13,7 @@
         - id: EmergencyOxygenTankFilled
         - id: EmergencyMedipen
         - id: Flare
-        # Start of Harmony Change: Remove MRE from survival box
-        #- id: FoodSnackNutribrick
-        # End of Harmony Change
+        #- id: FoodSnackNutribrick Harmony Commit Change: Remove MRE from survival box
         - id: DrinkWaterBottleFull
   - type: Sprite
     layers:
@@ -35,9 +33,7 @@
         - id: EmergencyNitrogenTankFilled
         - id: EmergencyMedipen
         - id: Flare
-        # Start of Harmony Change: Remove MRE from survival box
-        #- id: FoodSnackNutribrick
-        # End of Harmony Change
+        #- id: FoodSnackNutribrick Harmony Commit Change: Remove MRE from survival box
         - id: DrinkWaterBottleFull
   - type: Sprite
     layers:
@@ -61,9 +57,7 @@
         - id: ExtendedEmergencyOxygenTankFilled
         - id: EmergencyMedipen
         - id: Flare
-# Start of Harmony Change: Remove MRE from survival box
-        #- id: FoodSnackNutribrick
-# End of Harmony Change
+        #- id: FoodSnackNutribrick Harmony Commit Change: Remove MRE from survival box
         - id: DrinkWaterBottleFull
   - type: Sprite
     layers:
@@ -87,9 +81,7 @@
         - id: ExtendedEmergencyNitrogenTankFilled
         - id: EmergencyMedipen
         - id: Flare
-        # Start of Harmony Change: Remove MRE from survival box
-        #- id: FoodSnackNutribrick
-        # End of Harmony Change
+        #- id: FoodSnackNutribrick Harmony Commit Change: Remove MRE from survival box
         - id: DrinkWaterBottleFull
   - type: Sprite
     layers:
@@ -117,9 +109,7 @@
         - id: EmergencyOxygenTankFilled
         - id: EmergencyMedipen
         - id: Flare
-        # Start of Harmony Change: Remove MRE from survival box
-        #- id: FoodSnackNutribrick
-        # End of Harmony Change
+        #- id: FoodSnackNutribrick Harmony Commit Change: Remove MRE from survival box
         - id: DrinkWaterBottleFull
   - type: Sprite
     layers:
@@ -142,9 +132,7 @@
         - id: EmergencyNitrogenTankFilled
         - id: EmergencyMedipen
         - id: Flare
-        # Start of Harmony Change: Remove MRE from survival box
-        #- id: FoodSnackNutribrick
-        # End of Harmony Change
+        #- id: FoodSnackNutribrick Harmony Commit Change: Remove MRE from survival box
         - id: DrinkWaterBottleFull
   - type: Sprite
     layers:
@@ -172,9 +160,7 @@
         - id: EmergencyOxygenTankFilled
         - id: EmergencyMedipen
         - id: Flare
-        # Start of Harmony Change: Remove MRE from survival box
-        #- id: FoodSnackNutribrick
-        # End of Harmony Change
+        #- id: FoodSnackNutribrick Harmony Commit Change: Remove MRE from survival box
         - id: DrinkWaterBottleFull
   - type: Sprite
     layers:
@@ -197,9 +183,7 @@
         - id: EmergencyNitrogenTankFilled
         - id: EmergencyMedipen
         - id: Flare
-        # Start of Harmony Change: Remove MRE from survival box
-        #- id: FoodSnackNutribrick
-        # End of Harmony Change
+        #- id: FoodSnackNutribrick Harmony Commit Change: Remove MRE from survival box
         - id: DrinkWaterBottleFull
   - type: Sprite
     layers:
@@ -232,9 +216,7 @@
         - id: EmergencyFunnyOxygenTankFilled
         - id: EmergencyMedipen
         - id: Flare
-        # Start of Harmony Change: Remove MRE from survival box
-        - id: FoodPieBananaCream
-        # End of Harmony Change
+        - id: FoodPieBananaCream #Harmony Commit Change: Remove MRE from survival box
         - id: DrinkWaterBottleFull
   - type: Tag
     tags:
@@ -254,9 +236,7 @@
         - id: EmergencyNitrogenTankFilled
         - id: EmergencyMedipen
         - id: Flare
-        # Start of Harmony Change: Remove MRE from survival box
-        - id: FoodPieBananaCream
-        # End of Harmony Change
+        - id: FoodPieBananaCream #Harmony Commit Change: Remove MRE from survival box
         - id: DrinkWaterBottleFull
   - type: Label
     currentLabel: reagent-name-nitrogen

--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -117,7 +117,9 @@
         - id: EmergencyOxygenTankFilled
         - id: EmergencyMedipen
         - id: Flare
-        - id: FoodSnackNutribrick
+        # Start of Harmony Change: Remove MRE from survival box
+        #- id: FoodSnackNutribrick
+        # End of Harmony Change
         - id: DrinkWaterBottleFull
   - type: Sprite
     layers:


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
Changed MREs to MRE food tins, less nutritious and cheaper!

Also Changed Clowns MRE to Cream pies since they started a revolution over the sheer lameness of an MRE and would not accept the tins.

## Why / Balance
Given the fact that in almost every shift there's a Chef or at least a service worker, I feel as though it's only fair they now are to some degree required to do their job, if the chef dosen't have food out go get a snack we have plenty of snacks at home.

Of course this doesn't account for true low pop hours, though the thought of the captain spending a little bit just cooking in the kitchen is a funny thought.

Food Tins compared to MREs are very slightly less nutritious, 20 nutriment -> 15 nutriment

## Technical details
<!-- Summary of code changes for easier review. -->
Only changed the MREs to MREfoodtins exempt for clowns where they've been given a cream pie and syndicates because they're not NT
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Survival kits now have food tins instead of MREs
- tweak: Clowns now have a Cream Pie instead of an MRE in their Hug box

