### PR TITLE
Salvage land mine removal

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/spawners.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/spawners.yml
@@ -436,6 +436,7 @@
           tableId: TreasureCoinPileRare
       #- id: MobHivebot (solo hivebot spawn)
 
+
 - type: entity
   parent: MarkerBase
   id: SalvageSpawnerMobMagnet

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/spawners.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/spawners.yml
@@ -426,12 +426,6 @@
       - !type:AllSelector
         children:
         - id: MobSharkSalvage
-        # Harmony Change - Adds various space fauna to the MagnetMobTable
-        - id: MobBearSpaceSalvage
-        - id: MobKangarooSpaceSalvage
-        - id: MobTickSalvage
-        - id: MobFleshClampSalvage
-        # Harmony Change End
         - id: MobCarpSalvage
           amount: 2
         - !type:NestedSelector

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/spawners.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/spawners.yml
@@ -411,13 +411,15 @@
       children:
       - id: MobCarpSalvage
         weight: 2
-      - !type:AllSelector
-        weight: 1
-        children:
-        - id: LandMineExplosive
-        - !type:NestedSelector # what's that thing underneath the scrap?
-          prob: 0.33
-          tableId: SalvageScrapSpawnerCommon
+      # Harmony Change - Removes landmines from salvage spawners
+      # - !type:AllSelector
+        # weight: 1
+        # children:
+        #- id: LandMineExplosive
+        #- !type:NestedSelector # what's that thing underneath the scrap?
+        #  prob: 0.33
+        #  tableId: SalvageScrapSpawnerCommon
+      # Harmony Change End
     - !type:GroupSelector # scary monsters
       weight: 5
       children:
@@ -433,7 +435,6 @@
           rolls: 7, 10
           tableId: TreasureCoinPileRare
       #- id: MobHivebot (solo hivebot spawn)
-
 
 - type: entity
   parent: MarkerBase

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/spawners.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/spawners.yml
@@ -411,19 +411,27 @@
       children:
       - id: MobCarpSalvage
         weight: 2
-      - !type:AllSelector
-        weight: 1
-        children:
-        - id: LandMineExplosive
-        - !type:NestedSelector # what's that thing underneath the scrap?
-          prob: 0.33
-          tableId: SalvageScrapSpawnerCommon
+      # Harmony Change - Removes landmines from salvage spawners
+      # - !type:AllSelector
+        # weight: 1
+        # children:
+        #- id: LandMineExplosive
+        #- !type:NestedSelector # what's that thing underneath the scrap?
+        #  prob: 0.33
+        #  tableId: SalvageScrapSpawnerCommon
+      # Harmony Change End
     - !type:GroupSelector # scary monsters
       weight: 5
       children:
       - !type:AllSelector
         children:
         - id: MobSharkSalvage
+        # Harmony Change - Adds various space fauna to the MagnetMobTable
+        - id: MobBearSpaceSalvage
+        - id: MobKangarooSpaceSalvage
+        - id: MobTickSalvage
+        - id: MobFleshClampSalvage
+        # Harmony Change End
         - id: MobCarpSalvage
           amount: 2
         - !type:NestedSelector

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/spawners.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/spawners.yml
@@ -434,7 +434,7 @@
         - !type:NestedSelector
           rolls: 7, 10
           tableId: TreasureCoinPileRare
-      #- id: MobHivebot (solo hivebot spawn)
+      # id: MobHivebot (solo hivebot spawn)
 
 - type: entity
   parent: MarkerBase

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/spawners.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/spawners.yml
@@ -411,15 +411,13 @@
       children:
       - id: MobCarpSalvage
         weight: 2
-      # Harmony Change - Removes landmines from salvage spawners
-      # - !type:AllSelector
-        # weight: 1
-        # children:
-        #- id: LandMineExplosive
-        #- !type:NestedSelector # what's that thing underneath the scrap?
-        #  prob: 0.33
-        #  tableId: SalvageScrapSpawnerCommon
-      # Harmony Change End
+      - !type:AllSelector
+        weight: 1
+        children:
+        - id: LandMineExplosive
+        - !type:NestedSelector # what's that thing underneath the scrap?
+          prob: 0.33
+          tableId: SalvageScrapSpawnerCommon
     - !type:GroupSelector # scary monsters
       weight: 5
       children:

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/spawners.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/spawners.yml
@@ -434,7 +434,7 @@
         - !type:NestedSelector
           rolls: 7, 10
           tableId: TreasureCoinPileRare
-      # id: MobHivebot (solo hivebot spawn)
+      #- id: MobHivebot (solo hivebot spawn)
 
 - type: entity
   parent: MarkerBase


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
Removed Landmines from the salvage mob spawning pool.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Landmines exist in a problematic way by instantly RR'ing solo salvagers with little to no way of reacting to them. Additionally, things such as lag spikes or movement bugs (locker bug) can cause salvagers to just simply outright die in space in a largely unrecoverable manner. This content is not exactly fun or interactive in a positive way. Furthermore, salvage does not need more reasons to avoid collection of materials. While I am fully in belief of salvage requiring an element of danger, the current implementation of landmines does not represent fun or interesting gameplay.

## Technical details
<!-- Summary of code changes for easier review. -->
Commented out the LandMineExplosive section of the SalvageMagnetMobTable entityTable in spawners.yml

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
- remove: Removed landmines from magnet pulls