### PR TITLE
Change Order Computers to print slips

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -934,7 +934,8 @@
     account: Engineering
     announcementChannel: Engineering
     removeLimitAccess: [ "ChiefEngineer" ]
-    mode: SendToPrimary
+    #mode: SendToPrimary
+    mode: PrintSlip # Harmony Change SendToPrimary > PrintSlip
   - type: ActiveRadio
     channels:
     - Engineering
@@ -967,7 +968,8 @@
     account: Medical
     announcementChannel: Medical
     removeLimitAccess: [ "ChiefMedicalOfficer" ]
-    mode: SendToPrimary
+    #mode: SendToPrimary
+    mode: PrintSlip # Harmony Change SendToPrimary > PrintSlip
   - type: ActiveRadio
     channels:
     - Medical
@@ -1000,7 +1002,8 @@
     account: Science
     announcementChannel: Science
     removeLimitAccess: [ "ResearchDirector" ]
-    mode: SendToPrimary
+    #mode: SendToPrimary
+    mode: PrintSlip # Harmony Change SendToPrimary > PrintSlip
   - type: ActiveRadio
     channels:
     - Science
@@ -1033,7 +1036,8 @@
     account: Security
     announcementChannel: Security
     removeLimitAccess: [ "HeadOfSecurity" ]
-    mode: SendToPrimary
+    #mode: SendToPrimary
+    mode: PrintSlip # Harmony Change SendToPrimary > PrintSlip
   - type: ActiveRadio
     channels:
     - Security
@@ -1066,7 +1070,8 @@
     account: Service
     announcementChannel: Service
     removeLimitAccess: [ "HeadOfPersonnel" ]
-    mode: SendToPrimary
+    #mode: SendToPrimary
+    mode: PrintSlip # Harmony Change SendToPrimary > PrintSlip
   - type: ActiveRadio
     channels:
     - Service


### PR DESCRIPTION
## About the PR
I really liked cargo slips for encouraging interaction between cargo and the various departments.
So I have changed the ordering mode on the cargo request computers for all departments.

Thank you to DrWhoFan13 who made this PR: https://github.com/ss14-boxstation/ss14-boxstation/pull/164/changes
And showed me how easy it was to make my dreams come true again.

## Why / Balance
Cargo slips encouraged people to leave their departments and venture across the station to talk to cargo.
This is good for role play, this is good for antagonists, and it's great for cargo.

Bringing a slip to cargo means you get to talk to a cargo tech about what your department needs, and they might already have the resources for you.

This PR doesn't change the department economy; each department will still have their own funds.

## Technical details
Updated Computers.yml to change the order mode on department order computers

## Media
<img width="488" height="349" alt="image" src="https://github.com/user-attachments/assets/8ef23436-fee7-4e6a-91a2-bf0f12996223" />

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.

**Changelog**
:cl:
- add: Request computers make slips again