### PR TITLE
Add clearpda to passenger loadout.

### DIFF
--- a/Resources/Locale/en-US/_Harmony/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/_Harmony/preferences/loadout-groups.ftl
@@ -7,6 +7,7 @@ loadout-group-medical-doctor-neck = Medical Doctor neck
 # Civilian
 loadout-group-librarian-outerclothing = Librarian outer clothing
 loadout-group-librarian-neck = Librarian neck
+loadout-group-passenger-PDA = Passenger ID
 
 # Cargo
 loadout-group-salvage-specialist-neck = Salvage specialist neck

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/passenger.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/passenger.yml
@@ -121,3 +121,17 @@
   id: WinterBoots
   equipment:
     shoes: ClothingShoesBootsWinter
+
+# ID
+- type: loadout
+  id: PassengerPDA
+  equipment:
+    id: PassengerPDA
+
+- type: loadout
+  id: ClearPDA
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: GreyTider
+  equipment:
+    id: ClearPDA

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/passenger.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/passenger.yml
@@ -122,6 +122,7 @@
   equipment:
     shoes: ClothingShoesBootsWinter
 
+# Begin Harmony Change
 # ID
 - type: loadout
   id: PassengerPDA
@@ -135,3 +136,4 @@
     proto: GreyTider
   equipment:
     id: ClearPDA
+# End Harmony Change

--- a/Resources/Prototypes/Loadouts/LoadoutGroups/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/LoadoutGroups/loadout_groups.yml
@@ -274,6 +274,13 @@
   - BlackShoes
   - WinterBoots
 
+- type: loadoutGroup
+  id: PassengerPDA
+  name: loadout-group-passenger-PDA
+  loadouts:
+  - PassengerPDA
+  - ClearPDA
+
 #- type: loadoutGroup
 #  id: PassengerJobTrinkets
 #  name: loadout-group-jobtrinkets

--- a/Resources/Prototypes/Loadouts/LoadoutGroups/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/LoadoutGroups/loadout_groups.yml
@@ -274,12 +274,14 @@
   - BlackShoes
   - WinterBoots
 
+# Begin Harmony Change
 - type: loadoutGroup
   id: PassengerPDA
   name: loadout-group-passenger-PDA
   loadouts:
   - PassengerPDA
   - ClearPDA
+# End Harmony Change
 
 #- type: loadoutGroup
 #  id: PassengerJobTrinkets

--- a/Resources/Prototypes/Loadouts/RoleLoadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/RoleLoadouts/role_loadouts.yml
@@ -51,6 +51,7 @@
   - PassengerGloves
   - PassengerOuterClothing
   - PassengerShoes
+  - PassengerPDA # Harmony
   - Glasses
   - Survival
   - Trinkets

--- a/Resources/Prototypes/Roles/Jobs/Civilian/assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/assistant.yml
@@ -12,7 +12,7 @@
 - type: startingGear
   id: PassengerGear
   equipment:
-    id: PassengerPDA
+    # id: PassengerPDA - Harmony Change
     ears: ClothingHeadsetGrey
   #storage:
     #back:


### PR DESCRIPTION
## About the PR

Added the Clear PDA as a loadout option for Passengers.

## Why / Balance

Clear PDA's seem like a fun way to show your experience as a GrayTider on the station.

## Technical details

Commented out the passenger PDA in the assistant.yml file.
Added the Passenger and Clear PDA to the Passenger loadout_groups and the Passenger.yml
Added Passenger PDA to the role_loadout.yml
Added Passenger PDA to the loadout-groups.ftl

## Media

<img width="694" height="358" alt="Screenshot 2026-05-25 194439" src="https://github.com/user-attachments/assets/009f1ea1-3081-4e44-b3f4-4dd473a2cb05" />


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
Should be none.

**Changelog**

:cl:
- add: Clear PDAs can now be selected as a passenger loadout option.