### PR TITLE
NT Laminated Papers & Higher Quality Briefcases

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/service.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/service.yml
@@ -202,6 +202,7 @@
         - id: BoxEnvelope
         - id: BrbSign
         - id: ClothingNeckLanyard #Harmony addition. Also obtainable through character loadouts and PTech vendor
+        - id: BriefcaseBrown #Harmony addition: NT Laminated Papers & Higher Quality Briefcases
 
 - type: entity
   parent: CrateGenericSteel

--- a/Resources/Prototypes/Entities/Objects/Misc/briefcases.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/briefcases.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: BaseStorageItem
+  parent: [BaseStorageItem, ContentsExplosionResistanceBase]
   id: BriefcaseBase
   description: Useful for carrying items in your hands.
   abstract: true
@@ -16,6 +16,7 @@
   # Start of Harmony Changes: NT Laminated Papers & Higher Quality Briefcases
   - type: ExplosionResistance
     damageCoefficient: 0.8
+    worn: False
   - type: Lock
   - type: LockedStorage
   # End of Harmony Changes

--- a/Resources/Prototypes/Entities/Objects/Misc/briefcases.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/briefcases.yml
@@ -13,6 +13,12 @@
     damage:
       types:
         Blunt: 8
+  # Start of Harmony Changes: NT Laminated Papers & Higher Quality Briefcases
+  - type: ExplosionResistance
+    damageCoefficient: 0.8
+  - type: Lock
+  - type: LockedStorage
+  # End of Harmony Changes
 
 - type: entity
   parent: BriefcaseBase

--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -19,7 +19,7 @@
     canExtinguish: true
     damage:
       types:
-        Heat: 1
+        Heat: 5 # Harmony Change: NT Laminated Papers & Higher Quality Briefcases 1 -> 5
   - type: FireVisuals
     sprite: Effects/fire.rsi
     normalState: fire
@@ -34,7 +34,8 @@
       - !type:DoActsBehavior
         acts: ["Destruction"]
     - trigger:
-        !type:DamageTrigger
+        !type:DamageTypeTrigger # Harmony Fix: NT Laminated Papers & Higher Quality Briefcases... Wrong DamageTrigger Notified Upstream!
+        damageType: Heat
         damage: 15
       behaviors:
       - !type:SpawnEntitiesBehavior

--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -19,7 +19,7 @@
     canExtinguish: true
     damage:
       types:
-        Heat: 5 # Harmony Change: NT Laminated Papers & Higher Quality Briefcases 1 -> 5
+        Heat: 1
   - type: FireVisuals
     sprite: Effects/fire.rsi
     normalState: fire


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
Fixed paper ashing from all damage types (yes i notified upstream)
Briefcases also now slightly resist explosions and can be locked
Also a briefcase can now be found in Bureaucracy crates

## Why / Balance
Apparently this has just always been a bug, Upstream problem but until it's fixed i might aswell
Didn't make sense that briefcases didn't shield it's contents even a little bit IMO

## Technical details
Not much of note on the technical side

## Media
https://github.com/user-attachments/assets/f8d0b616-1d85-4525-adf2-a98f7758059e

HoP in the wild being blown up and losing _**EVERYTHING,**_ used in court against NT for being Anti-Bureaucratic!!
## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- tweak: Briefcases are now lockable and can now be found in Bureaucracy crates!
- fix: Fixed paper ashing from all damage types
