### PR TITLE
Removed Conspiracy from the Secret Game Mode Weights Table

### DIFF
--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -3,7 +3,6 @@
   weights:
 # Harmony Changes
     Traitor: 0.53
-    Conspiracy: 0.1
     Nukeops: 0.13
     Survival: 0.08
     Extended: 0.08


### PR DESCRIPTION
## About the PR, Why, and Balance
Earlier this year, we introduced the Conspirators game mode, a team antagonist focused on roleplay-driven objectives. After considerable discussion, we've decided to remove Conspirators from the game mode pool. However, it'll be left in-game for admin spawns and/or further development.

There are a few reasons for this change. While many have enjoyed this game mode, most of the current objectives are too ambiguous. This has created confusion about what conspirators  and the players around them are and aren't allowed to do, leading to situations that unintentionally break server rules, such as self-antagging. We don’t want to set our players up to break rules.

That said, we know many of you enjoyed the Conspirators' roleplay-focused objectives. We're going to explore ways to bring that style of gameplay back in a clearer form. One idea we're considering is adding new objectives to the traitor pool that allow for more creativity while clearly defining what is and isn’t allowed.

## Technical details
Removed Conspiracy from the game weights table

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
:cl:
- remove: Conspirators have been removed from secret's gamemode pool due to administrative issues.