### PR TITLE
Removed stamina slowdown

### DIFF
--- a/Content.Shared/Damage/Components/StaminaComponent.cs
+++ b/Content.Shared/Damage/Components/StaminaComponent.cs
@@ -94,7 +94,7 @@ public sealed partial class StaminaComponent : Component
     /// Thresholds that determine an entity's slowdown as a function of stamina damage, in percentages.
     /// </summary>
     [DataField]
-    public Dictionary<FixedPoint2, float> StunModifierThresholds = new() { { 0, 1f } }; // harmony change: stamina damage no longer slows you down.
+    public Dictionary<FixedPoint2, float> StunModifierThresholds = new() { {0, 1f }, { 0.6, 0.7f }, { 0.8, 0.5f } };
 
     #region Animation Data
 

--- a/Content.Shared/Damage/Components/StaminaComponent.cs
+++ b/Content.Shared/Damage/Components/StaminaComponent.cs
@@ -94,7 +94,7 @@ public sealed partial class StaminaComponent : Component
     /// Thresholds that determine an entity's slowdown as a function of stamina damage, in percentages.
     /// </summary>
     [DataField]
-    public Dictionary<FixedPoint2, float> StunModifierThresholds = new() { {0, 1f }, { 0.6, 0.7f }, { 0.8, 0.5f } };
+    public Dictionary<FixedPoint2, float> StunModifierThresholds = new() { { 0, 1f } }; // harmony change: stamina damage no longer slows you down.
 
     #region Animation Data
 

--- a/Resources/Prototypes/Entities/Mobs/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/base.yml
@@ -111,8 +111,10 @@
       - !type:VomitBehavior
   - type: RadiationReceiver
   - type: Stamina
+    # harmony change start: removed stamina slowdown
     stunModifierThresholds: 
       0: 1.0
+    # harmony change end
   - type: StunVisuals
   - type: MobState
   - type: MobThresholds

--- a/Resources/Prototypes/Entities/Mobs/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/base.yml
@@ -111,6 +111,8 @@
       - !type:VomitBehavior
   - type: RadiationReceiver
   - type: Stamina
+    stunModifierThresholds: 
+      0: 1.0
   - type: StunVisuals
   - type: MobState
   - type: MobThresholds


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
Removed the slowdown that having low stamina would cause.

## Why / Balance
Disablers are generally considered to be too strong and rather oppressive, which is not helped by the fact that after being shot by them twice, you take on what is nearly jugg-suit levels of slowdown rendering it almost impossible to dodge the third and fourth shot. This should make them feel slightly more fair to face while still keeping them as a strong option for subduing people from range. This will barely affect batons because being hit by a baton means you are already in melee range.

## Technical details
Changed 1 field in the Stamina component of MobDamageable.

## Media
Not sure how to show this via screenshot

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Low stamina will no longer slow you down.