### PR TITLE
Snowball De-Rotated

### DIFF
--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -7,11 +7,11 @@
   - Marathon
   - Oasis
   - Packed
- # - Plasma # Not in Harmony rotation
+# - Plasma # Not in Harmony rotation
   - Reach
   - Exo
-  - Snowball
- # - Serpentcrest # Not In Harmony rotation
+# - Snowball # Not in Harmony rotation
+# - Serpentcrest # Not In Harmony rotation
   # Harmony maps start
   - Aspid
   - Atlas


### PR DESCRIPTION
## About the PR
De-Rotated Snowball

## Why / Balance
General player sentiment of the map is heavily negative. Multiple discord discussions and multitude of requests for it to be removed from the pool.

## Technical details
Commented out snowball from Resources\Prototypes\Maps\Pools\default.yml. Fixed two other indentations on commented out lines. Marked up with harmony change comments.

## Test plan
Run server with release mode on. Repeat golobby -> Forcepreset Secret until verification of no Snowball in default mappool.

## Media
N/A

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None Expected

## Changelog
:cl:
- remove: Snowball from default map rotation.