### PR TITLE
Removed the DMR Bundle from the Nukie Uplink

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -269,24 +269,26 @@
       tags:
       - NukeOpsUplink
 
-- type: listing
-  id: UplinkEstocBundle
-  name: uplink-estoc-bundle-name
-  description: uplink-estoc-bundle-desc
-  icon: { sprite: /Textures/Objects/Weapons/Guns/Rifles/estoc.rsi, state: icon }
-  productEntity: ClothingBackpackDuffelSyndicateFilledRifle
-  discountCategory: veryRareDiscounts
-  discountDownTo:
-    Telecrystal: 11
-  cost:
-    Telecrystal: 18
-  categories:
-  - UplinkWeaponry
-  conditions:
-  - !type:StoreWhitelistCondition
-    whitelist:
-      tags:
-      - NukeOpsUplink
+# Harmony Change - Remove DMR Bundle
+# - type: listing
+#   id: UplinkEstocBundle
+#   name: uplink-estoc-bundle-name
+#   description: uplink-estoc-bundle-desc
+#   icon: { sprite: /Textures/Objects/Weapons/Guns/Rifles/estoc.rsi, state: icon }
+#   productEntity: ClothingBackpackDuffelSyndicateFilledRifle
+#   discountCategory: veryRareDiscounts
+#   discountDownTo:
+#     Telecrystal: 11
+#   cost:
+#     Telecrystal: 18
+#   categories:
+#   - UplinkWeaponry
+#   conditions:
+#   - !type:StoreWhitelistCondition
+#     whitelist:
+#       tags:
+#       - NukeOpsUplink
+# Harmony Change End
 
 - type: listing
   id: UplinkGrenadeLauncher


### PR DESCRIPTION
## About the PR
@kleinerstation13 Originally did work to create a new gun for Harmony but the DMR really wanted to be back.
However, Donk Co and its subsidiaries have taken it off the market in a couple of back room deals.

## Why / Balance
See PR #577 , #882 , #831 for HOW COOL the replacement gun is
Fixes issue: #1381 


## Media
IT gone.
<img width="802" height="785" alt="Screenshot 2026-05-15 094834" src="https://github.com/user-attachments/assets/3f163210-3023-4f5f-9f5e-aa508217118c" />


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.


**Changelog**
:cl:
- remove: Removed the Estoc again. 
