### PR TITLE
Add battle cry to all glove weapons

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -16,6 +16,17 @@
       collection: BoxingHit
     animation: WeaponArcFist
     mustBeEquippedToUse: true
+  # Harmony Changes begin - add battle cry for all boxing gloves
+  - type: MeleeSpeech
+  - type: ActivatableUI
+    key: enum.MeleeSpeechUiKey.Key
+    verbOnly: true
+  - type: Actions
+  - type: UserInterface
+    interfaces:
+      enum.MeleeSpeechUiKey.Key:
+        type: MeleeSpeechBoundUserInterface
+  # Harmony Changes end
   - type: Tag
     tags:
     - Kangaroo
@@ -518,6 +529,17 @@
       collection: Punch
     animation: WeaponArcFist
     mustBeEquippedToUse: true
+  # Harmony Changes begin - add battle cry to knuckledusters
+  - type: MeleeSpeech
+  - type: ActivatableUI
+    key: enum.MeleeSpeechUiKey.Key
+    verbOnly: true
+  - type: Actions
+  - type: UserInterface
+    interfaces:
+      enum.MeleeSpeechUiKey.Key:
+        type: MeleeSpeechBoundUserInterface
+  # Harmony Changes end
   - type: Tag
     tags:
     - WhitelistChameleon
@@ -569,6 +591,17 @@
     tags:
     - WhitelistChameleon
     - Kangaroo
+  # Harmony Changes begin - adds battle cry to QM knuckledusters
+  - type: MeleeSpeech
+  - type: ActivatableUI
+    key: enum.MeleeSpeechUiKey.Key
+    verbOnly: true
+  - type: Actions
+  - type: UserInterface
+    interfaces:
+      enum.MeleeSpeechUiKey.Key:
+        type: MeleeSpeechBoundUserInterface
+  # Harmony Changes end
   - type: StealTarget
     stealGroup: ClothingHandsKnuckleDustersQM
 
@@ -597,6 +630,17 @@
     tags:
     - WhitelistChameleon
     - Kangaroo
+  # Harmony changes begin - adds battle cry to syndicate knuckle dusters
+  - type: MeleeSpeech
+  - type: ActivatableUI
+    key: enum.MeleeSpeechUiKey.Key
+    verbOnly: true
+  - type: Actions
+  - type: UserInterface
+    interfaces:
+      enum.MeleeSpeechUiKey.Key:
+        type: MeleeSpeechBoundUserInterface
+  # Harmony changes end
   - type: StaticPrice
     price: 2000
 


### PR DESCRIPTION
## About the PR
Adds the battle cry system to all glove weapons except for the mantis blades.

## Why / Balance
Fun! I love the battle cry feature of the northstars, it's funny. I wanted to add it to all other glove weapons cause shouting when you punch someone is great. Mantis blades are excluded because they are a stealth weapon and thus it doesn't make too much sense for them to have them.

## Technical details
Code from ClothingHandsGlovesNorthStar

  - type: MeleeSpeech
  - type: ActivatableUI
    key: enum.MeleeSpeechUiKey.Key
    verbOnly: true
  - type: Actions
  - type: UserInterface
    interfaces:
      enum.MeleeSpeechUiKey.Key:
        type: MeleeSpeechBoundUserInterface

Was added with comments in Resources/Prototypes/Entities/Clothing/Hands/gloves.yml to ClothingHandsGlovesBoxingBase, ClothingHandsKnuckleDusters, ClothingHandsKnuckleDustersQM, and ClothingHandsKnuckleDustersSyndicate

## Test plan
Spawn in any boxing gloves or knuckledusters, set battle cry, hit stuff

## Media

https://github.com/user-attachments/assets/87a72722-4394-478a-a66a-09abc3579b41

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
Willow, the kangaroo boxing pet, cannot change her own battlecry despite the button appearing for her. I believe the battlecry system requires you to have hands in order to change it, which Willow does not have. I believe this is fine because you need for Willow to be mapped, cognizine administered to Willow, and for someone to take the ghost role for this to be a problem. I believe this problem is just like borgs wanting to wear hats, they need the help of someone else to do it for them which is a fun little moment.

## Changelog
:cl:
- add: All types of boxing gloves and knuckle dusters have battle cries now
