### PR TITLE
Pacifists can throw PAI's again + Changes to the DamageOtherOnHit Component & System

### DIFF
--- a/Content.Shared/Damage/Components/DamageOtherOnHitComponent.cs
+++ b/Content.Shared/Damage/Components/DamageOtherOnHitComponent.cs
@@ -21,4 +21,13 @@ public sealed partial class DamageOtherOnHitComponent : Component
     [DataField(required: true)]
     public DamageSpecifier Damage = default!;
 
+    // Harmony Change Start:  Allow Pacifists to throw certain items even if they deal damage
+
+    /// <summary>
+    /// Whether pacifists can throw the item.
+    /// </summary>
+    [DataField]
+    public bool PacifiedCanThrow = false;
+
+    // Harmony Change End
 }

--- a/Content.Shared/Damage/Systems/SharedDamageOtherOnHitSystem.cs
+++ b/Content.Shared/Damage/Systems/SharedDamageOtherOnHitSystem.cs
@@ -27,6 +27,7 @@ public abstract class SharedDamageOtherOnHitSystem : EntitySystem
     /// </summary>
     private void OnAttemptPacifiedThrow(Entity<DamageOtherOnHitComponent> ent, ref AttemptPacifiedThrowEvent args)
     {
+        if(!ent.Comp.PacifiedCanThrow) // Harmony Change: Bool variable allows for damage dealing items to be thrown by pacifists
         args.Cancel("pacified-cannot-throw");
     }
 }

--- a/Resources/Prototypes/Entities/Objects/Fun/pai.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/pai.yml
@@ -107,6 +107,7 @@
     damage:
       types:
         Blunt: 0.1
+    pacifiedCanThrow: true
   # End Harmony Change
 
 - type: entity


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
Edited the DamageOtherOnHit Component & System, allowing PAI's to be thrown by pacifists once again.
Big thanks to Orks & Sapphic_Bee for their help, I would not have been able to make this PR without them.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Mainly because it's funny, Pacifist players should be able to assist their PAI's in bonking some jerk on the head, or really anyone that annoys them.
## Technical details
<!-- Summary of code changes for easier review. -->
I've added a boolean variable to the DamageOtherOnHitComponent called PacifiedCanThrow.
When OnAttemptPacifiedThrow() is called, an if statement checks the state of PacifiedCanThrow, and will cancel the throw if false.  Otherwise, the pacifist can throw the item.  By default, the boolean is set to false.
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

https://github.com/user-attachments/assets/6d78480e-0f2b-4c3f-bdfc-83e8e45546fa

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
- fix: Pacifists can now throw PAI's again!