### PR TITLE
Edited Atlas Station to use Crimson Emergency Shuttle

### DIFF
--- a/Resources/Prototypes/_Harmony/Maps/atlas.yml
+++ b/Resources/Prototypes/_Harmony/Maps/atlas.yml
@@ -13,6 +13,8 @@
           nameGenerator:
             !type:NanotrasenNameGenerator
             prefixCreator: 'R4' # R4407/Goon. GS isn't as cool sounding.
+        - type: StationEmergencyShuttle
+          emergencyShuttlePath: /Maps/Shuttles/emergency_omega.yml
         - type: StationJobs
           availableJobs:
             #service

--- a/Resources/Prototypes/_Harmony/Maps/atlas.yml
+++ b/Resources/Prototypes/_Harmony/Maps/atlas.yml
@@ -14,7 +14,7 @@
             !type:NanotrasenNameGenerator
             prefixCreator: 'R4' # R4407/Goon. GS isn't as cool sounding.
         - type: StationEmergencyShuttle
-          emergencyShuttlePath: /Maps/Shuttles/emergency_omega.yml
+          emergencyShuttlePath: /Maps/Shuttles/emergency_crimson.yml
         - type: StationJobs
           availableJobs:
             #service


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
I changed the Atlas Station meta files to use the Crimson Emergency Shuttle.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I had a round on Atlas during one Harmup and found it incredibly tedious that there was no security department on the shuttle. As a Captain I had to designate for security to bring their two prisoners, who have been violent and tried to BOA prior, to use the Bridge as a makeshift evac brig, which is a complete disaster cause a single minibomb or jaws could cause tons of issues.
By default Atlas has no emergency shuttle set, and I did not have the confidence to neither edit the default shuttle, nor create one from scratch. so I went for a bandaid fix and just made it use the Crimson Shuttle.

## Technical details
<!-- Summary of code changes for easier review. -->
Its just two lines. Nothing huge.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
<img width="1920" height="1080" alt="Content Client_vBnXLJAyzs" src="https://github.com/user-attachments/assets/3e5a186b-9b36-422e-8c90-a9b6a4ed8f3c" />



## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
- tweak: Atlas now uses the Crimson Emergency Shuttle
