### PR TITLE
Remove Serpentcrest from Harmony Map Rotation

### DIFF
--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -11,7 +11,7 @@
   - Reach
   - Exo
   - Snowball
-  - Serpentcrest
+ # - Serpentcrest # Not In Harmony rotation
   # Harmony maps start
   - Aspid
   - Atlas


### PR DESCRIPTION
## About the PR
This PR removes Serpentcrest from the Harmony Map Rotation.

## Why / Balance
Serpentcrest currently contains a large amount of syndicate contraband that may encourage too many crew to self antag.
The admin team does not want to encourage our players to break server rules and we wish to remove it from our map rotation.

## Technical details
Comments out the map Serpentcrest from the Resources/Prototypes/Maps/Pools/default.yml


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- remove: Serpentcrest from map rotation