### PR TITLE
Gives nukie reinforcements nukie accesses

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1547,6 +1547,15 @@
   suffix: NukeOps
   components:
   - type: NukeOperative
+  # Harmony Change - Gives nukie monkey nukie access
+  - type: NpcFactionMember
+    factions:
+    - Syndicate
+  - type: Access
+    tags:
+    - NuclearOperative
+    - SyndicateAgent
+  # Harmony Change End
 
 - type: entity
   name: kobold
@@ -1707,6 +1716,15 @@
   suffix: NukeOps
   components:
   - type: NukeOperative
+# Harmony Change - Gives nukie kobolds nukie access
+  - type: NpcFactionMember
+    factions:
+    - Syndicate
+  - type: Access
+    tags:
+    - NuclearOperative
+    - SyndicateAgent
+# Harmony Change End
 
 - type: entity
   name: guidebook monkey


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
Gives Nukie monkeys and kobolds access privileges to the shuttle and planet.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It dawned on me while playing a syndicat, that a syndicat can indeed waltz around freely on the planet and shuttle while monkeys and kobold nukie reinforcements cannot. Yes, the monkeys and kobolds have suit slots for PDA/ID's, but they often will not be given one. There's no real reason a reinforcement shouldn't have accesses to the very place it's being called into. QOL change, really.

## Technical details
<!-- Summary of code changes for easier review. -->
Copy+Pasted 7 lines of YML from the syndiecat part of animals.yml to the nukie monkey and nukie kobold part.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

https://github.com/user-attachments/assets/09d0632d-7d74-4e2c-9912-0878db96835e

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
- tweak: Nukie monkey and kobolds now have access to the nukie shuttle and planet!
