### PR TITLE
Less clipping for headset and glasses

### DIFF
--- a/Resources/Prototypes/Body/species_appearance.yml
+++ b/Resources/Prototypes/Body/species_appearance.yml
@@ -39,7 +39,6 @@
     # - map: [ "eyes" ] # Harmony Change: Moves eyes over facialhair and headside
     # - map: [ "belt" ] # Harmony Change: Moves Belt back over outerclothing
     - map: [ "id" ]
-    - map: [ "id" ]
     - map: [ "outerClothing" ]
     - map: [ "belt" ] # Harmony Change: Moves Belt back over outerclothing
     - map: [ "back" ]

--- a/Resources/Prototypes/Body/species_appearance.yml
+++ b/Resources/Prototypes/Body/species_appearance.yml
@@ -35,9 +35,10 @@
     # More equipment
     - map: [ "gloves" ]
     - map: [ "shoes" ]
-    - map: [ "ears" ]
-    - map: [ "eyes" ]
+    # - map: [ "ears" ] # Harmony Change: Moves ears over facialhair and headside
+    # - map: [ "eyes" ] # Harmony Change: Moves eyes over facialhair and headside
     # - map: [ "belt" ] # Harmony Change: Moves Belt back over outerclothing
+    - map: [ "id" ]
     - map: [ "id" ]
     - map: [ "outerClothing" ]
     - map: [ "belt" ] # Harmony Change: Moves Belt back over outerclothing
@@ -55,6 +56,8 @@
     - map: [ "enum.HumanoidVisualLayers.TailOverlay" ]
 
     # Stuff that goes in front of stuff that goes in front of equipment
+    - map: [ "ears" ] # Harmony Change: Moves ears over facialhair and headside
+    - map: [ "eyes" ] # Harmony Change: Moves eyes over facialhair and headside
     - map: [ "mask" ]
     - map: [ "head" ]
     - map: [ "pocket1" ]


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
I've moved the ears and eyes sprite layer to be infront of facial hair, avali ears, and spider mandibles. This makes them more readable and also gets rid of some slipping issues.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
<img width="494" height="374" alt="image" src="https://github.com/user-attachments/assets/647f5b23-ebe5-4685-b8e0-f36134bc1470" />
Over-ear headsets are unreadable on Avali, Spiders, and anybody with a beard. They are clipped under them.
<img width="648" height="405" alt="image" src="https://github.com/user-attachments/assets/5e206c62-4a64-4e96-a6be-30beeb153166" />
Real life beards don't do this, and it also looks quite weird in game to me.

<img width="488" height="328" alt="image" src="https://github.com/user-attachments/assets/e14fcbd3-bb88-48c6-b97d-05385aa306b5" />

Jamjar glasses are the most noticeable because they are the biggest, but all glasses clip under beards currently.

## Technical details
<!-- Summary of code changes for easier review. -->
**_Harmony Namespace**
Resources/Prototypes/Body/species_appearance.yml -- Moved the ears and eyes layers in species_appearence.yml

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
Left is before and right is after to showcase how this looks ingame.
<img width="721" height="325" alt="image" src="https://github.com/user-attachments/assets/f530289f-97cc-40bb-b37c-cc16cffd3928" />
Corners of jamjar glasses are no longer clipped

<img width="721" height="325" alt="image" src="https://github.com/user-attachments/assets/e9775cb6-d1cc-4244-af66-05ee161d9e37" />
Over ear headset is now infront of the chelicerae

<img width="673" height="333" alt="image" src="https://github.com/user-attachments/assets/24a67ba9-ee96-4a31-971d-035d19dbf73a" />
Jamjar glasses are no longer behind beards. This does look very funny though.

<img width="668" height="235" alt="image" src="https://github.com/user-attachments/assets/f53e0302-a791-4bea-8a6e-d6e928f8cd78" />
Over ear headset is overtop of beards now.

<img width="625" height="349" alt="image" src="https://github.com/user-attachments/assets/3f375a2b-ab55-4a8a-a934-e6c899940a03" />



## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:

- tweak: Headsets and glasses are no longer behind beards.

